### PR TITLE
Mod Manager 4.1 Beta 4: Build 48

### DIFF
--- a/src/com/me3tweaks/modmanager/CustomDLCWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCWindow.java
@@ -1,0 +1,143 @@
+package com.me3tweaks.modmanager;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import javax.swing.table.DefaultTableModel;
+
+import org.apache.commons.io.FileUtils;
+
+import com.me3tweaks.modmanager.objects.ModType;
+import com.me3tweaks.modmanager.ui.ButtonColumn;
+
+public class CustomDLCWindow extends JDialog {
+
+	protected static final int COL_FOLDER = 0;
+	protected static final int COL_NAME = 1;
+	protected static final int COL_MOUNT = 2;
+	protected static final int COL_ACTION = 3;
+	private ArrayList<String> nameList;
+	private ArrayList<String> folderList;
+	private String bioGameDir;
+	private ArrayList<String> mountList;
+
+	public CustomDLCWindow(String bioGameDir) {
+		this.bioGameDir = bioGameDir;
+		setupWindow();
+		setLocationRelativeTo(ModManagerWindow.ACTIVE_WINDOW);
+		setVisible(true);
+	}
+
+	private void setupWindow() {
+		setIconImages(ModManager.ICONS);
+		setTitle("Custom DLCs");
+		setModal(true);
+		setPreferredSize(new Dimension(640, 480));
+		setMinimumSize(new Dimension(300, 200));
+
+		nameList = new ArrayList<String>();
+		folderList = new ArrayList<String>();
+		mountList = new ArrayList<String>();
+
+		JPanel panel = new JPanel(new BorderLayout());
+		JLabel infoLabel = new JLabel("<html>Installed Custom DLCs</html>",SwingConstants.CENTER);
+		panel.add(infoLabel, BorderLayout.NORTH);
+
+		File mainDlcDir = new File(ModManager.appendSlash(bioGameDir) + "DLC/");
+		String[] directories = mainDlcDir.list(new FilenameFilter() {
+			@Override
+			public boolean accept(File current, String name) {
+				return new File(current, name).isDirectory();
+			}
+		});
+
+		int datasize = 0;
+		for (String dir : directories) {
+			if (ModType.isKnownDLCFolder(dir)) {
+				continue;
+			}
+			datasize ++;
+			String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath()+ File.separator + dir);
+			String dlcName = "Unknown";
+			File metaFile = new File(path + ModInstallWindow.CUSTOMDLC_METADATA_FILE);
+			if (metaFile.exists()) {
+				try {
+					dlcName = FileUtils.readFileToString(metaFile);
+				} catch (IOException e1) {
+					ModManager.debugLogger.writeErrorWithException("Unable to read metadata file about customdlc:", e1);
+				}
+			}
+			
+			String pcConsole = path+"CookedPCConsole/";
+			File mountFile = new File(pcConsole+"Mount.dlc");
+			File sfarFile = new File(pcConsole+"Default.sfar");
+			
+			if (!mountFile.exists()){
+				dlcName = "No Mount.dlc file";
+				mountList.add(dlcName);
+			} else if (!sfarFile.exists()){
+				dlcName = "No Default.sfar file";
+				mountList.add("Not checked");
+			} else {
+				String mount = MountFileEditorWindow.getMountDescription(mountFile);
+				mountList.add(mount);
+			}
+			folderList.add(dir);
+			nameList.add(dlcName);
+		}
+
+		//TABLE
+		Object[][] data = new Object[datasize][4];
+		for (int i = 0; i < datasize; i++) {
+			data[i][COL_FOLDER] = folderList.get(i);
+			data[i][COL_NAME] = nameList.get(i);
+			data[i][COL_MOUNT] = mountList.get(i);
+			data[i][COL_ACTION] = "Delete DLC";
+		}
+
+		Action delete = new AbstractAction() {
+			public void actionPerformed(ActionEvent e) {
+				JTable table = (JTable) e.getSource();
+				int modelRow = Integer.valueOf(e.getActionCommand());
+				String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath() + File.separator+ table.getModel().getValueAt(modelRow, COL_FOLDER));
+				ModManager.debugLogger.writeMessage("Deleting Custom DLC folder: "+path);
+				FileUtils.deleteQuietly(new File(path));
+				Object breakpoint = table.getModel();
+				((DefaultTableModel) table.getModel()).removeRow(modelRow);
+			}
+		};
+		String[] columnNames = { "DLC Folder", "DLC Name", "DLC Mount Flag","Delete DLC" };
+		DefaultTableModel model = new DefaultTableModel(data, columnNames);
+		JTable table = new JTable(model) {
+			public boolean isCellEditable(int row, int column) {
+				return column == COL_ACTION;
+			}
+		};
+		table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+		ButtonColumn buttonColumn = new ButtonColumn(table, delete, COL_ACTION);
+		JScrollPane scrollpane = new JScrollPane(table);
+
+		panel.add(scrollpane, BorderLayout.CENTER);
+		
+		JLabel mpLabel = new JLabel("<html><div style=\"text-align: center;\">Custom DLC will never authorize unless you use a DLC bypass.<br>DLC that have MP in their Mount Flag will make all players require that DLC.</div></html>",SwingConstants.CENTER);
+		panel.add(mpLabel,BorderLayout.SOUTH);
+		panel.setBorder(new EmptyBorder(5,5,5,5));
+		add(panel);
+		pack();
+	}
+}

--- a/src/com/me3tweaks/modmanager/DeltaWindow.java
+++ b/src/com/me3tweaks/modmanager/DeltaWindow.java
@@ -815,7 +815,6 @@ public class DeltaWindow extends JDialog {
 									return false;
 								}
 							}
-
 						}
 					}
 				}
@@ -865,13 +864,12 @@ public class DeltaWindow extends JDialog {
 			}
 			performCleanup();
 			ModManager.debugLogger.writeMessage("============END OF DELTAWORKER()==============");
