### PR TITLE
Mod Manager 4.1r1: Build 50

### DIFF
--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -477,7 +477,9 @@ public class ModInstallWindow extends JDialog {
 		 */
 		private boolean processDLCJob(ModJob job) {
 			ModManager.debugLogger.writeMessage("===Processing a dlc job: " + job.getJobName() + "===");
-
+			if (job.getJobName().equals("LEVIATHAN")) {
+				System.out.println("BREAK");
+			}
 			File bgdir = new File(ModManager.appendSlash(bioGameDir));
 			String me3dir = ModManager.appendSlash(bgdir.getParent());
 
@@ -569,7 +571,7 @@ public class ModInstallWindow extends JDialog {
 						publish(job.getJobName() + ": Installing " + FilenameUtils.getName(newFile));
 						Path newfilepath = Paths.get(newFile);
 						Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
-						ModManager.debugLogger.writeMessage("Installed mod file: " + newFile);
+						ModManager.debugLogger.writeMessage("Installed mod file: " + originalpath);
 					} catch (IOException e) {
 						ModManager.debugLogger.writeException(e);
 						return false;
@@ -1057,7 +1059,7 @@ public class ModInstallWindow extends JDialog {
 						File bgdir = new File(ModManager.appendSlash(bioGameDir));
 						String me3dir = ModManager.appendSlash(bgdir.getParent());
 						try {
-							bghDB = new BasegameHashDB(null, me3dir, false);
+							bghDB = new BasegameHashDB(null, me3dir, true);
 						} catch (SQLException e) {
 							while (e.getNextException() != null) {
 								ModManager.debugLogger.writeErrorWithException("DB FAILED TO LOAD.", e);

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -61,14 +61,14 @@ import com.sun.jna.platform.win32.WinReg;
 public class ModManager {
 
 	public static final String VERSION = "4.1";
-	public static long BUILD_NUMBER = 49L;
-	public static final String BUILD_DATE = "12/24/2015";
+	public static long BUILD_NUMBER = 50L;
+	public static final String BUILD_DATE = "12/31/2015";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
-	public static final double MODMAKER_VERSION_SUPPORT = 1.9; // max modmaker
-																// version
+	public static final double MODMAKER_VERSION_SUPPORT = 2.0; // max modmaker
+															// version
 	public static final double MODDESC_VERSION_SUPPORT = 4.1; // max supported
 																// cmmver in
 																// moddesc

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -64,7 +64,7 @@ public class ModManager {
 	public static long BUILD_NUMBER = 50L;
 	public static final String BUILD_DATE = "12/31/2015";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = true;
+	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 2.0; // max modmaker

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -64,7 +64,7 @@ public class ModManager {
 	public static long BUILD_NUMBER = 49L;
 	public static final String BUILD_DATE = "12/24/2015";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 1.9; // max modmaker
@@ -1215,25 +1215,11 @@ public class ModManager {
 				sb.append("\"" + arg + "\" ");
 			}
 			sourceDestination.getParentFile().mkdirs();
-			ModManager.debugLogger.writeMessage("Executing ME3EXPLORER Decompressor command (into library): " + sb.toString());
+
 
 			ProcessBuilder decompressProcessBuilder = new ProcessBuilder(commandBuilder);
-			// patchProcessBuilder.redirectErrorStream(true);
-			// patchProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-			Process decompressProcess;
-			try {
-				decompressProcess = decompressProcessBuilder.start();
-				BufferedReader reader = new BufferedReader(new InputStreamReader(decompressProcess.getInputStream()));
-				String line;
-				while ((line = reader.readLine()) != null)
-					System.out.println(line);
-				int result = decompressProcess.waitFor();
-				ModManager.debugLogger.writeMessage("ME3Explorer process finished, return code: " + result);
-			} catch (IOException e) {
-				ModManager.debugLogger.writeException(e);
-			} catch (InterruptedException e) {
-				ModManager.debugLogger.writeException(e);
-			}
+			ProcessResult result = ModManager.runProcess(decompressProcessBuilder);
+			ModManager.debugLogger.writeMessage("File decompressed to location, and ready? : " + sourceDestination.exists());
 			return sourceDestination.getAbsolutePath();
 			// END OF
 			// BASEGAME======================================================
@@ -1666,6 +1652,7 @@ public class ModManager {
 	 */
 	public static ProcessResult runProcess(ProcessBuilder p) {
 		try {
+			ModManager.debugLogger.writeMessage("runProcess(): "+p.command());
 			long startTime = System.currentTimeMillis();
 			Process process = p.start();
 			int returncode = process.waitFor();

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -375,6 +375,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					publish("Downloading latest help information");
 					HelpMenu.getOnlineHelp();
 					publish("UPDATE_HELP_MENU");
+					publish("Updated help files from server");
 					if (modModel.getSize() > 0) {
 						publish("Checking for updates to mods");
 						checkAllModsForUpdates(false);

--- a/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
@@ -305,7 +305,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 			} else {
 				description += "---------------------------------\n";
 			}
-			description += patch.getPatchName();
+			description += patch.getPatchName() +" v"+patch.getPatchVersion();
 			description += "\n\n";
 			description += patch.getPatchDescription();
 			description += "\n\n";

--- a/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
@@ -78,18 +78,23 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 	 * checked for being in the local library. If they aren't in the library, it
 	 * attempts to download them from me3tweaks.com's library.
 	 * 
-	 * @param mixinIds me3tweaks patch ids
+	 * @param requiredMixinIds me3tweaks patch ids
 	 */
-	public PatchLibraryWindow(JDialog callingDialog, ArrayList<Integer> mixinIds, Mod mod) {
+	public PatchLibraryWindow(JDialog callingDialog, ArrayList<String> requiredMixinIds, Mod mod) {
 		setModalityType(ModalityType.APPLICATION_MODAL);
-		this.automated_requiredMixinIds = mixinIds;
-		this.automated_mod = mod;
+		ArrayList<ModmakerMixinIdentifier> modmakerIds = new ArrayList<ModmakerMixinIdentifier>();
+		ArrayList<Integer> requiredIds = new ArrayList<Integer>();
+
+		for (String requiredID : requiredMixinIds) {
+			modmakerIds.add(new ModmakerMixinIdentifier(requiredID));
+		}
+		
 		ModManager.debugLogger.writeMessage("Loading mixin library in automated mode");
 		boolean hasMissingMixIn = false;
-		for (int requiredID : mixinIds) {
+		for (ModmakerMixinIdentifier modmakermixin : modmakerIds) {
 			boolean foundId = false;
 			for (Patch patch : ModManagerWindow.ACTIVE_WINDOW.getPatchList()) {
-				if (patch.getMe3tweaksid() == requiredID) {
+				if (patch.getMe3tweaksid() == modmakermixin.mixinid && patch.getPatchVersion() >= modmakermixin.minVersion) {
 					foundId = true;
 					break;
 				}
@@ -99,6 +104,11 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 				break;
 			}
 		}
+		for (ModmakerMixinIdentifier mixin : modmakerIds) {
+			requiredIds.add(new Integer(mixin.mixinid));
+		}
+		this.automated_requiredMixinIds = requiredIds;
+		this.automated_mod = mod;
 
 		if (hasMissingMixIn) {
 			new ME3TweaksLibraryUpdater(ModManagerWindow.ACTIVE_WINDOW.getPatchList(), true).execute();
@@ -514,6 +524,40 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 			}
 		}
 
+	}
+	
+	private class ModmakerMixinIdentifier {
+		public int getMinVersion() {
+			return minVersion;
+		}
+
+		public void setMinVersion(int minVersion) {
+			this.minVersion = minVersion;
+		}
+
+		public int getMixinid() {
+			return mixinid;
+		}
+
+		public void setMixinid(int mixinid) {
+			this.mixinid = mixinid;
+		}
+
+		private int minVersion;
+		private int mixinid;
+
+		public ModmakerMixinIdentifier(String modmakerString) {
+			if (modmakerString.contains("v")){
+				int endIDIndex = modmakerString.indexOf('v');
+				String id = modmakerString.substring(0, endIDIndex);
+				String version = modmakerString.substring(endIDIndex+1, modmakerString.length());
+				this.mixinid = Integer.parseInt(id);
+				this.minVersion = Integer.parseInt(version);
+			} else {
+				this.mixinid = Integer.parseInt(modmakerString);
+				this.minVersion = 1;
+			}
+		}
 	}
 
 }

--- a/src/com/me3tweaks/modmanager/help/HelpMenu.java
+++ b/src/com/me3tweaks/modmanager/help/HelpMenu.java
@@ -72,9 +72,12 @@ public class HelpMenu {
 			HttpResponse response = httpClient.execute(new HttpGet(uri));
 			responseString = new BasicResponseHandler().handleResponse(response);
 			FileUtils.writeStringToFile(ModManager.getHelpFile(), responseString);
+			ModManager.debugLogger.writeMessage("File written to disk. Exists on filesystem, ready for loading: " + ModManager.getHelpFile().exists());
 			//Parse, download resources
 			DocumentBuilder db;
 			try {
+				helpItemExpr = xpath.compile("helpitem");
+				sublistExpr = xpath.compile("list");
 				db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 				InputSource is = new InputSource();
 				is.setCharacterStream(new FileReader(ModManager.getHelpFile()));

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -83,7 +83,7 @@ public class ModMakerCompilerWindow extends JDialog {
 	JLabel infoLabel, currentOperationLabel;
 	JProgressBar overallProgress, currentStepProgress;
 	private Mod mod;
-	private ArrayList<Integer> requiredMixinIds = new ArrayList<Integer>();
+	private ArrayList<String> requiredMixinIds = new ArrayList<String>();
 
 	/**
 	 * Starts a modmaker session for a user-selected download
@@ -280,7 +280,7 @@ public class ModMakerCompilerWindow extends JDialog {
 				for (int j = 0; j < mixinsNodeList.getLength(); j++) {
 					Node mixinNode = mixinsNodeList.item(j);
 					if (mixinNode.getNodeType() == Node.ELEMENT_NODE) {
-						requiredMixinIds.add(Integer.parseInt(mixinNode.getTextContent()));
+						requiredMixinIds.add(mixinNode.getTextContent());
 						ModManager.debugLogger.writeMessage("Mod recommends mixin with id "+mixinNode.getTextContent());
 					}
 				}
@@ -1456,7 +1456,7 @@ public class ModMakerCompilerWindow extends JDialog {
 			}
 			ModManager.debugLogger.writeMessage("Creating in-memory moddesc.ini");
 			ini = new Wini(moddesc);
-			ini.put("ModManager", "cmmver", 3.0);
+			ini.put("ModManager", "cmmver", 4.1);
 			ini.put("ModInfo", "modname", modName);
 			ini.put("ModInfo", "moddev", modDev);
 			ini.put("ModInfo", "moddesc", modDescription + "<br>Created with ME3Tweaks ModMaker.");

--- a/src/com/me3tweaks/modmanager/objects/Patch.java
+++ b/src/com/me3tweaks/modmanager/objects/Patch.java
@@ -341,26 +341,21 @@ public class Patch implements Comparable<Patch> {
 			}
 
 			ModManager.debugLogger.writeMessage("Executing JPATCH patch command: " + sb.toString());
-
 			ProcessBuilder patchProcessBuilder = new ProcessBuilder(commandBuilder);
-			//patchProcessBuilder.redirectErrorStream(true);
-			//patchProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-			Process patchProcess = patchProcessBuilder.start();
-			BufferedReader reader = new BufferedReader(new InputStreamReader(patchProcess.getInputStream()));
-			String line;
-			while ((line = reader.readLine()) != null)
-				System.out.println("tasklist: " + line);
-			patchProcess.waitFor();
-			System.out.println("BREAK");
+			ProcessResult result = ModManager.runProcess(patchProcessBuilder);
+			if (result.hadError()) {
+				ModManager.debugLogger.writeMessage("Error occured while attempting to apply patch.");
+				return APPLY_FAILED_OTHERERROR;
+			}
+			if (result.getReturnCode() != 0) {
+				return APPLY_FAILED_OTHERERROR;
+			}
 			stagingFile.delete();
 			ModManager.debugLogger.writeMessage("File has been patched.");
 			return APPLY_SUCCESS;
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			ModManager.debugLogger.writeErrorWithException("IOException applying mod:", e);
-			return APPLY_FAILED_OTHERERROR;
-		} catch (InterruptedException e) {
-			ModManager.debugLogger.writeErrorWithException("Patching process was interrupted:", e);
 			return APPLY_FAILED_OTHERERROR;
 		}
 	}

--- a/src/com/me3tweaks/modmanager/objects/ProcessResult.java
+++ b/src/com/me3tweaks/modmanager/objects/ProcessResult.java
@@ -4,10 +4,18 @@ public class ProcessResult {
 	private int returnCode;
 	private Exception error;
 
+	/**
+	 * Gets the return code of the process.
+	 * @return return code from process
+	 */
 	public int getReturnCode() {
 		return returnCode;
 	}
 
+	/**
+	 * Returns if the process had an exception.
+	 * @return true if error is not null, otherwise false
+	 */
 	public boolean hadError() {
 		return error != null;
 	}
@@ -18,6 +26,10 @@ public class ProcessResult {
 		this.error = e;
 	}
 
+	/**
+	 * Returns the throwable that was thrown during running the process
+	 * @return Throwable error, otherwise false if no error.
+	 */
 	public Throwable getError() {
 		return error;
 	}


### PR DESCRIPTION
Mod Manager 4.1r1 Build 50 Changelog

Mod Manager 4.1r0 => Mod Manager 4.1r1
**New Features**
- Supports ModMaker 2.0 spec

**Bug Fixes**
- Help menu fails to load on first mod manager launch and may corrupt future help menus from loading. This has been fixed

**Content Updates**
- More verbose logging for mixins
- Mixin applier now uses mod manager's standard process launching interface, rather than its old custom code for every process launch. This should reduce chances of bugs in the future due to using shared code instead of individually written