-
 		}
 	}
 
 	private boolean applyVariant(String modFolder, String variantFolder) {
 		if (new File(variantFolder).exists()) {
-			try {
+			try {	
 				ModManager.debugLogger.writeMessage("Applying Variant: " + variantFolder + " => " + modFolder);
 				FileUtils.copyDirectory(new File(variantFolder), new File(modFolder));
 				ModManager.debugLogger.writeMessage("Variant applied");

--- a/src/com/me3tweaks/modmanager/DeltaWindow.java
+++ b/src/com/me3tweaks/modmanager/DeltaWindow.java
@@ -789,6 +789,7 @@ public class DeltaWindow extends JDialog {
 										if (!verifyOnly) {
 											JOptionPane.showMessageDialog(null, sb.toString(), "Delta Error", JOptionPane.ERROR_MESSAGE);
 										}
+										addNewError("Could not find a property to update/remove.");
 										ModManager.debugLogger.writeError(sb.toString());
 										return false;
 									}

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -63,7 +63,7 @@ public class ModManager {
 	public static long BUILD_NUMBER = 47L;
 	public static final String BUILD_DATE = "10/29/2015";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 1.8; // max modmaker

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -59,9 +59,9 @@ import com.sun.jna.platform.win32.WinReg;
 
 public class ModManager {
 
-	public static final String VERSION = "4.1 Beta 3";
-	public static long BUILD_NUMBER = 47L;
-	public static final String BUILD_DATE = "10/29/2015";
+	public static final String VERSION = "4.1 Beta 4";
+	public static long BUILD_NUMBER = 48L;
+	public static final String BUILD_DATE = "11/11/2015";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = true;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -76,7 +76,8 @@ public class ModManager {
 	public static boolean ASKED_FOR_AUTO_UPDATE = false;
 	public static boolean CHECKED_FOR_UPDATE_THIS_SESSION = false;
 	public static long LAST_AUTOUPDATE_CHECK;
-	public final static int MIN_REQUIRED_ME3EXPLORER_REV = 721; // my custom build
+	public final static int MIN_REQUIRED_ME3EXPLORER_REV = 722;
+	
 	// version
 	private final static int MIN_REQUIRED_NET_FRAMEWORK_RELNUM = 378389; //4.5.0
 	public static boolean USE_GAME_TOCFILES_INSTEAD = false;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -63,7 +63,7 @@ public class ModManager {
 	public static long BUILD_NUMBER = 48L;
 	public static final String BUILD_DATE = "11/11/2015";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = true;
+	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 1.8; // max modmaker

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -117,6 +117,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	private JMenuItem restoreRevertUnpacked;
 	private JMenuItem restoreRevertBasegameUnpacked;
 	private JMenuItem restoredeleteAllCustomDLC;
+	private JMenuItem restoreCustomDLCManager;
 	private JMenuItem backupBasegameUnpacked;
 	private JMenuItem toolsUnpackDLC;
 	private JMenuItem modDeltaRevert;
@@ -993,6 +994,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoredeleteAllCustomDLC = new JMenuItem("Remove all Custom DLC");
 		restoredeleteAllCustomDLC.setToolTipText("<html>Deletes all non standard DLC folders in the DLC directory</html>");
 
+		restoreCustomDLCManager = new JMenuItem("Custom DLC Manager");
+		restoreCustomDLCManager.setToolTipText("<html>Allows selectively removing Custom DLC modules and indicates if MP is affected</html>");
+
 		restoreRevertBasegame = new JMenuItem("Restore basegame files");
 		restoreRevertBasegame.setToolTipText("<html>Restores all basegame files that have been modified by installing mods</html>");
 
@@ -1028,6 +1032,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreRevertEverything.addActionListener(this);
 		restoreDeleteUnpacked.addActionListener(this);
 		restoredeleteAllCustomDLC.addActionListener(this);
+		restoreCustomDLCManager.addActionListener(this);
 		restoreRevertBasegame.addActionListener(this);
 		restoreRevertUnpacked.addActionListener(this);
 		restoreVanillifyDLC.addActionListener(this);
@@ -1043,6 +1048,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreMenu.add(restoreDeleteUnpacked);
 		restoreMenu.addSeparator();
 		restoreMenu.add(restoredeleteAllCustomDLC);
+		restoreMenu.add(restoreCustomDLCManager);
 		restoreMenu.addSeparator();
 		restoreMenu.add(restoreRevertBasegame);
 		restoreMenu.add(restoreRevertUnpacked);
@@ -1237,12 +1243,30 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 		} else if (e.getSource() == restoredeleteAllCustomDLC) {
 			if (validateBIOGameDir()) {
-				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.REMOVECUSTOMDLC);
+				if (JOptionPane
+						.showConfirmDialog(
+								this,
+								"This will delete all folders in the BIOGame/DLC folder that aren't known to be official.\nDelete all custom DLC?",
+								"Delete all Custom DLC", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+
+					restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.REMOVECUSTOMDLC);
+				}
 			} else {
 				labelStatus.setText("Can't remove custom DLC with invalid BIOGame directory");
 				JOptionPane.showMessageDialog(null,
 						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+			}
+		} else if (e.getSource() == restoreCustomDLCManager) {
+			if (validateBIOGameDir()) {
+				new CustomDLCWindow(fieldBiogameDir.getText());
+			} else {
+				labelStatus.setText("Custom DLC Manager requires valid BIOGame directory");
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BioGame directory is not valid.\nCustom DLC Manager requires a valid directory.\nFix the BioGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertBasegame) {
 			if (validateBIOGameDir()) {
@@ -1592,23 +1616,16 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				new NetFrameworkMissingWindow("You must install .NET Framework 4.5 or higher to switch mod variants.");
 			}
 		} else if (e.getSource() == modutilsVerifyDeltas) {
-			if (validateBIOGameDir()) {
-				if (ModManager.validateNETFrameworkIsInstalled()) {
-					ModManager.debugLogger.writeMessage("Verifying deltas");
-					Mod mod = modModel.get(modList.getSelectedIndex());
-					for (ModDelta delta : mod.getModDeltas()) {
-						new DeltaWindow(mod, delta, true, false);
-					}
-				} else {
-					labelStatus.setText(".NET Framework 4.5 or higher is missing");
-					ModManager.debugLogger.writeMessage("Patch Library: Missing .NET Framework");
-					new NetFrameworkMissingWindow("You must install .NET Framework 4.5 or higher to switch mod variants.");
+			if (ModManager.validateNETFrameworkIsInstalled()) {
+				ModManager.debugLogger.writeMessage("Verifying deltas");
+				Mod mod = modModel.get(modList.getSelectedIndex());
+				for (ModDelta delta : mod.getModDeltas()) {
+					new DeltaWindow(mod, delta, true, false);
 				}
 			} else {
-				labelStatus.setText("Switching variants requires a valid BIOGame folder");
-				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				labelStatus.setText(".NET Framework 4.5 or higher is missing");
+				ModManager.debugLogger.writeMessage("Patch Library: Missing .NET Framework");
+				new NetFrameworkMissingWindow("You must install .NET Framework 4.5 or higher to switch mod variants.");
 			}
 		} else if (e.getSource() == modutilsUpdateXMLGenerator) {
 			ModManager.debugLogger.writeMessage(ModXMLTools.generateXMLList(modModel.getElementAt(modList.getSelectedIndex())));

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -389,8 +389,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					publish("Downloading latest help information");
 					HelpMenu.getOnlineHelp();
 					publish("UPDATE_HELP_MENU");
-					publish("Checking for updates to mods");
-					checkAllModsForUpdates(false);
+					if (modModel.getSize() > 0) {
+						publish("Checking for updates to mods");
+						checkAllModsForUpdates(false);
+					}
 				}
 			}
 		}

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1868,8 +1868,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	 * 
 	 * @return True if valid, false otherwise
 	 */
-	private boolean validateBIOGameDir() {
-		File coalesced = new File(ModManager.appendSlash(fieldBiogameDir.getText()) + "CookedPCConsole\\Coalesced.bin");
+	public static boolean validateBIOGameDir() {
+		File coalesced = new File(ModManager.appendSlash(ModManagerWindow.ACTIVE_WINDOW.fieldBiogameDir.getText()) + "CookedPCConsole\\Coalesced.bin");
 		if (coalesced.exists()) {
 			return true;
 		} else {

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -2135,7 +2135,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					modNoDeltas.setVisible(false);
 					for (ModDelta delta : selectedMod.getModDeltas()) {
 						JMenuItem deltaItem = new JMenuItem(delta.getDeltaName());
-						deltaItem.setToolTipText(delta.getDeltaDescription());
+						deltaItem.setToolTipText("<html>"+delta.getDeltaDescription()+"</html>");
 						deltaItem.addActionListener(new ActionListener() {
 							@Override
 							public void actionPerformed(ActionEvent e) {

--- a/src/com/me3tweaks/modmanager/MountFileEditorWindow.java
+++ b/src/com/me3tweaks/modmanager/MountFileEditorWindow.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.FileUtils;
 import com.me3tweaks.modmanager.objects.MountFlag;
 import com.me3tweaks.modmanager.ui.HintTextFieldUI;
 import com.me3tweaks.modmanager.ui.MountFlagCellRenderer;
+import com.me3tweaks.modmanager.utilities.ResourceUtils;
 
 public class MountFileEditorWindow extends JDialog {
 	private static final int MOUNTDLC_LENGTH = 108;
@@ -361,8 +362,7 @@ public class MountFileEditorWindow extends JDialog {
 					"Invalid DLC TLK ID", JOptionPane.ERROR_MESSAGE);
 			return false;
 		}
-
-		return false;
+		return true;
 	}
 
 	private void loadMount(String path) {
@@ -455,5 +455,38 @@ public class MountFileEditorWindow extends JDialog {
 	public static void main(String[] args) {
 		MountFileEditorWindow.ISRUNNINGASMAIN = true;
 		new MountFileEditorWindow();
+	}
+
+	public static String getMountDescription(File mountFile) {
+		byte[] data;
+		try {
+			data = Files.readAllBytes(mountFile.toPath());
+		} catch (IOException e) {
+			ModManager.debugLogger.writeErrorWithException("Failed to read mountfile:", e);
+			return "I/O Exception";
+		}
+		if (data.length != MOUNTDLC_LENGTH) {
+			return "Invalid Mount File (size)";
+		}
+
+		//MOUNT FLAG (8-BIT)
+		byte mountFlagVal = data[MPSPFLAG_OFFSET];
+		switch (mountFlagVal) {
+		case 8:
+			return "SP | Not required 0x"+ Integer.toString(8,16);
+		case 9:
+			return "SP | Required 0x"+ Integer.toString(9,16);
+		case 28:
+			return "SP&MP | Not required (SP) 0x"+ Integer.toString(28,16);
+		case 12:
+			return "MP (PATCH)| Loads in MP 0x"+ Integer.toString(12,16);
+		case 20:
+			return "MP | Loads in MP 0x"+ Integer.toString(20,16);
+		case 52:
+			return "MP | Loads in MP 0x"+ Integer.toString(52,16);
+		default:
+			return "Unknown Mount Flag: 0x"+Integer.toString(mountFlagVal, 16);
+		
+		}
 	}
 }

--- a/src/com/me3tweaks/modmanager/MountFileEditorWindow.java
+++ b/src/com/me3tweaks/modmanager/MountFileEditorWindow.java
@@ -159,8 +159,9 @@ public class MountFileEditorWindow extends JDialog {
 
 		mountFlagsCombobox = new JComboBox<MountFlag>();
 		flagModel = new DefaultComboBoxModel<MountFlag>();
+		flagModel.addElement(new MountFlag("SP | Does not require DLC in save file", 8));
 		flagModel.addElement(new MountFlag("SP | Requires DLC in save file", 9));
-		flagModel.addElement(new MountFlag("SP/MP | Does not require DLC in save file", 28));
+		flagModel.addElement(new MountFlag("SP&MP | Does not require DLC in save file", 28));
 		flagModel.addElement(new MountFlag("MP (PATCH) | Loads in MP", 12));
 		flagModel.addElement(new MountFlag("MP | Loads in MP", 20));
 		flagModel.addElement(new MountFlag("MP | Loads in MP", 52));

--- a/src/com/me3tweaks/modmanager/MountFileEditorWindow.java
+++ b/src/com/me3tweaks/modmanager/MountFileEditorWindow.java
@@ -361,8 +361,7 @@ public class MountFileEditorWindow extends JDialog {
 					"Invalid DLC TLK ID", JOptionPane.ERROR_MESSAGE);
 			return false;
 		}
-
-		return false;
+		return true;
 	}
 
 	private void loadMount(String path) {

--- a/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
+++ b/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
@@ -89,7 +89,7 @@ public class RestoreFilesWindow extends JDialog {
 		this.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
 		this.setTitle("Restoring game files");
 		this.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-		this.setPreferredSize(new Dimension(430, 240));
+		this.setPreferredSize(new Dimension(350, 240));
 		this.setResizable(false);
 		this.setIconImages(ModManager.ICONS);
 
@@ -373,7 +373,7 @@ public class RestoreFilesWindow extends JDialog {
 				String specificdlcbackupfolder = dlcbackupfolder + dlcFolderMap.get(header);
 				File backupdir = new File(specificdlcbackupfolder);
 				if (backupdir.exists()) {
-					Collection<File> backupfiles = FileUtils.listFiles(new File(backupfolder), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+					Collection<File> backupfiles = FileUtils.listFiles(backupdir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
 					for (File backup : backupfiles) {
 						String taskTitle = backup.getAbsolutePath().startsWith(dlcbackupfolder) ? "UNPACKED DLC" : "BASEGAME";
 						//verify it.

--- a/src/com/me3tweaks/modmanager/SelectiveRestoreWindow.java
+++ b/src/com/me3tweaks/modmanager/SelectiveRestoreWindow.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -68,6 +69,7 @@ public class SelectiveRestoreWindow extends JDialog {
 	 * @param BioGameDir
 	 */
 	public SelectiveRestoreWindow(String BioGameDir) {
+		ModManager.debugLogger.writeMessage("==============STARTING THE SELECTIVE RESTORE WINDOW==============");
 		// callingWindow.setEnabled(false);
 		this.BioGameDir = BioGameDir;
 		setupWindow();
@@ -95,9 +97,11 @@ public class SelectiveRestoreWindow extends JDialog {
 		//TABLE
 		Action restoreSfar = new AbstractAction() {
 			public void actionPerformed(ActionEvent e) {
+				
 				JTable table = (JTable) e.getSource();
 				int modelRow = Integer.valueOf(e.getActionCommand());
 				String header = (String) table.getModel().getValueAt(modelRow, COL_HUMNAME);
+				ModManager.debugLogger.writeMessage("==RESTORE SFAR CLICKED: "+header+"==");
 				new RestoreFilesWindow(BioGameDir, header, RestoreMode.SFAR_HEADER_RESTORE);
 				updateTable();
 			}
@@ -107,6 +111,7 @@ public class SelectiveRestoreWindow extends JDialog {
 				JTable table = (JTable) e.getSource();
 				int modelRow = Integer.valueOf(e.getActionCommand());
 				String header = (String) table.getModel().getValueAt(modelRow, COL_HUMNAME);
+				ModManager.debugLogger.writeMessage("==RESTORE UNPACKED CLICKED: "+header+"==");
 				new RestoreFilesWindow(BioGameDir, header, RestoreMode.UNPACKED_HEADER_RESTORE);
 				updateTable();
 			}
@@ -120,6 +125,7 @@ public class SelectiveRestoreWindow extends JDialog {
 						+ "?\nThis will additionally delete any unpacked backups Mod Manager has made of these files.", "Delete Unpacked Files",
 						JOptionPane.WARNING_MESSAGE);
 				if (result == JOptionPane.YES_OPTION) {
+					ModManager.debugLogger.writeMessage("==DELETE UNPACKED CLICKED: "+header+"==");
 					new RestoreFilesWindow(BioGameDir, header, RestoreMode.UNPACKED_HEADER_DELETE);
 					updateTable();
 				}
@@ -154,7 +160,9 @@ public class SelectiveRestoreWindow extends JDialog {
 		JPanel basegamePanel = new JPanel();
 		basegamePanel.setLayout(new BoxLayout(basegamePanel, BoxLayout.LINE_AXIS));
 		basegameRestoreButton = new JButton();
-		basegameFolderButton = new JButton("Open basegame backup folder");
+		basegameFolderButton = new JButton("Open backup folder");
+		basegameFolderButton.setToolTipText("<html>Opens the Mod Manager file backup folder</html>");
+
 		basegameRestoreButton.addActionListener(new ActionListener() {
 			
 			@Override
@@ -189,17 +197,24 @@ public class SelectiveRestoreWindow extends JDialog {
 			if (numfiles < 1) {
 				basegameRestoreButton.setText("No basegame files backed up yet");
 				basegameRestoreButton.setEnabled(false);
+				basegameRestoreButton.setToolTipText("<html>Mod Manager has not backed up any files that mods have modified yet.</html>");
 			} else {
 				basegameRestoreButton.setText("Restore "+numfiles+" basegame file"+((numfiles != 1) ? "s":""));
 				basegameRestoreButton.setEnabled(true);
+				basegameRestoreButton.setToolTipText("<html>Mod Manager has backed up basegame files as mods were installed.<br>Click this button to restore them.</html>");
 			}
 		} else {
 			basegameRestoreButton.setText("No basegame files backed up yet");
+			basegameRestoreButton.setToolTipText("<html>Mod Manager has not backed up any files that mods have modified yet.</html>");
 			basegameRestoreButton.setEnabled(false);
 		}
 
+		basegamePanel.add(Box.createHorizontalGlue());
 		basegamePanel.add(basegameRestoreButton);
+		basegamePanel.add(Box.createRigidArea(new Dimension(15,15)));
+
 		basegamePanel.add(basegameFolderButton);
+		basegamePanel.add(Box.createHorizontalGlue());
 
 		rootPanel.add(basegamePanel, BorderLayout.SOUTH);
 
@@ -221,6 +236,7 @@ public class SelectiveRestoreWindow extends JDialog {
 	 * Updates data in the dlcTableData table
 	 */
 	protected void updateTable() {
+		ModManager.debugLogger.writeMessage("===UPDATING CUSTOM RESTORE TABLE===");
 		HashMap<String, Long> sizesMap = ModType.getSizesMap();
 		HashMap<String, String> nameMap = ModType.getHeaderFolderMap();
 
@@ -296,6 +312,7 @@ public class SelectiveRestoreWindow extends JDialog {
 				continue;
 			}
 		}
+		ModManager.debugLogger.writeMessage("===END OF UPDATING CUSTOM RESTORE TABLE===");
 	}
 
 	private void setDLCNotInstalled(int i) {
@@ -320,7 +337,6 @@ public class SelectiveRestoreWindow extends JDialog {
 					if (file.isFile()) {
 						String filepath = file.getAbsolutePath();
 						if (!filepath.endsWith(".sfar") && !filepath.endsWith(".bak")) {
-							ModManager.debugLogger.writeMessage("Unpacked file: " + filepath);
 							filepaths.add(filepath);
 						}
 					}
@@ -328,7 +344,7 @@ public class SelectiveRestoreWindow extends JDialog {
 				//find PCConsoleTOC.bin for it
 				File dlcConsoleTOC = new File(ModManager.appendSlash(dlcDirectory.getParent()) + "PCConsoleTOC.bin");
 				if (dlcConsoleTOC.exists()) {
-					ModManager.debugLogger.writeMessage("Unpacked file: " + dlcConsoleTOC.getAbsolutePath());
+					//ModManager.debugLogger.writeMessage("Unpacked file: " + dlcConsoleTOC.getAbsolutePath());
 					filepaths.add(dlcConsoleTOC.getAbsolutePath());
 				}
 			}

--- a/src/com/me3tweaks/modmanager/SelectiveRestoreWindow.java
+++ b/src/com/me3tweaks/modmanager/SelectiveRestoreWindow.java
@@ -1,0 +1,338 @@
+package com.me3tweaks.modmanager;
+
+import java.awt.BorderLayout;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.border.EmptyBorder;
+import javax.swing.table.DefaultTableModel;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+
+import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
+import com.me3tweaks.modmanager.objects.ModType;
+import com.me3tweaks.modmanager.objects.RestoreMode;
+import com.me3tweaks.modmanager.ui.NumReqButtonColumn;
+import com.me3tweaks.modmanager.ui.SFARColumn;
+import com.me3tweaks.modmanager.ui.SelectiveRestoreTableCellRenderer;
+import com.me3tweaks.modmanager.utilities.ResourceUtils;
+
+@SuppressWarnings("serial")
+public class SelectiveRestoreWindow extends JDialog {
+	private static final int NUM_COLUMNS = 8;
+	public static final int COL_HUMNAME = 0;
+	public static final int COL_INTNAME = 1;
+	public static final int COL_INSTALLED = 2;
+	public static final int COL_BACKEDUP = 3;
+	public static final int COL_MODIFIED = 4;
+	public static final int COL_ACTION_SFAR = 5;
+	public static final int COL_ACTION_UNPACKED = 6;
+	public static final int COL_ACTION_DEL_UNPACKED = 7;
+
+	JLabel infoLabel;
+	// CheckBoxList dlcList;
+	String consoleQueue[];
+	boolean windowOpen = true;
+	String currentText;
+	String BioGameDir;
+	JPanel checkBoxPanel;
+	JButton backupButton;
+	JButton basegameRestoreButton;
+	JButton basegameFolderButton;
+	private Object[][] dlcTableData;
+	private String[] headerArray;
+	private JTable table;
+
+	/**
+	 * Manually invoked backup window
+	 * 
+	 * @param BioGameDir
+	 */
+	public SelectiveRestoreWindow(String BioGameDir) {
+		// callingWindow.setEnabled(false);
+		this.BioGameDir = BioGameDir;
+		setupWindow();
+
+		this.pack();
+		this.setLocationRelativeTo(ModManagerWindow.ACTIVE_WINDOW);
+		this.setVisible(true);
+	}
+
+	private void setupWindow() {
+		this.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
+		this.setTitle("Custom Restore");
+		this.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+		this.setIconImages(ModManager.ICONS);
+		this.setPreferredSize(new Dimension(820, 440));
+
+		JPanel rootPanel = new JPanel(new BorderLayout());
+		infoLabel = new JLabel("<html>Select data to restore.</html>");
+		rootPanel.add(infoLabel, BorderLayout.NORTH);
+
+		//DLC TABLE DATA SOURCE
+		headerArray = ModType.getDLCHeaderNameArray();
+		dlcTableData = new Object[headerArray.length][NUM_COLUMNS];
+
+		//TABLE
+		Action restoreSfar = new AbstractAction() {
+			public void actionPerformed(ActionEvent e) {
+				JTable table = (JTable) e.getSource();
+				int modelRow = Integer.valueOf(e.getActionCommand());
+				String header = (String) table.getModel().getValueAt(modelRow, COL_HUMNAME);
+				new RestoreFilesWindow(BioGameDir, header, RestoreMode.SFAR_HEADER_RESTORE);
+				updateTable();
+			}
+		};
+		Action restoreUnpacked = new AbstractAction() {
+			public void actionPerformed(ActionEvent e) {
+				JTable table = (JTable) e.getSource();
+				int modelRow = Integer.valueOf(e.getActionCommand());
+				String header = (String) table.getModel().getValueAt(modelRow, COL_HUMNAME);
+				new RestoreFilesWindow(BioGameDir, header, RestoreMode.UNPACKED_HEADER_RESTORE);
+				updateTable();
+			}
+		};
+		Action deleteUnpacked = new AbstractAction() {
+			public void actionPerformed(ActionEvent e) {
+				JTable table = (JTable) e.getSource();
+				int modelRow = Integer.valueOf(e.getActionCommand());
+				String header = (String) table.getModel().getValueAt(modelRow, COL_HUMNAME);
+				int result = JOptionPane.showConfirmDialog(SelectiveRestoreWindow.this, "Delete unpacked files for " + header
+						+ "?\nThis will additionally delete any unpacked backups Mod Manager has made of these files.", "Delete Unpacked Files",
+						JOptionPane.WARNING_MESSAGE);
+				if (result == JOptionPane.YES_OPTION) {
+					new RestoreFilesWindow(BioGameDir, header, RestoreMode.UNPACKED_HEADER_DELETE);
+					updateTable();
+				}
+			}
+		};
+		String[] columnNames = { "DLC Name", "Internal Name", "Installed", "Backed Up", "SFAR Status", "Restore SFAR", "Restore Unpacked",
+				"Delete Unpacked" };
+		DefaultTableModel model = new DefaultTableModel(dlcTableData, columnNames);
+		table = new JTable(model) {
+			public boolean isCellEditable(int row, int column) {
+				Object value = table.getValueAt(row, column);
+				switch (column) {
+				case COL_ACTION_SFAR:
+					return value != null && table.getValueAt(row, column).equals("RESTORE");
+				case COL_ACTION_UNPACKED:
+					return value != null && !table.getValueAt(row, column).equals(0);
+				case COL_ACTION_DEL_UNPACKED:
+					return value != null && !table.getValueAt(row, column).equals(0);
+				}
+				return column == -1; //TODO
+			}
+		};
+		table.setDefaultRenderer(Object.class, new SelectiveRestoreTableCellRenderer());
+		table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+		SFARColumn sfarCol = new SFARColumn(table, restoreSfar, COL_ACTION_SFAR);
+		NumReqButtonColumn unpackedCol = new NumReqButtonColumn(table, restoreUnpacked, COL_ACTION_UNPACKED);
+		NumReqButtonColumn deleteUnpackedCol = new NumReqButtonColumn(table, deleteUnpacked, COL_ACTION_DEL_UNPACKED);
+		updateTable();
+		JScrollPane scrollpane = new JScrollPane(table);
+		rootPanel.add(scrollpane, BorderLayout.CENTER);
+
+		JPanel basegamePanel = new JPanel();
+		basegamePanel.setLayout(new BoxLayout(basegamePanel, BoxLayout.LINE_AXIS));
+		basegameRestoreButton = new JButton();
+		basegameFolderButton = new JButton("Open basegame backup folder");
+		basegameRestoreButton.addActionListener(new ActionListener() {
+			
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				new RestoreFilesWindow(BioGameDir, RestoreMode.BASEGAME);
+			}
+		});
+		basegameFolderButton.addActionListener(new ActionListener() {
+			
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				ResourceUtils.openDir(ModManager.appendSlash(new File(BioGameDir).getParent()) + "cmmbackup\\BIOGame\\");
+			}
+		});
+		
+		//CALCULATE NUM BACKED UP BASEGAME FILES
+		String me3dir = (new File(BioGameDir)).getParent();
+		String basegamebackupfolder = ModManager.appendSlash(me3dir) + "cmmbackup\\BIOGame\\";
+		String blacklist = ModManager.appendSlash(me3dir) + "cmmbackup\\BIOGame\\DLC\\";
+		File backupdir = new File(basegamebackupfolder);
+		ModManager.debugLogger.writeMessage("Calculating num of basegame backup files: " + backupdir);
+		int numfiles = 0;
+		if (backupdir.exists()) {
+			Collection<File> backupfiles = FileUtils.listFiles(backupdir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+			for (File f : backupfiles) {
+				if (f.getAbsolutePath().toLowerCase().startsWith(blacklist.toLowerCase())){
+					continue;
+				}
+				numfiles++;
+			}
+			basegameRestoreButton.setText("Restore "+numfiles+" basegame file"+((numfiles != 1) ? "s":""));
+			if (numfiles < 1) {
+				basegameRestoreButton.setText("No basegame files backed up yet");
+				basegameRestoreButton.setEnabled(false);
+			} else {
+				basegameRestoreButton.setText("Restore "+numfiles+" basegame file"+((numfiles != 1) ? "s":""));
+				basegameRestoreButton.setEnabled(true);
+			}
+		} else {
+			basegameRestoreButton.setText("No basegame files backed up yet");
+			basegameRestoreButton.setEnabled(false);
+		}
+
+		basegamePanel.add(basegameRestoreButton);
+		basegamePanel.add(basegameFolderButton);
+
+		rootPanel.add(basegamePanel, BorderLayout.SOUTH);
+
+		rootPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
+		getContentPane().add(rootPanel);
+
+		addWindowListener(new WindowAdapter() {
+
+			@Override
+			public void windowClosing(WindowEvent e) {
+				windowOpen = false;
+				// methods will read this variable
+			}
+		});
+
+	}
+
+	/**
+	 * Updates data in the dlcTableData table
+	 */
+	protected void updateTable() {
+		HashMap<String, Long> sizesMap = ModType.getSizesMap();
+		HashMap<String, String> nameMap = ModType.getHeaderFolderMap();
+
+		int i = -1;
+		// Add and enable/disable DLC checkboxes and add to hashmap
+		for (String dlcName : headerArray) {
+			i++;
+			table.setValueAt(ME3TweaksUtils.headerNameToShortDLCFolderName(dlcName), i, COL_INTNAME);
+			table.setValueAt(dlcName, i, COL_HUMNAME);
+
+			String filepath = ModManager.appendSlash(BioGameDir) + ModManager.appendSlash(ModType.getDLCPath(dlcName));
+			File dlcPath = new File(filepath);
+			// Check if directory exists
+			if (!dlcPath.exists()) {
+				ModManager.debugLogger.writeMessage(dlcName + " DLC folder not present.");
+				setDLCNotInstalled(i);
+				continue;
+			}
+
+			// The folder exists.
+			File mainSfar = new File(dlcPath + "\\Default.sfar");
+			File testpatchSfar = new File(dlcPath + "\\Patch_001.sfar");
+			File mainSfarbackup = new File(dlcPath + "\\Default.sfar.bak");
+			File testpatchSfarbackup = new File(dlcPath + "\\Patch_001.sfar.bak");
+			ModManager.debugLogger.writeMessage("Looking for Default.sfar, Patch_001.sfar in " + filepath);
+			if (mainSfar.exists() || testpatchSfar.exists()) {
+				//SFAR exists.
+				table.setValueAt("YES", i, COL_INSTALLED);
+				//check for backups
+				if (!mainSfarbackup.exists() && !testpatchSfarbackup.exists()) {
+					table.setValueAt("NO", i, COL_BACKEDUP);
+					table.setValueAt("NO BACKUP", i, COL_ACTION_SFAR);
+				} else {
+					table.setValueAt("YES", i, COL_BACKEDUP);
+					table.setValueAt("RESTORE", i, COL_ACTION_SFAR);
+				}
+
+				if (mainSfar.exists()) {
+					if (mainSfar.length() != sizesMap.get(dlcName)) {
+						table.setValueAt("MODIFIED" + (mainSfar.length() > sizesMap.get(dlcName) ? "+" : "-"), i, COL_MODIFIED);
+
+					} else {
+						table.setValueAt("ORIGINAL", i, COL_MODIFIED);
+					}
+				} else {
+					if (testpatchSfar.length() != sizesMap.get(dlcName)) {
+						table.setValueAt("MODIFIED" + (testpatchSfar.length() > sizesMap.get(dlcName) ? "+" : "-"), i, COL_MODIFIED);
+					} else {
+						table.setValueAt("ORIGINAL", i, COL_MODIFIED);
+					}
+				}
+
+				//CALCULATE UNPACKED
+				//load Basegame DB
+				String me3dir = (new File(BioGameDir)).getParent();
+				String dlcbackupfolder = ModManager.appendSlash(me3dir) + "cmmbackup\\BIOGame\\DLC\\";
+				String specificdlcbackupfolder = dlcbackupfolder + nameMap.get(dlcName);
+				File backupdir = new File(specificdlcbackupfolder);
+				ModManager.debugLogger.writeMessage("Calculating num of unpacked files: " + backupdir);
+				if (backupdir.exists()) {
+					Collection<File> backupfiles = FileUtils.listFiles(backupdir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+					table.setValueAt(backupfiles.size(), i, COL_ACTION_UNPACKED);
+
+				} else {
+					table.setValueAt(0, i, COL_ACTION_UNPACKED);
+				}
+				ArrayList<String> unpackedFiles = getUnpackedFilesList(new String[] { dlcName });
+				table.setValueAt(unpackedFiles.size(), i, COL_ACTION_DEL_UNPACKED);
+				continue;
+			} else {
+				ModManager.debugLogger.writeMessage(dlcName + " folder exists, but SFAR is not present.");
+				setDLCNotInstalled(i);
+				continue;
+			}
+		}
+	}
+
+	private void setDLCNotInstalled(int i) {
+		table.setValueAt("NO", i, COL_INSTALLED);
+		table.setValueAt("N/A", i, COL_BACKEDUP);
+		table.setValueAt("N/A", i, COL_ACTION_UNPACKED);
+		table.setValueAt(0, i, COL_ACTION_UNPACKED);
+		table.setValueAt(0, i, COL_ACTION_DEL_UNPACKED);
+		table.setValueAt("", i, COL_MODIFIED);
+		table.setValueAt("N/A", i, COL_BACKEDUP);
+	}
+
+	private ArrayList<String> getUnpackedFilesList(String[] dlcHeaders) {
+		ArrayList<String> filepaths = new ArrayList<String>();
+
+		for (String header : dlcHeaders) {
+			String dlcFolderPath = ModManager.appendSlash(BioGameDir) + ModManager.appendSlash(ModType.getDLCPath(header));
+			File dlcDirectory = new File(dlcFolderPath);
+			if (dlcDirectory.exists()) {
+				File files[] = dlcDirectory.listFiles();
+				for (File file : files) {
+					if (file.isFile()) {
+						String filepath = file.getAbsolutePath();
+						if (!filepath.endsWith(".sfar") && !filepath.endsWith(".bak")) {
+							ModManager.debugLogger.writeMessage("Unpacked file: " + filepath);
+							filepaths.add(filepath);
+						}
+					}
+				}
+				//find PCConsoleTOC.bin for it
+				File dlcConsoleTOC = new File(ModManager.appendSlash(dlcDirectory.getParent()) + "PCConsoleTOC.bin");
+				if (dlcConsoleTOC.exists()) {
+					ModManager.debugLogger.writeMessage("Unpacked file: " + dlcConsoleTOC.getAbsolutePath());
+					filepaths.add(dlcConsoleTOC.getAbsolutePath());
+				}
+			}
+		}
+		return filepaths;
+	}
+}

--- a/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
@@ -281,6 +281,64 @@ public class ME3TweaksUtils {
 			return "CITADEL";
 		case "CITADEL_BASE":
 			return "CITADEL_BASE";
+		case "GENESIS2":
+			return "GENESIS2";
+		case "COLLECTORS_EDITION":
+			return "OnlinePassHidCE";
+		default:
+			ModManager.debugLogger.writeMessage("ME3TWEAKSUTILS ERROR: HEADER => INTERNAL " + header);
+			return null;
+		}
+	}
+	
+	/**
+	 * Converts ModDesc.ini headers and job names into DLC folder names. These should be used for making mod folders. This is not the folders in the game that a DLC is placed in.
+	 * 
+	 * @param header Header to lookup
+	 * @return local DLC name, such as MP1 or HEN_PR
+	 */
+	public static String headerNameToShortDLCFolderName(String header) {
+		switch (header) {
+		case "RESURGENCE":
+			return "MP1";
+		case "REBELLION":
+			return "MP2";
+		case "EARTH":
+			return "MP3";
+		case "RETALIATION":
+			return "MP4";
+		case "RECKONING":
+			return "MP5";
+		case "PATCH1":
+			return "PATCH1";
+		case "PATCH2":
+			return "PATCH2";
+		case "BASEGAME":
+			return "BASEGAME";
+		case "TESTPATCH":
+			return "TESTPATCH";
+		case "FROM_ASHES":
+			return "HEN_PR";
+		case "APPEARANCE":
+			return "APP01";
+		case "FIREFIGHT":
+			return "GUN01";
+		case "GROUNDSIDE":
+			return "GUN02";
+		case "EXTENDED_CUT":
+			return "END";
+		case "LEVIATHAN":
+			return "EXP001";
+		case "OMEGA":
+			return "EXP002";
+		case "CITADEL":
+			return "EXP003";
+		case "CITADEL_BASE":
+			return "EXP003_BASE";
+		case "GENESIS2":
+			return "DH1";
+		case "COLLECTORS_EDITION":
+			return "OnlinePassHidCE";
 		default:
 			ModManager.debugLogger.writeMessage("ME3TWEAKSUTILS ERROR: HEADER => INTERNAL " + header);
 			return null;

--- a/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
@@ -159,7 +159,7 @@ public class AllModsUpdateWindow extends JDialog {
 				publish(new Integer(numToGo));
 				ModManager.debugLogger.writeMessage("Processing: " + upackage.getMod().getModName());
 				ModUpdateWindow muw = new ModUpdateWindow(upackage);
-				muw.startAllModsUpdate(AllModsUpdateWindow.this);
+				boolean success = muw.startAllModsUpdate(AllModsUpdateWindow.this);
 				while (muw.isShowing()) {
 					Thread.sleep(350);
 				}

--- a/src/com/me3tweaks/modmanager/modupdater/ModUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModUpdateWindow.java
@@ -79,10 +79,17 @@ public class ModUpdateWindow extends JDialog implements PropertyChangeListener {
 	 * Starts a multi-mod update process (does not display modals)
 	 * @param amuw
 	 */
-	public void startAllModsUpdate(AllModsUpdateWindow amuw) {
+	public boolean startAllModsUpdate(AllModsUpdateWindow amuw) {
 		if (upackage.isModmakerupdate()) {
+			//validate biogamedir (TLK)
+			if (!ModManagerWindow.validateBIOGameDir()) {
+				ModManagerWindow.ACTIVE_WINDOW.fieldBiogameDir.setText("ModMaker mods not updatable, invalid BIOGame directory");
+				return false;
+			}
+			
 			//get default language
 			//set combobox from settings
+			
 			statusLabel.setText("Upgrading via ModMaker Compiler");
 			ModMakerCompilerWindow mcw = new ModMakerCompilerWindow(upackage.getMod(), ModMakerEntryWindow.getDefaultLanguages());
 			while (mcw.isShowing()) {
@@ -100,6 +107,7 @@ public class ModUpdateWindow extends JDialog implements PropertyChangeListener {
 			setLocationRelativeTo(ModManagerWindow.ACTIVE_WINDOW);
 			setVisible(true);
 		}
+		return true;
 	}
 
 	private void setupWindow() {

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -312,7 +312,7 @@ public class Mod implements Comparable<Mod> {
 				ModJob newJob = new ModJob();
 				newJob.setJobName(ModType.CUSTOMDLC); //backwards, it appears...
 				newJob.setJobType(ModJob.CUSTOMDLC);
-				newJob.sourceFolders = new ArrayList<String>();
+				newJob.setSourceFolders(new ArrayList<String>());
 				newJob.setDestFolders(new ArrayList<String>());
 
 				while (srcStrok.hasMoreTokens()) {
@@ -325,6 +325,13 @@ public class Mod implements Comparable<Mod> {
 								+ ", mod marked as invalid");
 						return;
 					}
+					if (ModType.isKnownDLCFolder(destFolder)) {
+						// Same number of tokens aren't the same
+						ModManager.debugLogger
+								.writeError("Custom DLC folder is not allowed as it is a default game one: "+destFolder);
+						return;
+					}
+					
 					List<File> sourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
 					for (File file : sourceFiles) {
 						String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
@@ -334,7 +341,7 @@ public class Mod implements Comparable<Mod> {
 							return;
 						}
 					}
-					newJob.sourceFolders.add(sourceFolder);
+					newJob.getSourceFolders().add(sourceFolder);
 					newJob.getDestFolders().add(destFolder);
 				}
 				ModManager.debugLogger.writeMessageConditionally(modName + ": Successfully made a new Mod Job for: " + ModType.CUSTOMDLC,
@@ -970,7 +977,7 @@ public class Mod implements Comparable<Mod> {
 					StringBuilder dfsb = new StringBuilder();
 
 					//source dirs
-					for (String file : job.sourceFolders) {
+					for (String file : job.getSourceFolders()) {
 						if (isFirst) {
 							isFirst = false;
 						} else {
@@ -1272,7 +1279,7 @@ public class Mod implements Comparable<Mod> {
 		modFolder.mkdirs();
 		for (ModJob job : jobs) {
 			if (job.getJobType() == ModJob.CUSTOMDLC) {
-				for (String sourceFolder : job.sourceFolders) {
+				for (String sourceFolder : job.getSourceFolders()) {
 					try {
 						File srcFolder = new File(ModManager.appendSlash(modDescFile.getParentFile().getAbsolutePath()) + sourceFolder);
 						File destFolder = new File(modFolder + File.separator + sourceFolder); //source folder is a string
@@ -1349,7 +1356,7 @@ public class Mod implements Comparable<Mod> {
 		for (ModDelta delta : newMod.getModDeltas()) {
 			new DeltaWindow(newMod, delta, true, true);
 		}
-		
+
 		new AutoTocWindow(newMod, AutoTocWindow.LOCALMOD_MODE, ModManagerWindow.ACTIVE_WINDOW.fieldBiogameDir.getText());
 		return newMod;
 	}

--- a/src/com/me3tweaks/modmanager/objects/ModJob.java
+++ b/src/com/me3tweaks/modmanager/objects/ModJob.java
@@ -21,7 +21,7 @@ public class ModJob {
 	private int jobType;
 	String DLCFilePath;
 	private String jobName, requirementText;
-	ArrayList<String> sourceFolders; //CUSTOMDLC (used only for writing desc file)
+	private ArrayList<String> sourceFolders; //CUSTOMDLC (used only for writing desc file)
 	private ArrayList<String> destFolders; //CUSTOMDLC (used only for writing desc file)
 	
 	public ArrayList<String> newFiles, filesToReplace, addFiles, addFilesTargets, removeFilesTargets;
@@ -263,6 +263,14 @@ public class ModJob {
 	 */
 	public void setSourceDir(String sourceDir) {
 		this.sourceDir = sourceDir;
+	}
+
+	public ArrayList<String> getSourceFolders() {
+		return sourceFolders;
+	}
+
+	public void setSourceFolders(ArrayList<String> sourceFolders) {
+		this.sourceFolders = sourceFolders;
 	}
 
 	public String getSourceDir() {

--- a/src/com/me3tweaks/modmanager/objects/ModType.java
+++ b/src/com/me3tweaks/modmanager/objects/ModType.java
@@ -54,7 +54,7 @@ public class ModType {
 
 	/**
 	 * Gets the list of standard folders in the DLC folder. Includes the __metadata directory.
-	 * @return
+	 * @return Arraylist of strings of things like DLC_CON_MP1 etc. Does not include DLC_TESTPATCH.
 	 */
 	public static ArrayList<String> getStandardDLCFolders() {
 		ArrayList<String> foldernames = new ArrayList<String>();
@@ -74,7 +74,6 @@ public class ModType {
 		foldernames.add("DLC_CON_APP01");
 		foldernames.add("DLC_CON_GUN01");
 		foldernames.add("DLC_CON_GUN02");
-		foldernames.add("DLC_CON_DH1");
 		foldernames.add("DLC_CON_DH1");
 		foldernames.add("DLC_OnlinePassHidCE");
 		foldernames.add("__metadata"); //don't delete
@@ -252,11 +251,11 @@ public class ModType {
 	}
 
 	public static String[] getSPHeaderNameArray() {
-		return new String[] { COLLECTORSEDITION, HEN_PR, END, EXP1, EXP2, EXP3, EXP3B, APP01, GUN01, GUN02, DH1 };
+		return new String[] { COLLECTORSEDITION, HEN_PR, END, EXP1, EXP2, EXP3, EXP3B, APP01, GUN01, GUN02, DH1, TESTPATCH };
 	}
 
 	public static String[] getSPBaseHeaderNameArray() {
-		return new String[] { BASEGAME, COLLECTORSEDITION, HEN_PR, END, EXP1, EXP2, EXP3, EXP3B, APP01, GUN01, GUN02, DH1};
+		return new String[] { BASEGAME, COLLECTORSEDITION, HEN_PR, END, EXP1, EXP2, EXP3, EXP3B, APP01, GUN01, GUN02, DH1, TESTPATCH};
 	}
 	
 	public static String[] getDLCHeaderNameArray() {
@@ -269,5 +268,22 @@ public class ModType {
 
 	public static String[] getMPBaseHeaderNameArray() {
 		return new String[] { BASEGAME, MP1, MP2, MP3, MP4, MP5, PATCH1, PATCH2, TESTPATCH };
+	}
+
+	/**
+	 * Checks if the the parameter is in the list of known DLC foldernames.
+	 * @param destFolder foldername to check
+	 * @return true if in the list, false otherwise. Comparison is done case insensitively.
+	 */
+	public static boolean isKnownDLCFolder(String destFolder) {
+		for (String knownFolder : getStandardDLCFolders()) {
+			if (destFolder.equalsIgnoreCase(knownFolder)) {
+				return true;
+			}
+		}
+		if (destFolder.equalsIgnoreCase("DLC_TestPatch")) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/src/com/me3tweaks/modmanager/objects/ModType.java
+++ b/src/com/me3tweaks/modmanager/objects/ModType.java
@@ -79,6 +79,30 @@ public class ModType {
 		foldernames.add("__metadata"); //don't delete
 		return foldernames;
 	}
+	
+	public static HashMap<String,String> getHeaderFolderMap() {
+		HashMap<String,String> foldernames = new HashMap<String,String>();
+		foldernames.put(MP1,"DLC_CON_MP1");
+		foldernames.put(MP2,"DLC_CON_MP2");
+		foldernames.put(MP3,"DLC_CON_MP3");
+		foldernames.put(MP4,"DLC_CON_MP4");
+		foldernames.put(MP5,"DLC_CON_MP5");
+		foldernames.put(PATCH1,"DLC_UPD_Patch01");
+		foldernames.put(PATCH2,"DLC_UPD_Patch02");
+		foldernames.put(HEN_PR,"DLC_HEN_PR");
+		foldernames.put(TESTPATCH,"DLC_TESTPATCH");
+		foldernames.put(END,"DLC_CON_END");
+		foldernames.put(EXP1,"DLC_EXP_Pack001");
+		foldernames.put(EXP2,"DLC_EXP_Pack002");
+		foldernames.put(EXP3,"DLC_EXP_Pack003");
+		foldernames.put(EXP3B,"DLC_EXP_Pack003_Base");
+		foldernames.put(APP01,"DLC_CON_APP01");
+		foldernames.put(GUN01,"DLC_CON_GUN01");
+		foldernames.put(GUN02,"DLC_CON_GUN02");
+		foldernames.put(DH1,"DLC_CON_DH1");
+		foldernames.put(COLLECTORSEDITION,"DLC_OnlinePassHidCE");
+		return foldernames;
+	}
 
 	/**
 	 * Returns the subdirectory from biogame (no leading or trailing slashes)

--- a/src/com/me3tweaks/modmanager/objects/RestoreMode.java
+++ b/src/com/me3tweaks/modmanager/objects/RestoreMode.java
@@ -1,5 +1,10 @@
 package com.me3tweaks.modmanager.objects;
 
+/**
+ * Defines constants to use when specifying items to restore
+ * @author Mgamerz
+ *
+ */
 public class RestoreMode {
 	public final static int ALL = 0;
 	public final static int MP = 1;
@@ -12,5 +17,71 @@ public class RestoreMode {
 	public static final int REMOVECUSTOMDLC = 8;
 	public static final int ALLDLC = 9;
 	public static final int REMOVEUNPACKEDITEMS = 10;
-	public static final int VANILLIFYDLC = 11;
+	
+	public static final int MP1SFAR = 11;
+	public static final int MP2SFAR = 12;
+	public static final int MP3SFAR = 13;
+	public static final int MP4SFAR = 14;
+	public static final int MP5SFAR = 15;
+	public static final int PATCH1SFAR = 16;
+	public static final int PATCH2SFAR = 17;
+	public static final int TESTPATCHSFAR = 18;
+	public static final int HENPRSFAR = 19;
+	public static final int ENDSFAR = 20;
+	public static final int EXP1SFAR = 21;
+	public static final int EXP2SFAR = 22;
+	public static final int EXP3SFAR = 23;
+	public static final int EXP3BSFAR = 24;
+	public static final int APP01SFAR = 25;
+	public static final int GUN01SFAR = 26;
+	public static final int GUN02SFAR = 27;
+	public static final int DH1SFAR = 28;
+	public static final int COLLECTORSEDITIONSFAR = 29;	
+	
+	public static final int MP1UNPACKED = 30;
+	public static final int MP2UNPACKED = 31;
+	public static final int MP3UNPACKED = 32;
+	public static final int MP4UNPACKED = 33;
+	public static final int MP5UNPACKED = 34;
+	public static final int PATCH1UNPACKED = 35;
+	public static final int PATCH2UNPACKED = 36;
+	public static final int TESTPATCHUNPACKED = 37;
+	public static final int HENPRUNPACKED = 38;
+	public static final int ENDUNPACKED = 39;
+	public static final int EXP1UNPACKED = 40;
+	public static final int EXP2UNPACKED = 41;
+	public static final int EXP3UNPACKED = 42;
+	public static final int EXP3BUNPACKED = 43;
+	public static final int APP01UNPACKED = 44;
+	public static final int GUN01UNPACKED = 45;
+	public static final int GUN02UNPACKED = 46;
+	public static final int DH1UNPACKED = 47;
+	public static final int COLLECTORSEDITIONUNPACKED = 48;	
+	
+	public static final int DEL_MP1UNPACKED = 49;
+	public static final int DEL_MP2UNPACKED = 50;
+	public static final int DEL_MP3UNPACKED = 51;
+	public static final int DEL_MP4UNPACKED = 52;
+	public static final int DEL_MP5UNPACKED = 53;
+	public static final int DEL_PATCH1UNPACKED = 54;
+	public static final int DEL_PATCH2UNPACKED = 55;
+	public static final int DEL_TESTPATCHUNPACKED = 56;
+	public static final int DEL_HENPRUNPACKED = 57;
+	public static final int DEL_ENDUNPACKED = 58;
+	public static final int DEL_EXP1UNPACKED = 59;
+	public static final int DEL_EXP2UNPACKED = 60;
+	public static final int DEL_EXP3UNPACKED = 61;
+	public static final int DEL_EXP3BUNPACKED = 62;
+	public static final int DEL_APP01UNPACKED = 63;
+	public static final int DEL_GUN01UNPACKED = 64;
+	public static final int DEL_GUN02UNPACKED = 65;
+	public static final int DEL_DH1UNPACKED = 66;
+	public static final int DEL_COLLECTORSEDITIONUNPACKED = 67;
+	
+	public static final int VANILLIFYDLC = 1000;
+	
+	//OPERATION TYPES
+	public static final int SFAR_HEADER_RESTORE = 100;	
+	public static final int UNPACKED_HEADER_RESTORE = 101;	
+	public static final int UNPACKED_HEADER_DELETE = 102;
 }

--- a/src/com/me3tweaks/modmanager/ui/ButtonColumn.java
+++ b/src/com/me3tweaks/modmanager/ui/ButtonColumn.java
@@ -1,0 +1,225 @@
+package com.me3tweaks.modmanager.ui;
+
+import java.awt.*;
+import java.awt.event.*;
+import javax.swing.*;
+import javax.swing.border.*;
+import javax.swing.table.*;
+
+/**
+ *  The ButtonColumn class provides a renderer and an editor that looks like a
+ *  JButton. The renderer and editor will then be used for a specified column
+ *  in the table. The TableModel will contain the String to be displayed on
+ *  the button.
+ *
+ *  The button can be invoked by a mouse click or by pressing the space bar
+ *  when the cell has focus. Optionally a mnemonic can be set to invoke the
+ *  button. When the button is invoked the provided Action is invoked. The
+ *  source of the Action will be the table. The action command will contain
+ *  the model row number of the button that was clicked.
+ *
+ */
+public class ButtonColumn extends AbstractCellEditor
+	implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener
+{
+	private JTable table;
+	private Action action;
+	private int mnemonic;
+	private Border originalBorder;
+	private Border focusBorder;
+
+	private JButton renderButton;
+	private JButton editButton;
+	private Object editorValue;
+	private boolean isButtonColumnEditor;
+
+	/**
+	 *  Create the ButtonColumn to be used as a renderer and editor. The
+	 *  renderer and editor will automatically be installed on the TableColumn
+	 *  of the specified column.
+	 *
+	 *  @param table the table containing the button renderer/editor
+	 *  @param action the Action to be invoked when the button is invoked
+	 *  @param column the column to which the button renderer/editor is added
+	 */
+	public ButtonColumn(JTable table, Action action, int column)
+	{
+		this.table = table;
+		this.action = action;
+
+		renderButton = new JButton();
+		editButton = new JButton();
+		editButton.setFocusPainted( false );
+		editButton.addActionListener( this );
+		originalBorder = editButton.getBorder();
+		setFocusBorder( new LineBorder(Color.BLUE) );
+
+		TableColumnModel columnModel = table.getColumnModel();
+		columnModel.getColumn(column).setCellRenderer( this );
+		columnModel.getColumn(column).setCellEditor( this );
+		table.addMouseListener( this );
+	}
+
+
+	/**
+	 *  Get foreground color of the button when the cell has focus
+	 *
+	 *  @return the foreground color
+	 */
+	public Border getFocusBorder()
+	{
+		return focusBorder;
+	}
+
+	/**
+	 *  The foreground color of the button when the cell has focus
+	 *
+	 *  @param focusBorder the foreground color
+	 */
+	public void setFocusBorder(Border focusBorder)
+	{
+		this.focusBorder = focusBorder;
+		editButton.setBorder( focusBorder );
+	}
+
+	public int getMnemonic()
+	{
+		return mnemonic;
+	}
+
+	/**
+	 *  The mnemonic to activate the button when the cell has focus
+	 *
+	 *  @param mnemonic the mnemonic
+	 */
+	public void setMnemonic(int mnemonic)
+	{
+		this.mnemonic = mnemonic;
+		renderButton.setMnemonic(mnemonic);
+		editButton.setMnemonic(mnemonic);
+	}
+
+	@Override
+	public Component getTableCellEditorComponent(
+		JTable table, Object value, boolean isSelected, int row, int column)
+	{
+		if (value == null)
+		{
+			editButton.setText( "" );
+			editButton.setIcon( null );
+		}
+		else if (value instanceof Icon)
+		{
+			editButton.setText( "" );
+			editButton.setIcon( (Icon)value );
+		}
+		else
+		{
+			editButton.setText( value.toString() );
+			editButton.setIcon( null );
+		}
+
+		this.editorValue = value;
+		return editButton;
+	}
+
+	@Override
+	public Object getCellEditorValue()
+	{
+		return editorValue;
+	}
+
+//
+//  Implement TableCellRenderer interface
+//
+	public Component getTableCellRendererComponent(
+		JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column)
+	{
+		if (isSelected)
+		{
+			renderButton.setForeground(table.getSelectionForeground());
+	 		renderButton.setBackground(table.getSelectionBackground());
+		}
+		else
+		{
+			renderButton.setForeground(table.getForeground());
+			renderButton.setBackground(UIManager.getColor("Button.background"));
+		}
+
+		if (hasFocus)
+		{
+			renderButton.setBorder( focusBorder );
+		}
+		else
+		{
+			renderButton.setBorder( originalBorder );
+		}
+
+//		renderButton.setText( (value == null) ? "" : value.toString() );
+		if (value == null)
+		{
+			renderButton.setText( "" );
+			renderButton.setIcon( null );
+		}
+		else if (value instanceof Icon)
+		{
+			renderButton.setText( "" );
+			renderButton.setIcon( (Icon)value );
+		}
+		else
+		{
+			renderButton.setText( value.toString() );
+			renderButton.setIcon( null );
+		}
+
+		return renderButton;
+	}
+
+//
+//  Implement ActionListener interface
+//
+	/*
+	 *	The button has been pressed. Stop editing and invoke the custom Action
+	 */
+	public void actionPerformed(ActionEvent e)
+	{
+		int row = table.convertRowIndexToModel( table.getEditingRow() );
+		fireEditingStopped();
+
+		//  Invoke the Action
+
+		ActionEvent event = new ActionEvent(
+			table,
+			ActionEvent.ACTION_PERFORMED,
+			"" + row);
+		action.actionPerformed(event);
+	}
+
+//
+//  Implement MouseListener interface
+//
+	/*
+	 *  When the mouse is pressed the editor is invoked. If you then then drag
+	 *  the mouse to another cell before releasing it, the editor is still
+	 *  active. Make sure editing is stopped when the mouse is released.
+	 */
+    public void mousePressed(MouseEvent e)
+    {
+    	if (table.isEditing()
+		&&  table.getCellEditor() == this)
+			isButtonColumnEditor = true;
+    }
+
+    public void mouseReleased(MouseEvent e)
+    {
+    	if (isButtonColumnEditor
+    	&&  table.isEditing())
+    		table.getCellEditor().stopCellEditing();
+
+		isButtonColumnEditor = false;
+    }
+
+    public void mouseClicked(MouseEvent e) {}
+	public void mouseEntered(MouseEvent e) {}
+    public void mouseExited(MouseEvent e) {}
+}

--- a/src/com/me3tweaks/modmanager/ui/NumReqButtonColumn.java
+++ b/src/com/me3tweaks/modmanager/ui/NumReqButtonColumn.java
@@ -20,7 +20,7 @@ import javax.swing.table.*;
  * number of the button that was clicked.
  *
  */
-public class ButtonColumn extends AbstractCellEditor implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
+public class NumReqButtonColumn extends AbstractCellEditor implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
 	private JTable table;
 	private Action action;
 	private int mnemonic;
@@ -45,10 +45,11 @@ public class ButtonColumn extends AbstractCellEditor implements TableCellRendere
 	 * @param column
 	 *            the column to which the button renderer/editor is added
 	 */
-	public ButtonColumn(JTable table, Action action, int column) {
+	public NumReqButtonColumn(JTable table, Action action, int column) {
 		this.table = table;
 		this.action = action;
 		defaultCell = new DefaultTableCellRenderer();
+		defaultCell.setHorizontalAlignment(JLabel.CENTER);
 		renderButton = new JButton();
 		editButton = new JButton();
 		editButton.setFocusPainted(false);
@@ -103,11 +104,23 @@ public class ButtonColumn extends AbstractCellEditor implements TableCellRendere
 		if (value == null) {
 			editButton.setText("");
 			editButton.setIcon(null);
-		} else if (value instanceof Icon) {
+		}
+		
+		String text = "Undefined";
+		if (value instanceof Integer) {
+			int numVal  = (Integer) value;
+			if (numVal > 0) {
+				text = numVal + " file"+((numVal != 1) ? "s": "");
+			} else {
+				defaultCell.setText("N/A");
+				return defaultCell;
+			}
+		}
+		if (value instanceof Icon) {
 			editButton.setText("");
 			editButton.setIcon((Icon) value);
 		} else {
-			editButton.setText(value.toString());
+			editButton.setText(text);
 			editButton.setIcon(null);
 		}
 
@@ -127,6 +140,18 @@ public class ButtonColumn extends AbstractCellEditor implements TableCellRendere
 		if (value == null) {
 			return defaultCell;
 		}
+		
+		String text = "Undefined";
+		if (value instanceof Integer) {
+			int numVal  = (Integer) value;
+			if (numVal > 0) {
+				text = numVal + " file"+((numVal != 1) ? "s": "");
+			} else {
+				defaultCell.setText("N/A");
+				return defaultCell;
+			}
+		}
+		
 		if (isSelected) {
 			renderButton.setForeground(table.getSelectionForeground());
 			renderButton.setBackground(table.getSelectionBackground());
@@ -144,7 +169,7 @@ public class ButtonColumn extends AbstractCellEditor implements TableCellRendere
 			renderButton.setText("");
 			renderButton.setIcon((Icon) value);
 		} else {
-			renderButton.setText(value.toString());
+			renderButton.setText(text);
 			renderButton.setIcon(null);
 		}
 

--- a/src/com/me3tweaks/modmanager/ui/SFARColumn.java
+++ b/src/com/me3tweaks/modmanager/ui/SFARColumn.java
@@ -20,7 +20,7 @@ import javax.swing.table.*;
  * number of the button that was clicked.
  *
  */
-public class ButtonColumn extends AbstractCellEditor implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
+public class SFARColumn extends AbstractCellEditor implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
 	private JTable table;
 	private Action action;
 	private int mnemonic;
@@ -45,10 +45,11 @@ public class ButtonColumn extends AbstractCellEditor implements TableCellRendere
 	 * @param column
 	 *            the column to which the button renderer/editor is added
 	 */
-	public ButtonColumn(JTable table, Action action, int column) {
+	public SFARColumn(JTable table, Action action, int column) {
 		this.table = table;
 		this.action = action;
 		defaultCell = new DefaultTableCellRenderer();
+		defaultCell.setHorizontalAlignment(JLabel.CENTER);
 		renderButton = new JButton();
 		editButton = new JButton();
 		editButton.setFocusPainted(false);
@@ -126,6 +127,14 @@ public class ButtonColumn extends AbstractCellEditor implements TableCellRendere
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
 		if (value == null) {
 			return defaultCell;
+		}
+		if (value instanceof String && ((String) value).equals("NO BACKUP")) {
+			defaultCell.setText("NO BACKUP");
+			defaultCell.setBackground(SelectiveRestoreTableCellRenderer.badColor);
+			return defaultCell;
+		} else {
+			defaultCell.setText("");
+			defaultCell.setBackground(null);
 		}
 		if (isSelected) {
 			renderButton.setForeground(table.getSelectionForeground());

--- a/src/com/me3tweaks/modmanager/ui/SelectiveRestoreTableCellRenderer.java
+++ b/src/com/me3tweaks/modmanager/ui/SelectiveRestoreTableCellRenderer.java
@@ -1,0 +1,49 @@
+package com.me3tweaks.modmanager.ui;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Font;
+
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableCellRenderer;
+
+import com.me3tweaks.modmanager.SelectiveRestoreWindow;
+
+public class SelectiveRestoreTableCellRenderer extends DefaultTableCellRenderer {
+	public static Color badColor = new Color(255, 140, 140);
+	private static Color naColor = Color.gray;
+
+	@Override
+	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+		JLabel c = (JLabel) super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+		if (value == null)
+			return c;
+		setHorizontalAlignment(JLabel.CENTER);
+		switch (column) {
+		case SelectiveRestoreWindow.COL_MODIFIED:
+			if (value.toString().startsWith("MODIFIED")) {
+				c.setBackground(badColor);
+				c.setFont(c.getFont().deriveFont(Font.BOLD));
+				c.setToolTipText("SFAR DLC size does not match known original");
+			} else {
+				c.setBackground(null);
+			}
+			break;
+		case SelectiveRestoreWindow.COL_BACKEDUP:
+			if (value.toString().equalsIgnoreCase("NO")) {
+				c.setFont(c.getFont().deriveFont(Font.BOLD));
+				c.setToolTipText("DLC SFAR is not backed up. You should do so now via the Backup menu.");
+				c.setBackground(badColor);
+			} else {
+				c.setBackground(null);
+			}
+			break;
+		default:
+			c.setBackground(null);
+			c.setToolTipText(null);
+			break;
+		}
+		return this;
+	}
+}

--- a/src/com/me3tweaks/modmanager/utilities/ResourceUtils.java
+++ b/src/com/me3tweaks/modmanager/utilities/ResourceUtils.java
@@ -1,12 +1,29 @@
 package com.me3tweaks.modmanager.utilities;
 
+import java.awt.Desktop;
 import java.io.File;
+import java.io.IOException;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
 
-public class ResourceUtils {
+import com.me3tweaks.modmanager.ModManager;
 
+public class ResourceUtils {
+	/**
+	 * Opens a directory in Windows Explorer.
+	 * 
+	 * @param dir
+	 *            Directory to open
+	 */
+	public static void openDir(String dir) {
+		try {
+			Desktop.getDesktop().open(new File(dir));
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			ModManager.debugLogger.writeErrorWithException("I/O Exception while opening directory " + dir + ".", e);
+		}
+	}
     /**
      * Get the relative path from one file to another, specifying the directory separator. 
      * If one of the provided resources does not exist, it is assumed to be a file unless it ends with '/' or


### PR DESCRIPTION
Changelog 47 => 48:

NEW FEATURES
- Custom DLC Manager in the Restore Menu. Lets you see the names of installed DLC and which mod installed them (if done via Mod Manager). Allows you to also delete them and see their mount flag.
- Custom Restore option in the restore menu. Shows you the state of the game and backups and lets you select what to restore by module.

BUG FIXES/FEATURE ENHANCEMENTS:
- Mount.dlc editor was fixed. 
- Automatic mod updating is not performed if the current BIOGame directory is not valid.
- Variants will show better error messages if a variant fails to apply
- Mod Manager AutoTOC now works on Custom DLC modules.

Mod Manager now uses a custom fork of ME3Explorer at http://github.com/mgamerz/me3explorer. This version removes some features that are not necessary for Mod Manager and contains more automation tools than the main verison has.
