### PR TITLE
Mod Manager 4.2.3: Build 56 r6

### DIFF
--- a/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
@@ -43,6 +43,7 @@ import com.me3tweaks.modmanager.objects.MountFile;
 import com.me3tweaks.modmanager.objects.MountFlag;
 import com.me3tweaks.modmanager.objects.ProcessResult;
 import com.me3tweaks.modmanager.objects.ThreadCommand;
+import com.me3tweaks.modmanager.utilities.ResourceUtils;
 
 /**
  * Shows conflicts between custom dlc mods.
@@ -343,9 +344,9 @@ public class CustomDLCConflictWindow extends JDialog {
 				commandBuilder.add(transplanterpath);
 				commandBuilder.add("--injectswf");
 				commandBuilder.add("--inputfolder");
-				commandBuilder.add(guilibrarypath);
+				commandBuilder.add(ResourceUtils.normalizeFilePath(guilibrarypath,true));
 				commandBuilder.add("--targetfile");
-				commandBuilder.add(transplantFile);
+				commandBuilder.add(ResourceUtils.normalizeFilePath(transplantFile,true));
 				String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
 				ModManager.debugLogger.writeMessage("Injecting SWFs into " + transplantFile);
 				int returncode = 1;

--- a/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
@@ -250,8 +250,8 @@ public class CustomDLCConflictWindow extends JDialog {
 
 		@Override
 		protected Boolean doInBackground() throws Exception {
-			String guilibrarypath = ModManager.getGUILibraryFor(conflictingGUIMod);
-			String transplanterpath = ModManager.getGUITransplanterCLI();
+			String guilibrarypath = ModManager.getGUILibraryFor(conflictingGUIMod,true);
+			String transplanterpath = ModManager.getGUITransplanterCLI(true);
 			if (guilibrarypath == null) {
 				publish(new ThreadCommand("MISSING_GUI_LIBRARY"));
 				return false;

--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -966,8 +966,15 @@ public class ModInstallWindow extends JDialog {
 		 */
 		private boolean processCustomDLCJob(ModJob job) {
 			ModManager.debugLogger.writeMessage("===Processing a customdlc job===");
-
+			ArrayList<String> destfolders = job.getDestFolders();
 			File dlcdir = new File(ModManager.appendSlash(bioGameDir) + "DLC" + File.separator);
+			for (String folder : destfolders) {
+				File dlcFolder = new File(dlcdir + File.separator + folder);
+				if (dlcFolder.exists() && dlcFolder.isDirectory()) {
+					ModManager.debugLogger.writeMessage("Deleting existing CustomDLC folder: "+dlcFolder);
+					FileUtils.deleteQuietly(dlcFolder);
+				}
+			}
 			taskSteps = job.getFilesToReplaceTargets().size();
 			completedTaskSteps = 0;
 			ModManager.debugLogger.writeMessage("Number of files to install: " + taskSteps);

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -970,7 +970,7 @@ public class ModManager {
 	}
 
 	private static boolean downloadGUITransplanter() {
-		String url = "http://me3tweaks.com/modmanager/toolsx/GUITRANSPLANTER.7z";
+		String url = "http://me3tweaks.com/modmanager/tools/GUITRANSPLANTER.7z";
 		ModManager.debugLogger.writeMessage("Downloading GUI Transplanter: " + url);
 		try {
 			File updateDir = new File(ModManager.getTempDir());
@@ -1777,6 +1777,7 @@ public class ModManager {
 				public void run() {
 					try {
 						IOUtils.copy(process.getInputStream(), writer);
+						IOUtils.copy(process.getErrorStream(), writer);
 					} catch (IOException e) {
 						// TODO Auto-generated catch block
 						e.printStackTrace();
@@ -1786,6 +1787,8 @@ public class ModManager {
 			int returncode = process.waitFor();
 			long endTime = System.currentTimeMillis();
 			ModManager.debugLogger.writeMessage("Process finished with code " + returncode + ", took " + (endTime - startTime) + " ms.");
+			ModManager.debugLogger.writeMessage("Process output: "+writer.toString());
+			writer.close();
 			return new ProcessResult(returncode, null);
 		} catch (IOException | InterruptedException e) {
 			ModManager.debugLogger.writeErrorWithException("Process exception occured:", e);
@@ -1948,7 +1951,7 @@ public class ModManager {
 
 			//construct lists of what custom dlc each file appears in
 			for (CustomDLC custDLC : customDLCs) {
-				String dlcFolder = ResourceUtils.normalizeFilePath(dlcdirectory + custDLC.getDlcName() + File.separator);
+				String dlcFolder = ResourceUtils.normalizeFilePath(dlcdirectory + custDLC.getDlcName() + File.separator, true);
 				Collection<File> files = FileUtils.listFiles(new File(dlcFolder), new RegexFileFilter("^(.*?)"), DirectoryFileFilter.DIRECTORY);
 				for (File file : files) {
 					if (!FilenameUtils.getExtension(file.getAbsolutePath()).equals("pcc")) {
@@ -2046,7 +2049,7 @@ public class ModManager {
 	 * @return true if extraction is OK, false if something went wrong
 	 */
 	private static boolean downloadGUILibrary(String dlcname) {
-		String url = "http://me3tweaks.com/modmanager/tools/uilibraryx/" + dlcname.toUpperCase() + ".7z";
+		String url = "http://me3tweaks.com/modmanager/tools/uilibrary/" + dlcname.toUpperCase() + ".7z";
 		ModManager.debugLogger.writeMessage("Downloading GUI library: " + url);
 		try {
 			File updateDir = new File(ModManager.getTempDir());

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -90,6 +90,7 @@ public class ModManager {
 	public static final int MIN_REQUIRED_ME3EXPLORER_MAIN = 2;
 	public static final int MIN_REQUIRED_ME3EXPLORER_MINOR = 0;
 	public final static int MIN_REQUIRED_ME3EXPLORER_REV = 3;
+	public static final int MIN_REQUIRED_ME3GUITRANSPLANTER_BUILD = 6; //1.0.0.X
 	private final static int MIN_REQUIRED_NET_FRAMEWORK_RELNUM = 378389; //4.5.0
 	public static boolean USE_GAME_TOCFILES_INSTEAD = false;
 	public static ArrayList<Image> ICONS;
@@ -955,14 +956,14 @@ public class ModManager {
 		return getToolsDir() + "GUITransplanter/";
 	}
 
-	public static String getGUITransplanterCLI() {
+	public static String getGUITransplanterCLI(boolean download) {
 		File transplanterexe = new File(getGUITransplanterDir() + "Transplanter-CLI.exe");
-		if (!transplanterexe.exists()) {
+		if (!transplanterexe.exists() && download) {
 			if (!downloadGUITransplanter()) {
 				return null;
 			}
 		}
-		if (!transplanterexe.exists()) {
+		if (!transplanterexe.exists() && download) {
 			//still hasn't downloaded...
 			return null;
 		}
@@ -2016,7 +2017,14 @@ public class ModManager {
 		return foldernames;
 	}
 
-	public static String getGUILibraryFor(String dlcname) {
+	
+	/**
+	 * Gets the path to the GUI library specified by the DLC name
+	 * @param dlcname DLC to get library for
+	 * @param download Download library if library not found. If set to false, this will return the library path, if true it will return null if the library can't be downloaded.
+	 * @return library path or null if download is true and library can't be downloaded
+	 */
+	public static String getGUILibraryFor(String dlcname, boolean download) {
 		String libraryPath = getUILibraryPath();
 		switch (dlcname) {
 		case "DLC_CON_XBX":
@@ -2031,10 +2039,10 @@ public class ModManager {
 		}
 
 		File libraryFolder = new File(libraryPath);
-		if (!libraryFolder.exists() || !libraryFolder.isDirectory()) {
+		if (!libraryFolder.exists() && download || !libraryFolder.isDirectory() && download) {
 			downloadGUILibrary(dlcname);
 		}
-		if (!libraryFolder.exists()) {
+		if (!libraryFolder.exists() && download) {
 			return null;
 		}
 		return libraryPath;

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -25,9 +25,7 @@ import java.nio.file.StandardCopyOption;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.swing.BorderFactory;
 import javax.swing.DefaultListModel;
@@ -57,6 +55,8 @@ import javax.swing.border.TitledBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
+import net.iharder.dnd.FileDrop;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -81,6 +81,7 @@ import com.me3tweaks.modmanager.objects.ModJob;
 import com.me3tweaks.modmanager.objects.ModList;
 import com.me3tweaks.modmanager.objects.Patch;
 import com.me3tweaks.modmanager.objects.RestoreMode;
+import com.me3tweaks.modmanager.objects.ThreadCommand;
 import com.me3tweaks.modmanager.repairdb.BasegameHashDB;
 import com.me3tweaks.modmanager.utilities.EXEFileInfo;
 import com.me3tweaks.modmanager.utilities.MD5Checksum;
@@ -93,8 +94,6 @@ import com.me3tweaks.modmanager.valueparsers.powercustomaction.PowerCustomAction
 import com.me3tweaks.modmanager.valueparsers.wavelist.WavelistGUI;
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.WinReg;
-
-import net.iharder.dnd.FileDrop;
 
 /**
  * Controls the main window for Mass Effect 3 Mod Manager.
@@ -114,17 +113,19 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	JMenuBar menuBar;
 	JMenu actionMenu, modMenu, modManagementMenu, devMenu, modDeltaMenu, toolsMenu, backupMenu, restoreMenu, sqlMenu, helpMenu, openToolMenu;
 	JMenuItem actionExitDebugMode, actionModMaker, actionVisitMe, actionOptions, actionReload, actionExit;
-	JMenuItem modManagementImportFromArchive, modManagementImportAlreadyInstalled, modManagementConflictDetector, modManagementModMaker, modManagementFailedMods,
-			modManagementPatchLibary;
-	JMenuItem modutilsHeader, modutilsInfoEditor, modNoDeltas, modutilsVerifyDeltas, modutilsInstallCustomKeybinds, modutilsAutoTOC, modutilsCheckforupdate, modutilsRestoreMod,
-			modutilsDeleteMod;
-	JMenuItem toolME3Explorer, toolsOpenME3Dir, toolsInstallLauncherWV, toolsInstallBinkw32, toolsUninstallBinkw32, toolsMountdlcEditor, toolsMergeMod, toolME3Config;
+	JMenuItem modManagementImportFromArchive, modManagementImportAlreadyInstalled, modManagementConflictDetector, modManagementModMaker,
+			modManagementFailedMods, modManagementPatchLibary;
+	JMenuItem modutilsHeader, modutilsInfoEditor, modNoDeltas, modutilsVerifyDeltas, modutilsInstallCustomKeybinds, modutilsAutoTOC,
+			modutilsCheckforupdate, modutilsRestoreMod, modutilsDeleteMod;
+	JMenuItem toolME3Explorer, toolsOpenME3Dir, toolsInstallLauncherWV, toolsInstallBinkw32, toolsUninstallBinkw32, toolsMountdlcEditor,
+			toolsMergeMod, toolME3Config;
 	JMenuItem backupBackupDLC, backupCreateGDB;
-	JMenuItem restoreSelective, restoreRevertEverything, restoreDeleteUnpacked, restoreRevertBasegame, restoreRevertAllDLC, restoreRevertSPDLC, restoreRevertMPDLC,
-			restoreRevertMPBaseDLC, restoreRevertSPBaseDLC, restoreRevertCoal, restoreVanillifyDLC;
+	JMenuItem restoreSelective, restoreRevertEverything, restoreDeleteUnpacked, restoreRevertBasegame, restoreRevertAllDLC, restoreRevertSPDLC,
+			restoreRevertMPDLC, restoreRevertMPBaseDLC, restoreRevertSPBaseDLC, restoreRevertCoal, restoreVanillifyDLC;
 
 	JMenuItem modDevStarterKit;
-	JMenuItem sqlWavelistParser, sqlDifficultyParser, sqlAIWeaponParser, sqlPowerCustomActionParser, sqlPowerCustomActionParser2, sqlConsumableParser, sqlGearParser;
+	JMenuItem sqlWavelistParser, sqlDifficultyParser, sqlAIWeaponParser, sqlPowerCustomActionParser, sqlPowerCustomActionParser2,
+			sqlConsumableParser, sqlGearParser;
 	JList<Mod> modList;
 	JProgressBar progressBar;
 	ListSelectionModel listSelectionModel;
@@ -176,11 +177,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} catch (Exception e) {
 			ModManager.debugLogger.writeErrorWithException("UNKNOWN CRITICAL STARTUP EXCEPTION FOR MOD MANAGER WINDOW:", e);
 			ModManager.debugLogger.writeError("Mod Manager has crashed!");
-			JOptionPane.showMessageDialog(null,
-					"<html><div style=\"width:330px;\">Mod Manager's interface (post-startup) encountered a critical unknown error and was unable to start:<br>" + e.getMessage()
-							+ "<br>"
-							+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>Please report this to femshep.</div></html>",
-					"Critical Error", JOptionPane.ERROR_MESSAGE);
+			JOptionPane
+					.showMessageDialog(
+							null,
+							"<html><div style=\"width:330px;\">Mod Manager's interface (post-startup) encountered a critical unknown error and was unable to start:<br>"
+									+ e.getMessage()
+									+ "<br>"
+									+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>Please report this to femshep.</div></html>",
+							"Critical Error", JOptionPane.ERROR_MESSAGE);
 			return;
 		}
 		validateBIOGameDir();
@@ -193,10 +197,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} catch (Exception e) {
 				ModManager.debugLogger.writeErrorWithException("Uncaught runtime exception:", e);
 				ModManager.debugLogger.writeError("Mod Manager hit exception!");
-				JOptionPane.showMessageDialog(null,
-						"<html><div style=\"width:330px;\">Mod Manager's interface has just encountered an error<br>" + e.getMessage() + "<br>"
-								+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>The application will attempt to ignore this error.</div></html>",
-						"Mod Manager Error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"<html><div style=\"width:330px;\">Mod Manager's interface has just encountered an error<br>"
+										+ e.getMessage()
+										+ "<br>"
+										+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>The application will attempt to ignore this error.</div></html>",
+								"Mod Manager Error", JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}
@@ -235,8 +243,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		this.pack();
 		setLocationRelativeTo(null);
 		if (isUpdate) {
-			JOptionPane.showMessageDialog(this, "Update successful: Updated to Mod Manager " + ModManager.VERSION + " (Build " + ModManager.BUILD_NUMBER + ").", "Update Complete",
-					JOptionPane.INFORMATION_MESSAGE);
+			JOptionPane.showMessageDialog(this, "Update successful: Updated to Mod Manager " + ModManager.VERSION + " (Build "
+					+ ModManager.BUILD_NUMBER + ").", "Update Complete", JOptionPane.INFORMATION_MESSAGE);
 		}
 
 		//clear pending updates (done via sideload update)
@@ -261,25 +269,25 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	 * @author Michael
 	 *
 	 */
-	class NetworkThread extends SwingWorker<Void, Object> {
+	class NetworkThread extends SwingWorker<Void, ThreadCommand> {
 
 		@Override
 		public Void doInBackground() {
 			File f7za = new File(ModManager.getToolsDir() + "7za.exe");
 			if (!f7za.exists()) {
-				publish("Downloading 7za Unzipper");
+				publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading 7za Unzipper"));
 				ModManager.debugLogger.writeMessage("7za.exe does not exist at the following path, downloading new copy: " + f7za.getAbsolutePath());
 				String url = "http://me3tweaks.com/modmanager/tools/7za.exe";
 				try {
 					File updateDir = new File(ModManager.getToolsDir());
 					updateDir.mkdirs();
 					FileUtils.copyURLToFile(new URL(url), new File(ModManager.getToolsDir() + "7za.exe"));
-					publish("Downloaded 7za Unzipper into tools directory");
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloaded 7za Unzipper into tools directory"));
 					ModManager.debugLogger.writeMessage("Downloaded missing 7za.exe file for updating Mod Manager");
 
 				} catch (IOException e) {
 					ModManager.debugLogger.writeErrorWithException("Error downloading 7za into tools folder", e);
-					publish("Error downloading 7za");
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Error downloading 7za"));
 				}
 			} else {
 				ModManager.debugLogger.writeMessage("7za.exe is present in tools/ directory");
@@ -287,19 +295,19 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 			File lzma = new File(ModManager.getToolsDir() + "lzma.exe");
 			if (!lzma.exists()) {
-				publish("Downloading LZMA tool");
+				publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading LZMA tool"));
 				ModManager.debugLogger.writeMessage("lzma.exe does not exist at the following path, downloading new copy: " + lzma.getAbsolutePath());
 				String url = "http://me3tweaks.com/modmanager/tools/lzma.exe";
 				try {
 					File updateDir = new File(ModManager.getToolsDir());
 					updateDir.mkdirs();
 					FileUtils.copyURLToFile(new URL(url), new File(ModManager.getToolsDir() + "lzma.exe"));
-					publish("Downloaded lzma.exe into tools directory");
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloaded lzma.exe into tools directory"));
 					ModManager.debugLogger.writeMessage("Downloaded missing lzma.exe file for preparing mod updates");
 
 				} catch (IOException e) {
 					ModManager.debugLogger.writeErrorWithException("Error downloading lzma into tools folder", e);
-					publish("Error downloading lzma");
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Error downloading lzma"));
 				}
 			} else {
 				ModManager.debugLogger.writeMessage("lzma.exe is present in tools/ directory");
@@ -310,7 +318,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			File tmtlk = new File(ModManager.getTankMasterTLKDir() + "MassEffect3.TlkEditor.exe");
 
 			if (!tmtlk.exists() || !tmc.exists()) {
-				publish("Downloading Tankmaster Tools");
+				publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading Tankmaster Tools"));
 				ModManager.debugLogger.writeMessage("Tankmaster's TLK/COALESCE tools are missing, downloading new copy: " + tmtlk.getAbsolutePath());
 				String url = "http://me3tweaks.com/modmanager/tools/tankmastertools.7z";
 				try {
@@ -351,14 +359,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 					ModManager.debugLogger.writeMessage("Unzip completed successfully (code 0): " + (p != null && returncode == 0));
 					if (returncode == 0) {
-						publish("Downloaded Tankmaster Tools into data directory");
+						publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloaded Tankmaster Tools into data directory"));
 					} else {
-						publish("Unknown error downloading Tankmaster tools");
+						publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Unknown error downloading Tankmaster tools"));
 					}
 					FileUtils.deleteQuietly(new File(ModManager.getTempDir() + "tankmastertools.7z"));
 				} catch (IOException e) {
 					ModManager.debugLogger.writeErrorWithException("Error downloading 7za into tools folder", e);
-					publish("Error downloading 7za for updating");
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Error downloading 7za for updating"));
 				}
 			} else {
 				ModManager.debugLogger.writeMessage("7za.exe is present in tools/ directory");
@@ -373,7 +381,221 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			return null;
 		}
-		
+
+		private void checkForME3ExplorerUpdates() {
+			String me3explorer = ModManager.getME3ExplorerEXEDirectory(false) + "ME3Explorer.exe";
+			File f = new File(me3explorer);
+			if (!f.exists()) {
+				ModManager.debugLogger.writeMessage("ME3Explorer is missing. Downloading from ME3TWeaks.");
+				if (ModManager.AUTO_UPDATE_ME3EXPLORER) {
+					new ME3ExplorerUpdaterWindow(ModManagerWindow.this);
+				} else {
+					ModManager.debugLogger.writeError("ME3Explorer missing but cannot download due to settings!");
+					JOptionPane
+							.showMessageDialog(
+									ModManagerWindow.this,
+									"ME3Explorer is missing from data/ME3Explorer.\nMod Manager requires ME3Explorer but you have auto updates for it turned off.\nIf there are errors in this session, they are not supported by FemShep.",
+									"Missing ME3Explorer", JOptionPane.ERROR_MESSAGE);
+				}
+			} else {
+				int main = EXEFileInfo.getMajorVersionOfProgram(me3explorer);
+				int rev = EXEFileInfo.getBuildOfProgram(me3explorer);
+				ModManager.debugLogger.writeMessage("ME3Explorer Version: " + Arrays.toString(EXEFileInfo.getVersionInfo(me3explorer)));
+				if (main < ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN || main == ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN
+						&& rev < ModManager.MIN_REQUIRED_ME3EXPLORER_REV) {
+					//we must update it
+					ModManager.debugLogger.writeMessage("ME3Explorer is outdated, local:" + main + "." + rev + ", required"
+							+ ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN + "." + ModManager.MIN_REQUIRED_ME3EXPLORER_REV + "+");
+					if (ModManager.AUTO_UPDATE_ME3EXPLORER) {
+						new ME3ExplorerUpdaterWindow(ModManagerWindow.this);
+					} else {
+						ModManager.debugLogger.writeError("ME3Explorer outdated but cannot download due to settings!");
+						JOptionPane
+								.showMessageDialog(
+										ModManagerWindow.this,
+										"Mod Manager requires a newer version of ME3Explorer for this build.\nYou have auto updates for it turned off. You will need to turn them back on to download this update.\nIf there are errors in this session, they are not supported by FemShep.",
+										"ME3Explorer Outdated", JOptionPane.ERROR_MESSAGE);
+					}
+				} else {
+					ModManager.debugLogger.writeMessage("Current ME3Explorer version satisfies requirements for Mod Manager");
+				}
+			}
+		}
+
+		private void checkForModUpdates() {
+			//Check for updates
+			if (ModManager.AUTO_UPDATE_MODS || forceUpdateOnReloadList.size() > 0) {
+				if (System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK > ModManager.AUTO_CHECK_INTERVAL_MS
+						|| forceUpdateOnReloadList.size() > 0) {
+					ModManager.debugLogger.writeMessage("Running auto-updater, it has been "
+							+ ModManager.getDurationBreakdown(System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK)
+							+ " since the last help/mods update check.");
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading latest help information"));
+					HelpMenu.getOnlineHelp();
+					publish(new ThreadCommand("UPDATE_HELP_MENU"));
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated help files from server"));
+					if (modModel.getSize() > 0) {
+						publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Checking for updates to mods"));
+						checkAllModsForUpdates(false);
+					}
+				}
+			}
+		}
+
+		@Override
+		protected void process(List<ThreadCommand> chunks) {
+			for (ThreadCommand latest : chunks) {
+				switch (latest.getCommand()) {
+				case "UPDATE_HELP_MENU":
+					menuBar.remove(helpMenu);
+					menuBar.add(HelpMenu.constructHelpMenu());
+					break;
+				case "SHOW_UPDATE_WINDOW":
+					new UpdateAvailableWindow((JSONObject) latest.getData(), ModManagerWindow.this);
+					break;
+				case "SET_STATUSBAR_TEXT":
+					labelStatus.setText(latest.getMessage());
+					break;
+				}
+
+			}
+		}
+
+		@Override
+		protected void done() {
+			forceUpdateOnReloadList.clear(); //remove pending updates
+			try {
+				get();
+			} catch (Exception e) {
+				ModManager.debugLogger.writeErrorWithException("Exception in the network thread: ", e);
+			}
+		}
+
+		private Void checkForUpdates() {
+			labelStatus.setText("Checking for Mod Manager updates");
+			ModManager.debugLogger.writeMessage("Checking for update...");
+			// Check for update
+			try {
+				String update_check_link;
+				if (ModManager.IS_DEBUG) {
+					update_check_link = "http://webdev-c9-mgamerz.c9.io/modmanager/updatecheck?currentversion=" + ModManager.BUILD_NUMBER;
+				} else {
+					update_check_link = "https://me3tweaks.com/modmanager/updatecheck-testing?currentversion=" + ModManager.BUILD_NUMBER;
+				}
+				String serverJSON = null;
+				try {
+					serverJSON = IOUtils.toString(new URL(update_check_link), StandardCharsets.UTF_8);
+					System.out.println(update_check_link);
+				} catch (Exception e) {
+					ModManager.debugLogger.writeError("Error checking for updates:");
+					ModManager.debugLogger.writeException(e);
+					labelStatus.setText("Error checking for update (check logs)");
+					ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
+					return null;
+				}
+				if (serverJSON == null) {
+					ModManager.debugLogger.writeError("No response from server");
+					labelStatus.setText("Updater: No response from server");
+					ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
+					return null;
+				}
+
+				JSONParser parser = new JSONParser();
+				JSONObject latest_object = (JSONObject) parser.parse(serverJSON);
+				String buildHash = (String) latest_object.get("build_md5");
+				boolean hashMismatch = false;
+				if (new File("ME3CMM.exe").exists()) {
+					try {
+						String currentHash = MD5Checksum.getMD5Checksum("ME3CMM.exe");
+						if (buildHash != null && !buildHash.equals("") && !currentHash.equals(buildHash)) {
+							//hash mismatch
+							hashMismatch = true;
+							ModManager.debugLogger.writeMessage("Local hash (" + currentHash + ") does not match server hash (" + buildHash + ")");
+						} else {
+							ModManager.debugLogger.writeMessage("Local hash matches server hash: " + buildHash);
+						}
+					} catch (Exception e1) {
+						ModManager.debugLogger.writeErrorWithException("Unable to hash ME3CMM.exe:", e1);
+					}
+				} else {
+					ModManager.debugLogger.writeMessage("Skipping hash check for updates. Likely running in IDE or some other wizardry");
+				}
+
+				long latest_build = (long) latest_object.get("latest_build_number");
+				if (latest_build < ModManager.BUILD_NUMBER) {
+					//build is newer than current
+					labelStatus.setVisible(true);
+					ModManager.debugLogger.writeMessage("No updates, at latest version. (or could not contact update server.)");
+					labelStatus.setText("No Mod Manager updates available");
+					ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
+					checkForGUIupdates(latest_object);
+					return null;
+				}
+
+				if (latest_build == ModManager.BUILD_NUMBER && !hashMismatch) {
+					//build is same as server version
+					labelStatus.setVisible(true);
+					ModManager.debugLogger.writeMessage("No updates, at latest version.");
+					labelStatus.setText("Mod Manager is up to date");
+					ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
+					checkForGUIupdates(latest_object);
+					return null;
+				}
+
+				ModManager.debugLogger.writeMessage("Update check: Local:" + ModManager.BUILD_NUMBER + " Latest: " + latest_build + ", is less? "
+						+ (ModManager.BUILD_NUMBER < latest_build));
+
+				boolean showUpdate = true;
+				// make sure the user hasn't declined this one.
+				Wini settingsini;
+				try {
+					settingsini = new Wini(new File(ModManager.SETTINGS_FILENAME));
+					String showIfHigherThan = settingsini.get("Settings", "nextupdatedialogbuild");
+					long build_check = ModManager.BUILD_NUMBER;
+					if (showIfHigherThan != null && !showIfHigherThan.equals("")) {
+						try {
+							build_check = Integer.parseInt(showIfHigherThan);
+							if (latest_build > build_check) {
+								// update is newer than one stored in ini, show the
+								// dialog.
+								ModManager.debugLogger.writeMessage("Advertising build " + latest_build);
+								showUpdate = true;
+							} else {
+								ModManager.debugLogger.writeMessage("User isn't seeing updates until build " + build_check);
+								// don't show it.
+								showUpdate = false;
+							}
+						} catch (NumberFormatException e) {
+							ModManager.debugLogger
+									.writeMessage("Number format exception reading the build number updateon in the ini. Showing the dialog.");
+						}
+					}
+				} catch (InvalidFileFormatException e) {
+					ModManager.debugLogger.writeErrorWithException("Invalid INI! Did the user modify it by hand?", e);
+					e.printStackTrace();
+				} catch (IOException e) {
+					ModManager.debugLogger
+							.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting stored to disk.");
+				}
+
+				if (showUpdate) {
+					// An update is available!
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Mod Manager update available"));
+					publish(new ThreadCommand("SHOW_UPDATE_WINDOW", null, latest_object));
+					ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
+				} else {
+					labelStatus.setVisible(true);
+					labelStatus.setText("No updates available");
+				}
+				checkForGUIupdates(latest_object);
+			} catch (ParseException e) {
+				// TODO Auto-generated catch block
+				ModManager.debugLogger.writeErrorWithException("Error parsing server response:", e);
+			}
+			ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
+			return null;
+		}
+
 		/**
 		 * Parses additional info out of the latest server json related to GUI
 		 * library info
@@ -390,11 +612,13 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					//update GUI Transplanter
 					File cli = new File(cliPath);
 					if (cli.exists()) {
+						ModManager.debugLogger.writeMessage("Checking for updates for GUI Transplanter");
 						int build = EXEFileInfo.getRevisionOfProgram(cliPath);
 						if (build < latestGUITransplanter) {
 							//download
-							publish("Downloading update for GUI Transplanter");
-							ModManager.debugLogger.writeMessage("GUI Transplanter is out of date from server. Local " + build + " vs server " + latestGUITransplanter);
+							publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading update for GUI Transplanter"));
+							ModManager.debugLogger.writeMessage("GUI Transplanter is out of date from server. Local " + build + " vs server "
+									+ latestGUITransplanter);
 							File transplanterFolder = cli.getParentFile();
 							FileUtils.deleteQuietly(transplanterFolder);
 							ModManager.debugLogger.writeMessage("Downloading new GUI Transplanter");
@@ -403,105 +627,101 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 								int newbuild = EXEFileInfo.getRevisionOfProgram(cliPath);
 								if (newbuild == latestGUITransplanter) {
 									ModManager.debugLogger.writeMessage("Downloaded latest GUI Transplanter build: " + newbuild);
-									publish("Updated GUI Transplanter");
+									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated GUI Transplanter"));
 								} else {
 									ModManager.debugLogger.writeError("Failed to download proper updated build. Instead we downloaded: " + newbuild);
-									publish("Failed to download new GUI Transplanter");
+									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Transplanter"));
 								}
 							} else {
 								ModManager.debugLogger.writeError("Failed to download GUI Transplanter");
-								publish("Failed to download new GUI Transplanter");
+								publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Transplanter"));
 							}
+						} else {
+							ModManager.debugLogger.writeMessage("GUI Transplanter is up to date (1.0.0." + build + ")");
 						}
+					} else {
+						ModManager.debugLogger.writeMessage("No GUI Transplanter tool downloaded, skipping update check for it");
 					}
 				}
 			}
 
 			String uiLibPath = ModManager.getGUILibraryFor("DLC_CON_UIScaling", false);
-			String xbxLibPath = ModManager.getGUILibraryFor("DLC_CON_XBX", false);
-		}
-
-		private void checkForME3ExplorerUpdates() {
-			String me3explorer = ModManager.getME3ExplorerEXEDirectory(false) + "ME3Explorer.exe";
-			File f = new File(me3explorer);
-			if (!f.exists()) {
-				ModManager.debugLogger.writeMessage("ME3Explorer is missing. Downloading from ME3TWeaks.");
-				if (ModManager.AUTO_UPDATE_ME3EXPLORER) {
-					new ME3ExplorerUpdaterWindow(ModManagerWindow.this);
+			{
+				File uiLibVersionFile = new File(uiLibPath + "libraryversion.txt");
+				if (uiLibVersionFile.exists()) {
+					try {
+						String uilibverstr = FileUtils.readFileToString(uiLibVersionFile);
+						double libver = Double.parseDouble(uilibverstr);
+						obj = serversJSON.get("latest_uiscaling_guilibrary");
+						if (obj != null) {
+							double serverver = (double) obj;
+							if (libver < serverver) {
+								ModManager.debugLogger.writeMessage("UIScaling Library is out of date, updating...");
+								FileUtils.deleteQuietly(new File(uiLibPath));
+								publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updating Interface Scaling Mod GUI library"));
+								String newLib = ModManager.getGUILibraryFor("DLC_CON_UIScaling", true);
+								if (newLib != null) {
+									String newlibverstr = FileUtils.readFileToString(uiLibVersionFile);
+									double newlibver = Double.parseDouble(newlibverstr);
+									if (newlibver == serverver) {
+										ModManager.debugLogger.writeMessage("Downloaded latest Interface Scaling Mod GUI Library: " + newlibver);
+										publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated Interface Scaling Mod GUI library"));
+									} else {
+										ModManager.debugLogger.writeError("Failed to download proper updated GUI Library. Instead we downloaded: "
+												+ newlibver);
+										publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Library"));
+									}
+								}
+							}
+						}
+					} catch (IOException e) {
+						ModManager.debugLogger.writeErrorWithException("Error reading local settings:", e);
+					} catch (NumberFormatException e) {
+						ModManager.debugLogger.writeErrorWithException("Error parsing version numbers:", e);
+					}
 				} else {
-					ModManager.debugLogger.writeError("ME3Explorer missing but cannot download due to settings!");
-					JOptionPane.showMessageDialog(ModManagerWindow.this,
-							"ME3Explorer is missing from data/ME3Explorer.\nMod Manager requires ME3Explorer but you have auto updates for it turned off.\nIf there are errors in this session, they are not supported by FemShep.",
-							"Missing ME3Explorer", JOptionPane.ERROR_MESSAGE);
+					ModManager.debugLogger.writeMessage("No UIScaling GUI Library, skipping update check for it");
+				}
+			}
+
+			String xbxLibPath = ModManager.getGUILibraryFor("DLC_CON_XBX", false);
+			File xbxLibVersionFile = new File(uiLibPath + "libraryversion.txt");
+			if (xbxLibVersionFile.exists()) {
+				try {
+					String xbxlibverstr = FileUtils.readFileToString(xbxLibVersionFile);
+					double libver = Double.parseDouble(xbxlibverstr);
+					obj = serversJSON.get("latest_xbx_guilibrary");
+					if (obj != null) {
+						double serverver = (double) obj;
+						if (libver < serverver) {
+							ModManager.debugLogger.writeMessage("XBX Library is out of date, updating...");
+							FileUtils.deleteQuietly(new File(uiLibPath));
+							publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updating SP Controller Support GUI library"));
+							String newLib = ModManager.getGUILibraryFor("DLC_CON_XBX", true);
+							if (newLib != null) {
+								String newlibverstr = FileUtils.readFileToString(xbxLibVersionFile);
+								double newlibver = Double.parseDouble(newlibverstr);
+								if (newlibver == serverver) {
+									ModManager.debugLogger.writeMessage("Downloaded latest SP Controller Support GUI Library: " + newlibver);
+									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated SP Controller Support GUI library"));
+								} else {
+									ModManager.debugLogger.writeError("Failed to download proper updated GUI Library. Instead we downloaded: "
+											+ newlibver);
+									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Library"));
+								}
+							}
+						}
+					}
+				} catch (IOException e) {
+					ModManager.debugLogger.writeErrorWithException("Error reading local settings:", e);
+				} catch (NumberFormatException e) {
+					ModManager.debugLogger.writeErrorWithException("Error parsing version numbers:", e);
 				}
 			} else {
-				int main = EXEFileInfo.getMajorVersionOfProgram(me3explorer);
-				int rev = EXEFileInfo.getBuildOfProgram(me3explorer);
-				ModManager.debugLogger.writeMessage("ME3Explorer Version: " + Arrays.toString(EXEFileInfo.getVersionInfo(me3explorer)));
-				if (main < ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN || main == ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN && rev < ModManager.MIN_REQUIRED_ME3EXPLORER_REV) {
-					//we must update it
-					ModManager.debugLogger.writeMessage("ME3Explorer is outdated, local:" + main + "." + rev + ", required" + ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN + "."
-							+ ModManager.MIN_REQUIRED_ME3EXPLORER_REV + "+");
-					if (ModManager.AUTO_UPDATE_ME3EXPLORER) {
-						new ME3ExplorerUpdaterWindow(ModManagerWindow.this);
-					} else {
-						ModManager.debugLogger.writeError("ME3Explorer outdated but cannot download due to settings!");
-						JOptionPane.showMessageDialog(ModManagerWindow.this,
-								"Mod Manager requires a newer version of ME3Explorer for this build.\nYou have auto updates for it turned off. You will need to turn them back on to download this update.\nIf there are errors in this session, they are not supported by FemShep.",
-								"ME3Explorer Outdated", JOptionPane.ERROR_MESSAGE);
-					}
-				} else {
-					ModManager.debugLogger.writeMessage("Current ME3Explorer version satisfies requirements for Mod Manager");
-				}
+				ModManager.debugLogger.writeMessage("No XBX GUI Library, skipping update check for it");
 			}
 		}
 
-		private void checkForModUpdates() {
-			//Check for updates
-			if (ModManager.AUTO_UPDATE_MODS || forceUpdateOnReloadList.size() > 0) {
-				if (System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK > ModManager.AUTO_CHECK_INTERVAL_MS || forceUpdateOnReloadList.size() > 0) {
-					ModManager.debugLogger.writeMessage("Running auto-updater, it has been "
-							+ ModManager.getDurationBreakdown(System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK) + " since the last help/mods update check.");
-					publish("Downloading latest help information");
-					HelpMenu.getOnlineHelp();
-					publish("UPDATE_HELP_MENU");
-					publish("Updated help files from server");
-					if (modModel.getSize() > 0) {
-						publish("Checking for updates to mods");
-						checkAllModsForUpdates(false);
-					}
-				}
-			}
-		}
-
-		@Override
-		protected void process(List<Object> chunks) {
-			for (Object latest : chunks) {
-				if (latest instanceof String) {
-					String update = (String) latest;
-					switch (update) {
-					case "UPDATE_HELP_MENU":
-						menuBar.remove(helpMenu);
-						menuBar.add(HelpMenu.constructHelpMenu());
-						break;
-					default:
-						labelStatus.setText(update);
-						break;
-					}
-
-				}
-			}
-		}
-
-		@Override
-		protected void done() {
-			forceUpdateOnReloadList.clear(); //remove pending updates
-			try {
-				get();
-			} catch (Exception e) {
-				ModManager.debugLogger.writeErrorWithException("Exception in the network thread: ", e);
-			}
-		}
 	}
 
 	class SingleModUpdateCheckThread extends SwingWorker<Void, Object> {
@@ -536,17 +756,18 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				if (latest instanceof UpdatePackage) {
 					UpdatePackage upackage = (UpdatePackage) latest;
 					if (upackage.requiresSideload()) {
-						JOptionPane.showMessageDialog(ModManagerWindow.this,
-								upackage.getMod().getModName()
-										+ " has an update available from ME3Tweaks, but requires a sideloaded update first.\nAfter this dialog is closed, a browser window will open where you can download this sideload update.\nDrag and drop this downloaded file onto Mod Manager to install it.\nAfter the sideloaded update is complete, Mod Manager will download the rest of the update.\n\nThis is to save on bandwidth costs for both ME3Tweaks and the developer of "
-										+ upackage.getMod().getModName() + ".",
-								"Sideload update required", JOptionPane.WARNING_MESSAGE);
+						JOptionPane
+								.showMessageDialog(
+										ModManagerWindow.this,
+										upackage.getMod().getModName()
+												+ " has an update available from ME3Tweaks, but requires a sideloaded update first.\nAfter this dialog is closed, a browser window will open where you can download this sideload update.\nDrag and drop this downloaded file onto Mod Manager to install it.\nAfter the sideloaded update is complete, Mod Manager will download the rest of the update.\n\nThis is to save on bandwidth costs for both ME3Tweaks and the developer of "
+												+ upackage.getMod().getModName() + ".", "Sideload update required", JOptionPane.WARNING_MESSAGE);
 						try {
 							ModManager.openWebpage(new URL(upackage.getSideloadURL()));
 						} catch (MalformedURLException e) {
 							ModManager.debugLogger.writeError("Invalid sideload URL: " + upackage.getSideloadURL());
-							JOptionPane.showMessageDialog(ModManagerWindow.this,
-									upackage.getMod().getModName() + " specified an invalid URL for it's sideload upload:\n" + upackage.getSideloadURL(), "Invalid Sideload URL",
+							JOptionPane.showMessageDialog(ModManagerWindow.this, upackage.getMod().getModName()
+									+ " specified an invalid URL for it's sideload upload:\n" + upackage.getSideloadURL(), "Invalid Sideload URL",
 									JOptionPane.ERROR_MESSAGE);
 						}
 					} else {
@@ -554,7 +775,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 						updatetext += AllModsUpdateWindow.getVersionUpdateString(upackage);
 
 						updatetext += "Update this mod?";
-						int result = JOptionPane.showConfirmDialog(ModManagerWindow.this, updatetext, "Mod update available", JOptionPane.YES_NO_OPTION);
+						int result = JOptionPane.showConfirmDialog(ModManagerWindow.this, updatetext, "Mod update available",
+								JOptionPane.YES_NO_OPTION);
 						if (result == JOptionPane.YES_OPTION) {
 							ModManager.debugLogger.writeMessage("Starting manual single-mod updater");
 							ModUpdateWindow muw = new ModUpdateWindow(upackage);
@@ -573,130 +795,6 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				ModManager.debugLogger.writeErrorWithException("Exception in the single mod update thread: ", e);
 			}
 		}
-	}
-
-	private Void checkForUpdates() {
-		labelStatus.setText("Checking for Mod Manager updates");
-		ModManager.debugLogger.writeMessage("Checking for update...");
-		// Check for update
-		try {
-			String update_check_link;
-			if (ModManager.IS_DEBUG) {
-				update_check_link = "http://webdev-c9-mgamerz.c9.io/modmanager/updatecheck?currentversion=" + ModManager.BUILD_NUMBER;
-			} else {
-				update_check_link = "https://me3tweaks.com/modmanager/updatecheck-testing?currentversion=" + ModManager.BUILD_NUMBER;
-			}
-			String serverJSON = null;
-			try {
-				serverJSON = IOUtils.toString(new URL(update_check_link), StandardCharsets.UTF_8);
-				System.out.println(update_check_link);
-			} catch (Exception e) {
-				ModManager.debugLogger.writeError("Error checking for updates:");
-				ModManager.debugLogger.writeException(e);
-				labelStatus.setText("Error checking for update (check logs)");
-				ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-				return null;
-			}
-			if (serverJSON == null) {
-				ModManager.debugLogger.writeError("No response from server");
-				labelStatus.setText("Updater: No response from server");
-				ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-				return null;
-			}
-
-			JSONParser parser = new JSONParser();
-			JSONObject latest_object = (JSONObject) parser.parse(serverJSON);
-			String buildHash = (String) latest_object.get("build_md5");
-			boolean hashMismatch = false;
-			if (new File("ME3CMM.exe").exists()) {
-				try {
-					String currentHash = MD5Checksum.getMD5Checksum("ME3CMM.exe");
-					if (buildHash != null && !buildHash.equals("") && !currentHash.equals(buildHash)) {
-						//hash mismatch
-						hashMismatch = true;
-						ModManager.debugLogger.writeMessage("Local hash (" + currentHash + ") does not match server hash (" + buildHash + ")");
-					} else {
-						ModManager.debugLogger.writeMessage("Local hash matches server hash: " + buildHash);
-					}
-				} catch (Exception e1) {
-					ModManager.debugLogger.writeErrorWithException("Unable to hash ME3CMM.exe:", e1);
-				}
-			} else {
-				ModManager.debugLogger.writeMessage("Skipping hash check for updates. Likely running in IDE or some other wizardry");
-			}
-
-			long latest_build = (long) latest_object.get("latest_build_number");
-			if (latest_build < ModManager.BUILD_NUMBER) {
-				//build is newer than current
-				labelStatus.setVisible(true);
-				ModManager.debugLogger.writeMessage("No updates, at latest version. (or could not contact update server.)");
-				labelStatus.setText("No Mod Manager updates available");
-				ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-				checkForGUIupdates(latest_object);
-				return null;
-			}
-
-			if (latest_build == ModManager.BUILD_NUMBER && !hashMismatch) {
-				//build is same as server version
-				labelStatus.setVisible(true);
-				ModManager.debugLogger.writeMessage("No updates, at latest version.");
-				labelStatus.setText("Mod Manager is up to date");
-				ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-				checkForGUIupdates(latest_object);
-				return null;
-			}
-
-			ModManager.debugLogger
-					.writeMessage("Update check: Local:" + ModManager.BUILD_NUMBER + " Latest: " + latest_build + ", is less? " + (ModManager.BUILD_NUMBER < latest_build));
-
-			boolean showUpdate = true;
-			// make sure the user hasn't declined this one.
-			Wini settingsini;
-			try {
-				settingsini = new Wini(new File(ModManager.SETTINGS_FILENAME));
-				String showIfHigherThan = settingsini.get("Settings", "nextupdatedialogbuild");
-				long build_check = ModManager.BUILD_NUMBER;
-				if (showIfHigherThan != null && !showIfHigherThan.equals("")) {
-					try {
-						build_check = Integer.parseInt(showIfHigherThan);
-						if (latest_build > build_check) {
-							// update is newer than one stored in ini, show the
-							// dialog.
-							ModManager.debugLogger.writeMessage("Advertising build " + latest_build);
-							showUpdate = true;
-						} else {
-							ModManager.debugLogger.writeMessage("User isn't seeing updates until build " + build_check);
-							// don't show it.
-							showUpdate = false;
-						}
-					} catch (NumberFormatException e) {
-						ModManager.debugLogger.writeMessage("Number format exception reading the build number updateon in the ini. Showing the dialog.");
-					}
-				}
-			} catch (InvalidFileFormatException e) {
-				ModManager.debugLogger.writeErrorWithException("Invalid INI! Did the user modify it by hand?", e);
-				e.printStackTrace();
-			} catch (IOException e) {
-				ModManager.debugLogger.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting stored to disk.");
-			}
-
-			if (showUpdate) {
-				// An update is available!
-				labelStatus.setVisible(true);
-				labelStatus.setText("Update available");
-				new UpdateAvailableWindow(latest_object, this);
-				ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-			} else {
-				labelStatus.setVisible(true);
-				labelStatus.setText("No updates available");
-			}
-			checkForGUIupdates(latest_object);
-		} catch (ParseException e) {
-			// TODO Auto-generated catch block
-			ModManager.debugLogger.writeErrorWithException("Error parsing server response:", e);
-		}
-		ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-		return null;
 	}
 
 	/**
@@ -795,11 +893,13 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 		// Title Panel
 		JPanel titlePanel = new JPanel(new BorderLayout());
-		titlePanel.add(new JLabel("Mass Effect 3 Mod Manager " + ModManager.VERSION + (ModManager.IS_DEBUG ? " [DEBUG MODE]" : ""), SwingConstants.LEFT), BorderLayout.WEST);
+		titlePanel.add(new JLabel("Mass Effect 3 Mod Manager " + ModManager.VERSION + (ModManager.IS_DEBUG ? " [DEBUG MODE]" : ""),
+				SwingConstants.LEFT), BorderLayout.WEST);
 
 		// BioGameDir Panel
 		cookedDirPanel = new JPanel(new BorderLayout());
-		TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Mass Effect 3 BIOGame Directory");
+		TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
+				"Mass Effect 3 BIOGame Directory");
 		fieldBiogameDir = new JTextField();
 		fieldBiogameDir.setText(getInitialBiogameDirText());
 		fieldBiogameDir.addFocusListener(new FocusListener() {
@@ -816,8 +916,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 		});
 		buttonBioGameDir = new JButton("Browse...");
-		buttonBioGameDir.setToolTipText(
-				"<html>Browse and set the BIOGame directory.<br>This is located in the installation directory for Mass Effect 3.<br>Typically this is in the Origin Games folder.</html>");
+		buttonBioGameDir
+				.setToolTipText("<html>Browse and set the BIOGame directory.<br>This is located in the installation directory for Mass Effect 3.<br>Typically this is in the Origin Games folder.</html>");
 		fieldBiogameDir.setColumns(37);
 		buttonBioGameDir.setPreferredSize(new Dimension(90, 14));
 
@@ -842,8 +942,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		JScrollPane listScroller = new JScrollPane(modList, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 
 		modlistFailedIndicatorLink = new JButton();
-		modlistFailedIndicatorLink
-				.setText("<HTML><font color=#ff2020><u>" + invalidMods.size() + " mod" + (invalidMods.size() != 1 ? "s" : "") + " failed to load</u></font></HTML>");
+		modlistFailedIndicatorLink.setText("<HTML><font color=#ff2020><u>" + invalidMods.size() + " mod" + (invalidMods.size() != 1 ? "s" : "")
+				+ " failed to load</u></font></HTML>");
 		modlistFailedIndicatorLink.setBorderPainted(false);
 		modlistFailedIndicatorLink.setBackground(UIManager.getColor("Panel.background"));
 		modlistFailedIndicatorLink.setFocusPainted(false);
@@ -938,8 +1038,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		}
 		buttonStartGame = new JButton("Start Game");
 		buttonStartGame.addActionListener(this);
-		buttonStartGame.setToolTipText(
-				"<html>Starts the game.<br>If LauncherWV DLC bypass is installed, it will launch instead to patch out the DLC verifiction test.<br>The game will then start.</html>");
+		buttonStartGame
+				.setToolTipText("<html>Starts the game.<br>If LauncherWV DLC bypass is installed, it will launch instead to patch out the DLC verifiction test.<br>The game will then start.</html>");
 
 		buttonPanel.add(buttonApplyMod);
 		buttonPanel.add(buttonStartGame);
@@ -965,8 +1065,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			if (modList.getSelectedIndex() == -1) {
 				buttonApplyMod.setToolTipText("Select a mod on the left");
 			} else {
-				buttonApplyMod.setToolTipText(
-						"<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
+				buttonApplyMod
+						.setToolTipText("<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
 
 			}
 		} else {
@@ -990,10 +1090,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 		JMenu actionImportMenu = new JMenu("Import mod");
 		modManagementImportAlreadyInstalled = new JMenuItem("Import installed Custom DLC mod");
-		modManagementImportAlreadyInstalled.setToolTipText("<html>Import an already installed DLC mod.<br>You can then manage that mod with Mod Manager.</html>");
+		modManagementImportAlreadyInstalled
+				.setToolTipText("<html>Import an already installed DLC mod.<br>You can then manage that mod with Mod Manager.</html>");
 		modManagementImportFromArchive = new JMenuItem("Import mod from .7z/.rar/.zip");
-		modManagementImportFromArchive.setToolTipText(
-				"<html>Import a mod that has been packaged for importing into Mod Manager.<br>For directions on how to make mods in this format, please see the Mod Manager moddesc page.</html>");
+		modManagementImportFromArchive
+				.setToolTipText("<html>Import a mod that has been packaged for importing into Mod Manager.<br>For directions on how to make mods in this format, please see the Mod Manager moddesc page.</html>");
 
 		actionOptions = new JMenuItem("Options");
 		actionOptions.setToolTipText("Configure Mod Manager Options");
@@ -1007,7 +1108,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolTankmasterTLK = new JMenuItem("TankMaster ME2/ME3 TLK Tool");
 		toolTankmasterTLK.setToolTipText("Runs the bundled TLK tool provided by TankMaster");
 		toolsAutoTOCGame = new JMenuItem("Run AutoTOC on game");
-		toolsAutoTOCGame.setToolTipText("<html>Updates TOC files for basegame, DLC (unpacked and modified SFAR), and custom DLC.<br>May help fix infinite loading issues</html>");
+		toolsAutoTOCGame
+				.setToolTipText("<html>Updates TOC files for basegame, DLC (unpacked and modified SFAR), and custom DLC.<br>May help fix infinite loading issues</html>");
 
 		actionReload = new JMenuItem("Reload Mod Manager");
 		actionReload.setToolTipText("Reloads Mod Manager to refresh mods, mixins, and help documentation");
@@ -1039,7 +1141,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modManagementConflictDetector = new JMenuItem("Custom DLC Conflict Detector");
 		modManagementConflictDetector.setToolTipText("Scans installed custom DLC for file conflicts that may prevent them from working correctly");
 		modManagementCheckallmodsforupdate = new JMenuItem("Check eligible mods for updates");
-		modManagementCheckallmodsforupdate.setToolTipText("Checks eligible mods for updates on ME3Tweaks and prompts to download an update if one is available");
+		modManagementCheckallmodsforupdate
+				.setToolTipText("Checks eligible mods for updates on ME3Tweaks and prompts to download an update if one is available");
 		modManagementPatchLibary = new JMenuItem("MixIn Library");
 		modManagementPatchLibary.setToolTipText("Add premade mixins to mods using patches in your patch library");
 		modManagementOpenModsFolder = new JMenuItem("Open mods/ folder");
@@ -1081,7 +1184,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		if (!checkForKeybindsOverride()) {
 			ModManager.debugLogger.writeMessage("No keybinds file in the override directory (bioinput.xml)");
 			modutilsInstallCustomKeybinds.setEnabled(false);
-			modutilsInstallCustomKeybinds.setToolTipText("<html>To enable installing custom keybinds put a<br>BioInput.xml file in the data/override/ directory.</html>");
+			modutilsInstallCustomKeybinds
+					.setToolTipText("<html>To enable installing custom keybinds put a<br>BioInput.xml file in the data/override/ directory.</html>");
 		} else {
 			ModManager.debugLogger.writeMessage("Found keybinds file in the override directory (bioinput.xml)");
 			modutilsInstallCustomKeybinds.setToolTipText("<html>Replace BioInput.xml in the BASEGAME Coalesced file</html>");
@@ -1096,12 +1200,13 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modutilsInfoEditor.setToolTipText("Rename this mod and change the description shown in the descriptions window");
 
 		modDeltaMenu = new JMenu("0 available variants");
-		modDeltaMenu.setToolTipText(
-				"<html>This mod has variants that allow quick changes to the mod without shipping a full new version.<br>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
+		modDeltaMenu
+				.setToolTipText("<html>This mod has variants that allow quick changes to the mod without shipping a full new version.<br>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
 		modDeltaMenu.setVisible(false);
 
 		modNoDeltas = new JMenuItem("No included variants");
-		modNoDeltas.setToolTipText("<html>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
+		modNoDeltas
+				.setToolTipText("<html>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
 		modNoDeltas.setEnabled(false);
 
 		modutilsVerifyDeltas = new JMenuItem("Verify variants");
@@ -1154,10 +1259,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolsOpenME3Dir.setToolTipText("Opens a Windows Explorer window in the BIOGame Directory");
 
 		toolsInstallLauncherWV = new JMenuItem("Install LauncherWV DLC Bypass");
-		toolsInstallLauncherWV.setToolTipText("<html>Installs an in-memory patcher giving you console and allowing modified DLC.<br>This does not does not modify files</html>");
+		toolsInstallLauncherWV
+				.setToolTipText("<html>Installs an in-memory patcher giving you console and allowing modified DLC.<br>This does not does not modify files</html>");
 		toolsInstallBinkw32 = new JMenuItem("Install Binkw32 DLC Bypass");
-		toolsInstallBinkw32.setToolTipText(
-				"<html>Installs a startup patcher giving you console and allowing modified DLC.<br>This modifies your game and is erased when doing an Origin Repair</html>");
+		toolsInstallBinkw32
+				.setToolTipText("<html>Installs a startup patcher giving you console and allowing modified DLC.<br>This modifies your game and is erased when doing an Origin Repair</html>");
 		toolsUninstallBinkw32 = new JMenuItem("Uninstall Binkw32 DLC Bypass");
 		toolsUninstallBinkw32.setToolTipText("<html>Removes the Binkw32.dll startup patcher, reverting the original file</html>");
 
@@ -1168,7 +1274,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolsMountdlcEditor.setToolTipText("Allows you to modify or create new Mount.dlc files easily");
 
 		toolME3Config = new JMenuItem("ME3 Config Tool");
-		toolME3Config.setToolTipText("<html>Opens the ME3 Configuration Utility that comes packaged with the game.<br>Lets you configure graphics and audio settings.</html>");
+		toolME3Config
+				.setToolTipText("<html>Opens the ME3 Configuration Utility that comes packaged with the game.<br>Lets you configure graphics and audio settings.</html>");
 
 		toolsAutoTOCGame.addActionListener(this);
 		modManagementModMaker.addActionListener(this);
@@ -1219,13 +1326,16 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		backupMenu = new JMenu("Backup");
 
 		backupBackupDLC = new JMenuItem("Backup DLCs");
-		backupBackupDLC.setToolTipText("Backs up your DLC to .bak files. When installing a mod it will ask if a .bak files does not exist if you want to backup");
+		backupBackupDLC
+				.setToolTipText("Backs up your DLC to .bak files. When installing a mod it will ask if a .bak files does not exist if you want to backup");
 
 		backupBasegameUnpacked = new JMenuItem("Backup basegame/unpacked files");
-		backupBasegameUnpacked.setToolTipText("An Unpacked and basegame file will be automatically backed up when Mod Manager replaces or removes that file");
+		backupBasegameUnpacked
+				.setToolTipText("An Unpacked and basegame file will be automatically backed up when Mod Manager replaces or removes that file");
 
 		backupCreateGDB = new JMenuItem("Update game repair database");
-		backupCreateGDB.setToolTipText("Creates/updates a database of checksums for basegame and unpacked DLC files for verifying restoring and backing up");
+		backupCreateGDB
+				.setToolTipText("Creates/updates a database of checksums for basegame and unpacked DLC files for verifying restoring and backing up");
 
 		backupBackupDLC.addActionListener(this);
 		backupBasegameUnpacked.addActionListener(this);
@@ -1244,8 +1354,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreSelective.setToolTipText("Allows you to restore specific basegame, DLC, and unpacked files");
 
 		restoreRevertEverything = new JMenuItem("Restore everything");
-		restoreRevertEverything.setToolTipText(
-				"<html>Restores all basegame files, deletes unpacked DLC files, and restores all SFAR files.<br>This will delete any non standard DLC folders.</html>");
+		restoreRevertEverything
+				.setToolTipText("<html>Restores all basegame files, deletes unpacked DLC files, and restores all SFAR files.<br>This will delete any non standard DLC folders.</html>");
 
 		restoreDeleteUnpacked = new JMenuItem("Delete all unpacked DLC files");
 		restoreDeleteUnpacked
@@ -1267,7 +1377,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreRevertUnpacked.setToolTipText("<html>Restores all unpacked DLC files that have been modified by installing mods</html>");
 
 		restoreRevertBasegameUnpacked = new JMenuItem("Restore basegame + unpacked files");
-		restoreRevertBasegameUnpacked.setToolTipText("<html>Restores all basegame and unpacked DLC files that have been modified by installing mods</html>");
+		restoreRevertBasegameUnpacked
+				.setToolTipText("<html>Restores all basegame and unpacked DLC files that have been modified by installing mods</html>");
 
 		restoreVanillifyDLC = new JMenuItem("Vanillify game DLC");
 		restoreVanillifyDLC.setToolTipText("<html>Removes custom DLC, deletes unpacked files, restores SFARs.</html>");
@@ -1279,14 +1390,15 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreRevertSPDLC.setToolTipText("<html>Restores all SP DLCs.<br>This does not remove custom DLC modules.</html>");
 
 		restoreRevertSPBaseDLC = new JMenuItem("Restore SP DLC SFARs + Basegame");
-		restoreRevertSPBaseDLC.setToolTipText("<html>Restores all basegame files, and checks all SP DLC SFAR files.<br>This does not remove custom DLC modules.</html>");
+		restoreRevertSPBaseDLC
+				.setToolTipText("<html>Restores all basegame files, and checks all SP DLC SFAR files.<br>This does not remove custom DLC modules.</html>");
 
 		restoreRevertMPDLC = new JMenuItem("Restore MP DLC SFARs");
 		restoreRevertMPDLC.setToolTipText("<html>Restores all MP DLC SFARs.<br>This does not remove custom DLC modules.</html>");
 
 		restoreRevertMPBaseDLC = new JMenuItem("Restore MP DLC SFARs + Basegame");
-		restoreRevertMPBaseDLC.setToolTipText(
-				"<html>Restores all basegame files, and checks all Multiplayer DLC files.<br>This does not remove custom DLC modules.<br>If you are doing multiplayer mods, you should use this to restore</html>");
+		restoreRevertMPBaseDLC
+				.setToolTipText("<html>Restores all basegame files, and checks all Multiplayer DLC files.<br>This does not remove custom DLC modules.<br>If you are doing multiplayer mods, you should use this to restore</html>");
 		restoreRevertCoal = new JMenuItem("Restore vanilla Coalesced.bin");
 		restoreRevertCoal.setToolTipText("<html>Restores the basegame coalesced file</html>");
 
@@ -1402,7 +1514,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				dirChooser.setCurrentDirectory(new File(fieldBiogameDir.getText()));
 			} else {
 				if (ModManager.logging) {
-					ModManager.debugLogger.writeMessage("Directory " + fieldBiogameDir.getText() + " does not exist, defaulting to working directory.");
+					ModManager.debugLogger.writeMessage("Directory " + fieldBiogameDir.getText()
+							+ " does not exist, defaulting to working directory.");
 				}
 				dirChooser.setCurrentDirectory(new java.io.File("."));
 			}
@@ -1436,8 +1549,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("ModMaker requires valid BIOGame directory to start");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 
 			}
 		} else if (e.getSource() == modManagementConflictDetector) {
@@ -1455,8 +1568,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Conflict detector requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modManagementFailedMods) {
 			new FailedModsWindow();
@@ -1466,8 +1579,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Backing up DLC requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1475,26 +1588,31 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			if (validateBIOGameDir()) {
 				String me3dir = (new File(fieldBiogameDir.getText())).getParent();
 				String backupLocation = ModManager.appendSlash(me3dir) + "cmmbackup";
-				JOptionPane.showMessageDialog(this,
-						"<html><div style=\"width:330px;\">Basegame and unpacked DLC files are automatically backed up by Mod Manager when a Mod Manager mod replaces or removes that file while being applied.<br>"
-								+ "The game repair database verifies the file being backed up matches the metadata in the database so it can restore back to that version later. When restoring, the backed up file is checked again to make sure it wasn't modified. Otherwise you may restore files of different sizes and the game will crash.<br>"
-								+ "This is why modifications outside of Mod Manager are not backed up and are not supported. If you want to use modifications outside of Mod Manager, update the game repair database after you make your changes outside of Mod Manager. Make sure your game is in a working state before you do this or you will restore to a broken snapshot.<br><br>"
-								+ "The backup files created by Mod Manager are placed in the following folder:<br>" + backupLocation
-								+ "<br><br>MixIns do not support modified files except for those modified by other non-finalizing MixIns.</div></html>",
-						"Backup of basegame/unpacked files", JOptionPane.INFORMATION_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								this,
+								"<html><div style=\"width:330px;\">Basegame and unpacked DLC files are automatically backed up by Mod Manager when a Mod Manager mod replaces or removes that file while being applied.<br>"
+										+ "The game repair database verifies the file being backed up matches the metadata in the database so it can restore back to that version later. When restoring, the backed up file is checked again to make sure it wasn't modified. Otherwise you may restore files of different sizes and the game will crash.<br>"
+										+ "This is why modifications outside of Mod Manager are not backed up and are not supported. If you want to use modifications outside of Mod Manager, update the game repair database after you make your changes outside of Mod Manager. Make sure your game is in a working state before you do this or you will restore to a broken snapshot.<br><br>"
+										+ "The backup files created by Mod Manager are placed in the following folder:<br>"
+										+ backupLocation
+										+ "<br><br>MixIns do not support modified files except for those modified by other non-finalizing MixIns.</div></html>",
+								"Backup of basegame/unpacked files", JOptionPane.INFORMATION_MESSAGE);
 			} else {
 				labelStatus.setText("ModMaker requires valid BIOGame directory to start");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == backupCreateGDB) {
 			if (validateBIOGameDir()) {
 				createBasegameDB(fieldBiogameDir.getText());
 			} else {
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot update or create the game repair database.\nFix the BioGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BioGame directory is not valid.\nMod Manager cannot update or create the game repair database.\nFix the BioGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1503,7 +1621,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreCoalesced(fieldBiogameDir.getText());
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modDevStarterKit) {
@@ -1513,19 +1632,22 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.ALLDLC);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoredeleteAllCustomDLC) {
 			if (validateBIOGameDir()) {
-				if (JOptionPane.showConfirmDialog(this, "This will delete all folders in the BIOGame/DLC folder that aren't known to be official.\nDelete all custom DLC?",
+				if (JOptionPane.showConfirmDialog(this,
+						"This will delete all folders in the BIOGame/DLC folder that aren't known to be official.\nDelete all custom DLC?",
 						"Delete all Custom DLC", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 
 					restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.REMOVECUSTOMDLC);
 				}
 			} else {
 				labelStatus.setText("Can't remove custom DLC with invalid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreCustomDLCManager) {
@@ -1533,24 +1655,30 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				new CustomDLCWindow(fieldBiogameDir.getText());
 			} else {
 				labelStatus.setText("Custom DLC Manager requires valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nCustom DLC Manager requires a valid directory.\nFix the BioGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BioGame directory is not valid.\nCustom DLC Manager requires a valid directory.\nFix the BioGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreSelective) {
 			if (validateBIOGameDir()) {
 				new SelectiveRestoreWindow(fieldBiogameDir.getText());
 			} else {
 				labelStatus.setText("Custom Restore requires valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nCustom Restore requires a valid directory.\nFix the BioGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BioGame directory is not valid.\nCustom Restore requires a valid directory.\nFix the BioGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertBasegame) {
 			if (validateBIOGameDir()) {
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.BASEGAME);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertUnpacked) {
@@ -1558,7 +1686,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.UNPACKED);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertBasegameUnpacked) {
@@ -1566,20 +1695,24 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.UNPACKEDBASEGAME);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreVanillifyDLC) {
 			if (validateBIOGameDir()) {
-				if (JOptionPane.showConfirmDialog(this,
-						"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
-						"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+				if (JOptionPane
+						.showConfirmDialog(
+								this,
+								"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
+								"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 
 					restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.VANILLIFYDLC);
 				}
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertSPDLC) {
@@ -1587,7 +1720,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.SP);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 
@@ -1596,7 +1730,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.MP);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertSPBaseDLC) {
@@ -1604,7 +1739,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.SPBASE);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertMPBaseDLC) {
@@ -1612,7 +1748,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.MPBASE);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
@@ -1620,31 +1757,38 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		if (e.getSource() == restoreRevertEverything) {
 			if (validateBIOGameDir()) {
 				if (validateBIOGameDir()) {
-					if (JOptionPane.showConfirmDialog(this,
-							"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
-							"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+					if (JOptionPane
+							.showConfirmDialog(
+									this,
+									"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
+									"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 
 						restoreCoalesced(fieldBiogameDir.getText());
 						restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.ALL);
 					}
 				} else {
 					labelStatus.setText("Cannot restore files without valid BIOGame directory");
-					JOptionPane.showMessageDialog(null,
-							"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
-							"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+					JOptionPane
+							.showMessageDialog(
+									null,
+									"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+									"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		} else if (e.getSource() == restoreDeleteUnpacked) {
 			if (validateBIOGameDir()) {
-				if (JOptionPane.showConfirmDialog(this,
-						"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
-						"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+				if (JOptionPane
+						.showConfirmDialog(
+								this,
+								"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
+								"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 					restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.REMOVEUNPACKEDITEMS);
 				}
 			} else {
 				labelStatus.setText("Cannot delete files with invalid BIOGame directory");
 
-				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == actionExitDebugMode) {
@@ -1715,8 +1859,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing a mod requires valid BIOGame path");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1727,9 +1871,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Starting the game requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null,
-						"The BIOGame directory is not valid.\nMod Manager does not know where to launch the game executable.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BIOGame directory is not valid.\nMod Manager does not know where to launch the game executable.\nFix the BIOGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1831,14 +1977,17 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					}
 				} else {
 					ModManager.debugLogger.writeError("Config tool is missing! Not found at " + path);
-					JOptionPane.showMessageDialog(null, "The config tool executable doesn't exist where it should:\n" + path, "Missing Config Tool exe", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null, "The config tool executable doesn't exist where it should:\n" + path,
+							"Missing Config Tool exe", JOptionPane.ERROR_MESSAGE);
 				}
 			} else {
 				labelStatus.setText("ME3 Config tool requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null,
-						"The BIOGame directory is not valid.\nCannot open the ME3 Config tool if Mod Manager doesn't know where Mass Effect 3 is.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BIOGame directory is not valid.\nCannot open the ME3 Config tool if Mod Manager doesn't know where Mass Effect 3 is.\nFix the BIOGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsUnpackDLC) {
 			if (validateBIOGameDir()) {
@@ -1855,9 +2004,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Unpacking DLC requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null,
-						"The BIOGame directory is not valid.\nCannot unpack DLC without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BIOGame directory is not valid.\nCannot unpack DLC without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsMountdlcEditor) {
 			new MountFileEditorWindow();
@@ -1878,9 +2029,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Game AutoTOC requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null,
-						"The BIOGame directory is not valid.\nCannot update TOC files without a valid directory.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BIOGame directory is not valid.\nCannot update TOC files without a valid directory.\nFix the BIOGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modutilsAutoTOC) {
 			if (ModManager.validateNETFrameworkIsInstalled()) {
@@ -1913,9 +2066,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null,
-						"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modutilsRestoreMod) {
 
@@ -1934,14 +2089,19 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null,
-						"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modutilsDeleteMod) {
 			ModManager.debugLogger.writeMessage("User clicked Delete Mod on " + modModel.get(modList.getSelectedIndex()).getModName());
-			int result = JOptionPane.showConfirmDialog(this, "Deleting this mod will remove it from your filesystem.\nThis operation cannot be reversed.\nDelete "
-					+ modModel.get(modList.getSelectedIndex()).getModName() + "?", "Confirm Mod Deletion", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+			int result = JOptionPane.showConfirmDialog(
+					this,
+					"Deleting this mod will remove it from your filesystem.\nThis operation cannot be reversed.\nDelete "
+							+ modModel.get(modList.getSelectedIndex()).getModName() + "?", "Confirm Mod Deletion", JOptionPane.YES_NO_OPTION,
+					JOptionPane.WARNING_MESSAGE);
 			if (result == JOptionPane.OK_OPTION) {
 				ModManager.debugLogger.writeMessage("Deleting mod: " + modModel.get(modList.getSelectedIndex()).getModPath());
 				FileUtils.deleteQuietly(new File(modModel.get(modList.getSelectedIndex()).getModPath()));
@@ -1951,7 +2111,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new KeybindsInjectionWindow(this, modModel.getElementAt(modList.getSelectedIndex()), false);
 		} else if (e.getSource() == modManagementCheckallmodsforupdate) {
 			if (!validateBIOGameDir()) {
-				JOptionPane.showMessageDialog(this, "Your BIOGame directory is not correctly set.\nOnly non-ModMaker mods will be checked for updates.",
+				JOptionPane.showMessageDialog(this,
+						"Your BIOGame directory is not correctly set.\nOnly non-ModMaker mods will be checked for updates.",
 						"Invalid BIOGame Directory", JOptionPane.WARNING_MESSAGE);
 			}
 			checkAllModsForUpdates(true);
@@ -1970,8 +2131,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Use of the patch library requires a valid BIOGame folder");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modDeltaRevert) {
 			//if (validateBIOGameDir()) {
@@ -2021,8 +2182,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing DLC bypass requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsInstallBinkw32) {
 			if (validateBIOGameDir()) {
@@ -2031,8 +2192,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing DLC bypass requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsUninstallBinkw32) {
 			if (validateBIOGameDir()) {
@@ -2041,8 +2202,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing DLC bypass requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}
@@ -2085,9 +2246,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new AllModsUpdateWindow(this, isManualCheck, updatableMods);
 		} else {
 			if (isManualCheck) {
-				JOptionPane.showMessageDialog(null,
-						"No mods are eligible for the Mod Manager update service.\nEligible mods include ModMaker mods and ones hosted on ME3Tweaks.com.", "No updatable mods",
-						JOptionPane.WARNING_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"No mods are eligible for the Mod Manager update service.\nEligible mods include ModMaker mods and ones hosted on ME3Tweaks.com.",
+								"No updatable mods", JOptionPane.WARNING_MESSAGE);
 			}
 			Wini ini;
 			try {
@@ -2102,7 +2265,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} catch (InvalidFileFormatException e) {
 				e.printStackTrace();
 			} catch (IOException e) {
-				ModManager.debugLogger.writeErrorWithException("Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
+				ModManager.debugLogger.writeErrorWithException(
+						"Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
 			}
 		}
 	}
@@ -2154,7 +2318,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new BackupWindow(this, bioGameDir);
 		} else {
 			// Biogame is invalid
-			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
+			JOptionPane.showMessageDialog(null,
+					"The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
 					"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			labelStatus.setText("DLC backup failed");
 			labelStatus.setVisible(true);
@@ -2168,7 +2333,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new BackupWindow(this, bioGameDir, dlcName);
 		} else {
 			// Biogame is invalid
-			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
+			JOptionPane.showMessageDialog(null,
+					"The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
 					"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			labelStatus.setText("DLC backup failed");
 			labelStatus.setVisible(true);
@@ -2183,8 +2349,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		File coalesced = new File(ModManager.appendSlash(dirChooser.getSelectedFile().toString()) + "CookedPCConsole\\Coalesced.bin");
 		if (coalesced.exists()) {
 			String YesNo[] = { "Yes", "No" };
-			int saveDir = JOptionPane.showOptionDialog(null, "BioGame directory set to: " + dirChooser.getSelectedFile().toString() + "\nSave this path?", "Save BIOGame path?",
-					JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
+			int saveDir = JOptionPane.showOptionDialog(null, "BioGame directory set to: " + dirChooser.getSelectedFile().toString()
+					+ "\nSave this path?", "Save BIOGame path?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
 			if (saveDir == 0) {
 				Wini ini;
 				try {
@@ -2198,7 +2364,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				} catch (InvalidFileFormatException e) {
 					e.printStackTrace();
 				} catch (IOException e) {
-					ModManager.debugLogger.writeErrorWithException("Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
+					ModManager.debugLogger.writeErrorWithException(
+							"Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
 				}
 				labelStatus.setText("Saved BioGame directory to me3cmm.ini");
 				labelStatus.setVisible(true);
@@ -2206,7 +2373,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			fieldBiogameDir.setText(dirChooser.getSelectedFile().toString());
 			validateBIOGameDir();
 		} else {
-			JOptionPane.showMessageDialog(null, "Coalesced.bin not found in " + dirChooser.getSelectedFile().toString(), "Error", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null, "Coalesced.bin not found in " + dirChooser.getSelectedFile().toString(), "Error",
+					JOptionPane.ERROR_MESSAGE);
 		}
 	}
 
@@ -2234,12 +2402,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	 */
 	private static void setBioDirHighlight(boolean highlight) {
 		if (highlight) {
-			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Mass Effect 3 BIOGame Directory (INVALID)",
-					TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager.getDefaults().getFont("titledBorder.font"), Color.RED);
+			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
+					"Mass Effect 3 BIOGame Directory (INVALID)", TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager
+							.getDefaults().getFont("titledBorder.font"), Color.RED);
 			ModManagerWindow.ACTIVE_WINDOW.cookedDirPanel.setBorder(cookedDirTitle);
 		} else {
-			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Mass Effect 3 BIOGame Directory",
-					TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager.getDefaults().getFont("titledBorder.font"), new Color(0, 150, 0));
+			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
+					"Mass Effect 3 BIOGame Directory", TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager.getDefaults()
+							.getFont("titledBorder.font"), new Color(0, 150, 0));
 			ModManagerWindow.ACTIVE_WINDOW.cookedDirPanel.setBorder(cookedDirTitle);
 		}
 	}
@@ -2294,9 +2464,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} catch (InvalidFileFormatException e) {
 			ModManager.debugLogger.writeError("Invalid file format exception writing to settings ini.");
 		} catch (IOException e) {
-			ModManager.debugLogger.writeErrorWithException("I/O Exception attemping to get ME3 install directory. Could be a settings file not writing: ", e);
+			ModManager.debugLogger.writeErrorWithException(
+					"I/O Exception attemping to get ME3 install directory. Could be a settings file not writing: ", e);
 		} catch (Throwable e) {
-			ModManager.debugLogger.writeErrorWithException("Error occured while attempting to get/set the biogame directory! Could be the JNA crash.", e);
+			ModManager.debugLogger.writeErrorWithException(
+					"Error occured while attempting to get/set the biogame directory! Could be the JNA crash.", e);
 			return "C:\\Program Files (x86)\\Origin Games\\Mass Effect 3\\BIOGame";
 		}
 		ModManager.debugLogger.writeMessage("Directory that was fetched: " + setDir);
@@ -2356,8 +2528,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 				if ((defaultsfarMainFileExists || patch001farMainFileExists) && !backFile.exists()) {
 					String YesNo[] = { "Yes", "No" }; // Yes/no buttons
-					int showDLCBackup = JOptionPane.showOptionDialog(null, "<html>" + job.getJobName() + " DLC has not been backed up.<br>Back it up now?</hmtl>", "Backup DLC",
-							JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
+					int showDLCBackup = JOptionPane.showOptionDialog(null, "<html>" + job.getJobName()
+							+ " DLC has not been backed up.<br>Back it up now?</hmtl>", "Backup DLC", JOptionPane.YES_NO_OPTION,
+							JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
 					if (showDLCBackup == 0) {
 						autoBackupDLC(fieldBiogameDir.getText(), job.getJobName());
 					}
@@ -2400,8 +2573,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				fieldDescription.setCaretPosition(0);
 				buttonApplyMod.setEnabled(true);
 				if (ModManager.NET_FRAMEWORK_IS_INSTALLED) {
-					buttonApplyMod.setToolTipText(
-							"<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
+					buttonApplyMod
+							.setToolTipText("<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
 				} else {
 					buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework 4.5 or higher in order to install mods");
 				}
@@ -2419,7 +2592,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					} else {
 						moddevUpdateXMLGenerator.setEnabled(true);
 						moddevUpdateXMLGenerator.setText("Prepare " + selectedMod.getModName() + " for ME3Tweaks Updater Service");
-						moddevUpdateXMLGenerator.setToolTipText("Compresses mod files for storage on ME3Tweaks and generates a mod manifest. Copies to clipboard when complete.");
+						moddevUpdateXMLGenerator
+								.setToolTipText("Compresses mod files for storage on ME3Tweaks and generates a mod manifest. Copies to clipboard when complete.");
 
 					}
 				} else {
@@ -2430,7 +2604,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					moddevUpdateXMLGenerator.setEnabled(false);
 					moddevUpdateXMLGenerator.setToolTipText(selectedMod.getModName() + " does not have a ME3Tweaks update code");
 					moddevUpdateXMLGenerator.setText("Cannot prepare " + selectedMod.getModName() + " for ME3Tweaks Updater Service");
-					modutilsCheckforupdate.setToolTipText("<html>Mod update eligibility requires a floating point version number<br>and an update code from ME3Tweaks</html>");
+					modutilsCheckforupdate
+							.setToolTipText("<html>Mod update eligibility requires a floating point version number<br>and an update code from ME3Tweaks</html>");
 				}
 
 				UrlValidator urlValidator = new UrlValidator(new String[] { "http", "https" });
@@ -2486,7 +2661,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					}
 
 					modDeltaMenu.addSeparator();
-					modDeltaMenu.setText(selectedMod.getModDeltas().size() + " available variant" + (selectedMod.getModDeltas().size() != 1 ? "s" : ""));
+					modDeltaMenu.setText(selectedMod.getModDeltas().size() + " available variant"
+							+ (selectedMod.getModDeltas().size() != 1 ? "s" : ""));
 					modDeltaMenu.setVisible(true);
 					modNoDeltas.setVisible(false);
 					for (ModDelta delta : selectedMod.getModDeltas()) {
@@ -2531,9 +2707,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					// Copy
 					String destFile = ModManager.appendSlash(bioGameDir) + "CookedPCConsole\\Coalesced.bin";
 					if (new File(destFile).exists() == false) {
-						JOptionPane.showMessageDialog(null,
-								"Coalesced.bin to be restored was not found in the specified BIOGame\\CookedPCConsole directory.\nYou must fix the directory before you can restore Coalesced.",
-								"Coalesced not found", JOptionPane.ERROR_MESSAGE);
+						JOptionPane
+								.showMessageDialog(
+										null,
+										"Coalesced.bin to be restored was not found in the specified BIOGame\\CookedPCConsole directory.\nYou must fix the directory before you can restore Coalesced.",
+										"Coalesced not found", JOptionPane.ERROR_MESSAGE);
 						labelStatus.setText("Coalesced.bin not restored");
 						labelStatus.setVisible(true);
 						return false;
@@ -2548,9 +2726,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				} else {
 					labelStatus.setText("Coalesced.bin not restored.");
 					labelStatus.setVisible(true);
-					JOptionPane.showMessageDialog(null,
-							"Your backed up original Coalesced.bin file does not match the known original from Mass Effect 3.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.",
-							"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
+					JOptionPane
+							.showMessageDialog(
+									null,
+									"Your backed up original Coalesced.bin file does not match the known original from Mass Effect 3.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.",
+									"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
 					return false;
 				}
 			} catch (Exception e) {
@@ -2562,9 +2742,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} else {
 			labelStatus.setText("Coalesced.bin not restored");
 			labelStatus.setVisible(true);
-			JOptionPane.showMessageDialog(null,
-					"The backed up Coalesced.bin file (data/Coalesced.original) does not exist.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.\n\nThis error should have been caught but can be thrown due to file system changes \nwhile the program is open.",
-					"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
+			JOptionPane
+					.showMessageDialog(
+							null,
+							"The backed up Coalesced.bin file (data/Coalesced.original) does not exist.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.\n\nThis error should have been caught but can be thrown due to file system changes \nwhile the program is open.",
+							"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
 
 		}
 		return false;
@@ -2588,8 +2770,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} else {
 			labelStatus.setText("Invalid BioGame Directory");
 			labelStatus.setVisible(true);
-			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid. Files cannot be restored.\nFix the directory and try again.", "Invalid BioGame Directory",
-					JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid. Files cannot be restored.\nFix the directory and try again.",
+					"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			return false;
 		}
 	}
@@ -2605,11 +2787,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			int minorBuildNum = EXEFileInfo.getMinorVersionOfProgram(executable.getAbsolutePath());
 			if (minorBuildNum > 5) {
 				ModManager.debugLogger.writeMessage("!!!!This user has >1.5 version of Mass Effect 3!!!!");
-				JOptionPane.showMessageDialog(this,
-						"<html><div style='width: 300px'>You have a version of Mass Effect 3 higher than 1.5 (1." + minorBuildNum
-								+ "), which is the main version most of the world uses.<br>"
-								+ "It seems BioWare has been slowly pushing this version out to some users starting in September 2013. Not all users will get this version.<br><br>If you encounter issues you may consider downgrading to the 1.5 EXE. If you play Multiplayer, you will only be able to connect to other 1.6 users, which are very few.<br>Check the ME3Tweaks forums for info on how to downgrade.</div></html>",
-						"Mass Effect 3 Rare Version Detected", JOptionPane.WARNING_MESSAGE);
+				JOptionPane
+						.showMessageDialog(
+								this,
+								"<html><div style='width: 300px'>You have a version of Mass Effect 3 higher than 1.5 (1."
+										+ minorBuildNum
+										+ "), which is the main version most of the world uses.<br>"
+										+ "It seems BioWare has been slowly pushing this version out to some users starting in September 2013. Not all users will get this version.<br><br>If you encounter issues you may consider downgrading to the 1.5 EXE. If you play Multiplayer, you will only be able to connect to other 1.6 users, which are very few.<br>Check the ME3Tweaks forums for info on how to downgrade.</div></html>",
+								"Mass Effect 3 Rare Version Detected", JOptionPane.WARNING_MESSAGE);
 			}
 		} catch (Exception e) {
 			//do nothing. Continue like the old mod manager did.
@@ -2634,9 +2819,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 		// check if the new one exists
 		if (!executable.exists()) {
-			JOptionPane.showMessageDialog(null,
-					"Unable to find game executable in the specified directory:\n" + executable.getAbsolutePath() + "\nMake sure your BIOGame directory is correct.",
-					"Unable to Launch Game", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null, "Unable to find game executable in the specified directory:\n" + executable.getAbsolutePath()
+					+ "\nMake sure your BIOGame directory is correct.", "Unable to Launch Game", JOptionPane.ERROR_MESSAGE);
 			return;
 		}
 		// Executable exists.
@@ -2685,9 +2869,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			return result;
 		}
-		JOptionPane.showMessageDialog(null,
-				"The BioGame directory is not valid.\nMod Manager cannot install the LauncherWV DLC bypass.\nFix the BioGame directory before continuing.",
-				"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+		JOptionPane
+				.showMessageDialog(
+						null,
+						"The BioGame directory is not valid.\nMod Manager cannot install the LauncherWV DLC bypass.\nFix the BioGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 		return false;
 	}
 
@@ -2702,8 +2888,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			return result;
 		}
-		JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot install Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
-				"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+		JOptionPane
+				.showMessageDialog(
+						null,
+						"The BioGame directory is not valid.\nMod Manager cannot install Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 		return false;
 	}
 
@@ -2718,9 +2907,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			return result;
 		}
-		JOptionPane.showMessageDialog(null,
-				"The BioGame directory is not valid.\nMod Manager cannot revert the Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
-				"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+		JOptionPane
+				.showMessageDialog(
+						null,
+						"The BioGame directory is not valid.\nMod Manager cannot revert the Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 		return false;
 	}
 

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -113,19 +113,17 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	JMenuBar menuBar;
 	JMenu actionMenu, modMenu, modManagementMenu, devMenu, modDeltaMenu, toolsMenu, backupMenu, restoreMenu, sqlMenu, helpMenu, openToolMenu;
 	JMenuItem actionExitDebugMode, actionModMaker, actionVisitMe, actionOptions, actionReload, actionExit;
-	JMenuItem modManagementImportFromArchive, modManagementImportAlreadyInstalled, modManagementConflictDetector, modManagementModMaker,
-			modManagementFailedMods, modManagementPatchLibary;
-	JMenuItem modutilsHeader, modutilsInfoEditor, modNoDeltas, modutilsVerifyDeltas, modutilsInstallCustomKeybinds, modutilsAutoTOC,
-			modutilsCheckforupdate, modutilsRestoreMod, modutilsDeleteMod;
-	JMenuItem toolME3Explorer, toolsOpenME3Dir, toolsInstallLauncherWV, toolsInstallBinkw32, toolsUninstallBinkw32, toolsMountdlcEditor,
-			toolsMergeMod, toolME3Config;
+	JMenuItem modManagementImportFromArchive, modManagementImportAlreadyInstalled, modManagementConflictDetector, modManagementModMaker, modManagementFailedMods,
+			modManagementPatchLibary;
+	JMenuItem modutilsHeader, modutilsInfoEditor, modNoDeltas, modutilsVerifyDeltas, modutilsInstallCustomKeybinds, modutilsAutoTOC, modutilsCheckforupdate, modutilsRestoreMod,
+			modutilsDeleteMod;
+	JMenuItem toolME3Explorer, toolsOpenME3Dir, toolsInstallLauncherWV, toolsInstallBinkw32, toolsUninstallBinkw32, toolsMountdlcEditor, toolsMergeMod, toolME3Config;
 	JMenuItem backupBackupDLC, backupCreateGDB;
-	JMenuItem restoreSelective, restoreRevertEverything, restoreDeleteUnpacked, restoreRevertBasegame, restoreRevertAllDLC, restoreRevertSPDLC,
-			restoreRevertMPDLC, restoreRevertMPBaseDLC, restoreRevertSPBaseDLC, restoreRevertCoal, restoreVanillifyDLC;
+	JMenuItem restoreSelective, restoreRevertEverything, restoreDeleteUnpacked, restoreRevertBasegame, restoreRevertAllDLC, restoreRevertSPDLC, restoreRevertMPDLC,
+			restoreRevertMPBaseDLC, restoreRevertSPBaseDLC, restoreRevertCoal, restoreVanillifyDLC;
 
 	JMenuItem modDevStarterKit;
-	JMenuItem sqlWavelistParser, sqlDifficultyParser, sqlAIWeaponParser, sqlPowerCustomActionParser, sqlPowerCustomActionParser2,
-			sqlConsumableParser, sqlGearParser;
+	JMenuItem sqlWavelistParser, sqlDifficultyParser, sqlAIWeaponParser, sqlPowerCustomActionParser, sqlPowerCustomActionParser2, sqlConsumableParser, sqlGearParser;
 	JList<Mod> modList;
 	JProgressBar progressBar;
 	ListSelectionModel listSelectionModel;
@@ -177,14 +175,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} catch (Exception e) {
 			ModManager.debugLogger.writeErrorWithException("UNKNOWN CRITICAL STARTUP EXCEPTION FOR MOD MANAGER WINDOW:", e);
 			ModManager.debugLogger.writeError("Mod Manager has crashed!");
-			JOptionPane
-					.showMessageDialog(
-							null,
-							"<html><div style=\"width:330px;\">Mod Manager's interface (post-startup) encountered a critical unknown error and was unable to start:<br>"
-									+ e.getMessage()
-									+ "<br>"
-									+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>Please report this to femshep.</div></html>",
-							"Critical Error", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null,
+					"<html><div style=\"width:330px;\">Mod Manager's interface (post-startup) encountered a critical unknown error and was unable to start:<br>" + e.getMessage()
+							+ "<br>"
+							+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>Please report this to femshep.</div></html>",
+					"Critical Error", JOptionPane.ERROR_MESSAGE);
 			return;
 		}
 		validateBIOGameDir();
@@ -197,14 +192,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} catch (Exception e) {
 				ModManager.debugLogger.writeErrorWithException("Uncaught runtime exception:", e);
 				ModManager.debugLogger.writeError("Mod Manager hit exception!");
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"<html><div style=\"width:330px;\">Mod Manager's interface has just encountered an error<br>"
-										+ e.getMessage()
-										+ "<br>"
-										+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>The application will attempt to ignore this error.</div></html>",
-								"Mod Manager Error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"<html><div style=\"width:330px;\">Mod Manager's interface has just encountered an error<br>" + e.getMessage() + "<br>"
+								+ "<br>This has been logged to the me3cmm_last_run_log.txt file if you didn't explicitly turn logging off.<br>The application will attempt to ignore this error.</div></html>",
+						"Mod Manager Error", JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}
@@ -243,8 +234,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		this.pack();
 		setLocationRelativeTo(null);
 		if (isUpdate) {
-			JOptionPane.showMessageDialog(this, "Update successful: Updated to Mod Manager " + ModManager.VERSION + " (Build "
-					+ ModManager.BUILD_NUMBER + ").", "Update Complete", JOptionPane.INFORMATION_MESSAGE);
+			JOptionPane.showMessageDialog(this, "Update successful: Updated to Mod Manager " + ModManager.VERSION + " (Build " + ModManager.BUILD_NUMBER + ").", "Update Complete",
+					JOptionPane.INFORMATION_MESSAGE);
 		}
 
 		//clear pending updates (done via sideload update)
@@ -386,35 +377,30 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			String me3explorer = ModManager.getME3ExplorerEXEDirectory(false) + "ME3Explorer.exe";
 			File f = new File(me3explorer);
 			if (!f.exists()) {
-				ModManager.debugLogger.writeMessage("ME3Explorer is missing. Downloading from ME3TWeaks.");
+				ModManager.debugLogger.writeMessage("ME3Explorer is missing. Downloading from ME3Tweaks.");
 				if (ModManager.AUTO_UPDATE_ME3EXPLORER) {
 					new ME3ExplorerUpdaterWindow(ModManagerWindow.this);
 				} else {
 					ModManager.debugLogger.writeError("ME3Explorer missing but cannot download due to settings!");
-					JOptionPane
-							.showMessageDialog(
-									ModManagerWindow.this,
-									"ME3Explorer is missing from data/ME3Explorer.\nMod Manager requires ME3Explorer but you have auto updates for it turned off.\nIf there are errors in this session, they are not supported by FemShep.",
-									"Missing ME3Explorer", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(ModManagerWindow.this,
+							"ME3Explorer is missing from data/ME3Explorer.\nMod Manager requires ME3Explorer but you have auto updates for it turned off.\nIf there are errors in this session, they are not supported by FemShep.",
+							"Missing ME3Explorer", JOptionPane.ERROR_MESSAGE);
 				}
 			} else {
 				int main = EXEFileInfo.getMajorVersionOfProgram(me3explorer);
 				int rev = EXEFileInfo.getBuildOfProgram(me3explorer);
 				ModManager.debugLogger.writeMessage("ME3Explorer Version: " + Arrays.toString(EXEFileInfo.getVersionInfo(me3explorer)));
-				if (main < ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN || main == ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN
-						&& rev < ModManager.MIN_REQUIRED_ME3EXPLORER_REV) {
+				if (main < ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN || main == ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN && rev < ModManager.MIN_REQUIRED_ME3EXPLORER_REV) {
 					//we must update it
-					ModManager.debugLogger.writeMessage("ME3Explorer is outdated, local:" + main + "." + rev + ", required"
-							+ ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN + "." + ModManager.MIN_REQUIRED_ME3EXPLORER_REV + "+");
+					ModManager.debugLogger.writeMessage("ME3Explorer is outdated, local:" + main + "." + rev + ", required" + ModManager.MIN_REQUIRED_ME3EXPLORER_MAIN + "."
+							+ ModManager.MIN_REQUIRED_ME3EXPLORER_REV + "+");
 					if (ModManager.AUTO_UPDATE_ME3EXPLORER) {
 						new ME3ExplorerUpdaterWindow(ModManagerWindow.this);
 					} else {
 						ModManager.debugLogger.writeError("ME3Explorer outdated but cannot download due to settings!");
-						JOptionPane
-								.showMessageDialog(
-										ModManagerWindow.this,
-										"Mod Manager requires a newer version of ME3Explorer for this build.\nYou have auto updates for it turned off. You will need to turn them back on to download this update.\nIf there are errors in this session, they are not supported by FemShep.",
-										"ME3Explorer Outdated", JOptionPane.ERROR_MESSAGE);
+						JOptionPane.showMessageDialog(ModManagerWindow.this,
+								"Mod Manager requires a newer version of ME3Explorer for this build.\nYou have auto updates for it turned off. You will need to turn them back on to download this update.\nIf there are errors in this session, they are not supported by FemShep.",
+								"ME3Explorer Outdated", JOptionPane.ERROR_MESSAGE);
 					}
 				} else {
 					ModManager.debugLogger.writeMessage("Current ME3Explorer version satisfies requirements for Mod Manager");
@@ -425,11 +411,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		private void checkForModUpdates() {
 			//Check for updates
 			if (ModManager.AUTO_UPDATE_MODS || forceUpdateOnReloadList.size() > 0) {
-				if (System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK > ModManager.AUTO_CHECK_INTERVAL_MS
-						|| forceUpdateOnReloadList.size() > 0) {
+				if (System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK > ModManager.AUTO_CHECK_INTERVAL_MS || forceUpdateOnReloadList.size() > 0) {
 					ModManager.debugLogger.writeMessage("Running auto-updater, it has been "
-							+ ModManager.getDurationBreakdown(System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK)
-							+ " since the last help/mods update check.");
+							+ ModManager.getDurationBreakdown(System.currentTimeMillis() - ModManager.LAST_AUTOUPDATE_CHECK) + " since the last help/mods update check.");
 					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading latest help information"));
 					HelpMenu.getOnlineHelp();
 					publish(new ThreadCommand("UPDATE_HELP_MENU"));
@@ -480,7 +464,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				if (ModManager.IS_DEBUG) {
 					update_check_link = "http://webdev-c9-mgamerz.c9.io/modmanager/updatecheck?currentversion=" + ModManager.BUILD_NUMBER;
 				} else {
-					update_check_link = "https://me3tweaks.com/modmanager/updatecheck-testing?currentversion=" + ModManager.BUILD_NUMBER;
+					update_check_link = "https://me3tweaks.com/modmanager/updatecheck?currentversion=" + ModManager.BUILD_NUMBER;
 				}
 				String serverJSON = null;
 				try {
@@ -542,8 +526,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					return null;
 				}
 
-				ModManager.debugLogger.writeMessage("Update check: Local:" + ModManager.BUILD_NUMBER + " Latest: " + latest_build + ", is less? "
-						+ (ModManager.BUILD_NUMBER < latest_build));
+				ModManager.debugLogger
+						.writeMessage("Update check: Local:" + ModManager.BUILD_NUMBER + " Latest: " + latest_build + ", is less? " + (ModManager.BUILD_NUMBER < latest_build));
 
 				boolean showUpdate = true;
 				// make sure the user hasn't declined this one.
@@ -566,16 +550,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 								showUpdate = false;
 							}
 						} catch (NumberFormatException e) {
-							ModManager.debugLogger
-									.writeMessage("Number format exception reading the build number updateon in the ini. Showing the dialog.");
+							ModManager.debugLogger.writeMessage("Number format exception reading the build number updateon in the ini. Showing the dialog.");
 						}
 					}
 				} catch (InvalidFileFormatException e) {
 					ModManager.debugLogger.writeErrorWithException("Invalid INI! Did the user modify it by hand?", e);
 					e.printStackTrace();
 				} catch (IOException e) {
-					ModManager.debugLogger
-							.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting stored to disk.");
+					ModManager.debugLogger.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting stored to disk.");
 				}
 
 				if (showUpdate) {
@@ -606,55 +588,55 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			Object obj = serversJSON.get("latest_guitransplanter");
 			long latestGUITransplanter = ModManager.MIN_REQUIRED_ME3GUITRANSPLANTER_BUILD;
 			if (obj != null) {
-				if (obj instanceof Long) {
-					latestGUITransplanter = (long) obj;
-					String cliPath = ModManager.getGUITransplanterCLI(false);
-					//update GUI Transplanter
-					File cli = new File(cliPath);
-					if (cli.exists()) {
-						ModManager.debugLogger.writeMessage("Checking for updates for GUI Transplanter");
-						int build = EXEFileInfo.getRevisionOfProgram(cliPath);
-						if (build < latestGUITransplanter) {
-							//download
-							publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading update for GUI Transplanter"));
-							ModManager.debugLogger.writeMessage("GUI Transplanter is out of date from server. Local " + build + " vs server "
-									+ latestGUITransplanter);
-							File transplanterFolder = cli.getParentFile();
-							FileUtils.deleteQuietly(transplanterFolder);
-							ModManager.debugLogger.writeMessage("Downloading new GUI Transplanter");
-							String newcli = ModManager.getGUITransplanterCLI(true);
-							if (newcli != null) {
-								int newbuild = EXEFileInfo.getRevisionOfProgram(cliPath);
-								if (newbuild == latestGUITransplanter) {
-									ModManager.debugLogger.writeMessage("Downloaded latest GUI Transplanter build: " + newbuild);
-									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated GUI Transplanter"));
-								} else {
-									ModManager.debugLogger.writeError("Failed to download proper updated build. Instead we downloaded: " + newbuild);
-									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Transplanter"));
-								}
+				latestGUITransplanter = Long.parseLong((String) obj);
+				String cliPath = ModManager.getGUITransplanterCLI(false);
+				//update GUI Transplanter
+				File cli = new File(cliPath);
+				if (cli.exists()) {
+					ModManager.debugLogger.writeMessage("Checking for updates for GUI Transplanter.");
+					int build = EXEFileInfo.getRevisionOfProgram(cliPath);
+					ModManager.debugLogger.writeMessage("The local build of GUI Transplanter is currently 1.0.0." + build + ".");
+					if (build < latestGUITransplanter) {
+						//download
+						publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading update for GUI Transplanter"));
+						ModManager.debugLogger.writeMessage("GUI Transplanter is out of date from server. Local " + build + " vs server " + latestGUITransplanter);
+						File transplanterFolder = cli.getParentFile();
+						FileUtils.deleteQuietly(transplanterFolder);
+						ModManager.debugLogger.writeMessage("Downloading new GUI Transplanter");
+						String newcli = ModManager.getGUITransplanterCLI(true);
+						if (newcli != null) {
+							int newbuild = EXEFileInfo.getRevisionOfProgram(cliPath);
+							if (newbuild == latestGUITransplanter) {
+								ModManager.debugLogger.writeMessage("Downloaded latest GUI Transplanter build: " + newbuild);
+								publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated GUI Transplanter"));
 							} else {
-								ModManager.debugLogger.writeError("Failed to download GUI Transplanter");
+								ModManager.debugLogger.writeError("Failed to download proper updated build. Instead we downloaded: " + newbuild);
 								publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Transplanter"));
 							}
 						} else {
-							ModManager.debugLogger.writeMessage("GUI Transplanter is up to date (1.0.0." + build + ")");
+							ModManager.debugLogger.writeError("Failed to download GUI Transplanter");
+							publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Transplanter"));
 						}
 					} else {
-						ModManager.debugLogger.writeMessage("No GUI Transplanter tool downloaded, skipping update check for it");
+						ModManager.debugLogger.writeMessage("GUI Transplanter is up to date (1.0.0." + build + ")");
 					}
+				} else {
+					ModManager.debugLogger.writeMessage("No GUI Transplanter tool downloaded, skipping update check for it");
 				}
 			}
 
 			String uiLibPath = ModManager.getGUILibraryFor("DLC_CON_UIScaling", false);
 			{
 				File uiLibVersionFile = new File(uiLibPath + "libraryversion.txt");
+				ModManager.debugLogger.writeMessage("Checking for UISCALING GUI library version file at " + uiLibVersionFile);
 				if (uiLibVersionFile.exists()) {
 					try {
 						String uilibverstr = FileUtils.readFileToString(uiLibVersionFile);
 						double libver = Double.parseDouble(uilibverstr);
+						ModManager.debugLogger.writeMessage("Local UISCALING library version: " + libver);
 						obj = serversJSON.get("latest_uiscaling_guilibrary");
 						if (obj != null) {
-							double serverver = (double) obj;
+							double serverver = Double.parseDouble((String) obj);
 							if (libver < serverver) {
 								ModManager.debugLogger.writeMessage("UIScaling Library is out of date, updating...");
 								FileUtils.deleteQuietly(new File(uiLibPath));
@@ -667,11 +649,12 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 										ModManager.debugLogger.writeMessage("Downloaded latest Interface Scaling Mod GUI Library: " + newlibver);
 										publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated Interface Scaling Mod GUI library"));
 									} else {
-										ModManager.debugLogger.writeError("Failed to download proper updated GUI Library. Instead we downloaded: "
-												+ newlibver);
+										ModManager.debugLogger.writeError("Failed to download proper updated GUI Library. Instead we downloaded: " + newlibver);
 										publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Library"));
 									}
 								}
+							} else {
+								ModManager.debugLogger.writeMessage("Local UISCALING library is up to date");
 							}
 						}
 					} catch (IOException e) {
@@ -685,14 +668,16 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 
 			String xbxLibPath = ModManager.getGUILibraryFor("DLC_CON_XBX", false);
-			File xbxLibVersionFile = new File(uiLibPath + "libraryversion.txt");
+			File xbxLibVersionFile = new File(xbxLibPath + "libraryversion.txt");
+			ModManager.debugLogger.writeMessage("Checking for XBX GUI library version file at " + xbxLibVersionFile);
 			if (xbxLibVersionFile.exists()) {
 				try {
 					String xbxlibverstr = FileUtils.readFileToString(xbxLibVersionFile);
 					double libver = Double.parseDouble(xbxlibverstr);
+					ModManager.debugLogger.writeMessage("Local XBX library version: " + libver);
 					obj = serversJSON.get("latest_xbx_guilibrary");
 					if (obj != null) {
-						double serverver = (double) obj;
+						double serverver = Double.parseDouble((String) obj);
 						if (libver < serverver) {
 							ModManager.debugLogger.writeMessage("XBX Library is out of date, updating...");
 							FileUtils.deleteQuietly(new File(uiLibPath));
@@ -705,11 +690,12 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 									ModManager.debugLogger.writeMessage("Downloaded latest SP Controller Support GUI Library: " + newlibver);
 									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated SP Controller Support GUI library"));
 								} else {
-									ModManager.debugLogger.writeError("Failed to download proper updated GUI Library. Instead we downloaded: "
-											+ newlibver);
+									ModManager.debugLogger.writeError("Failed to download proper updated GUI Library. Instead we downloaded: " + newlibver);
 									publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Failed to download new GUI Library"));
 								}
 							}
+						} else {
+							ModManager.debugLogger.writeMessage("Local XBX library is up to date");
 						}
 					}
 				} catch (IOException e) {
@@ -756,18 +742,17 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				if (latest instanceof UpdatePackage) {
 					UpdatePackage upackage = (UpdatePackage) latest;
 					if (upackage.requiresSideload()) {
-						JOptionPane
-								.showMessageDialog(
-										ModManagerWindow.this,
-										upackage.getMod().getModName()
-												+ " has an update available from ME3Tweaks, but requires a sideloaded update first.\nAfter this dialog is closed, a browser window will open where you can download this sideload update.\nDrag and drop this downloaded file onto Mod Manager to install it.\nAfter the sideloaded update is complete, Mod Manager will download the rest of the update.\n\nThis is to save on bandwidth costs for both ME3Tweaks and the developer of "
-												+ upackage.getMod().getModName() + ".", "Sideload update required", JOptionPane.WARNING_MESSAGE);
+						JOptionPane.showMessageDialog(ModManagerWindow.this,
+								upackage.getMod().getModName()
+										+ " has an update available from ME3Tweaks, but requires a sideloaded update first.\nAfter this dialog is closed, a browser window will open where you can download this sideload update.\nDrag and drop this downloaded file onto Mod Manager to install it.\nAfter the sideloaded update is complete, Mod Manager will download the rest of the update.\n\nThis is to save on bandwidth costs for both ME3Tweaks and the developer of "
+										+ upackage.getMod().getModName() + ".",
+								"Sideload update required", JOptionPane.WARNING_MESSAGE);
 						try {
 							ModManager.openWebpage(new URL(upackage.getSideloadURL()));
 						} catch (MalformedURLException e) {
 							ModManager.debugLogger.writeError("Invalid sideload URL: " + upackage.getSideloadURL());
-							JOptionPane.showMessageDialog(ModManagerWindow.this, upackage.getMod().getModName()
-									+ " specified an invalid URL for it's sideload upload:\n" + upackage.getSideloadURL(), "Invalid Sideload URL",
+							JOptionPane.showMessageDialog(ModManagerWindow.this,
+									upackage.getMod().getModName() + " specified an invalid URL for it's sideload upload:\n" + upackage.getSideloadURL(), "Invalid Sideload URL",
 									JOptionPane.ERROR_MESSAGE);
 						}
 					} else {
@@ -775,8 +760,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 						updatetext += AllModsUpdateWindow.getVersionUpdateString(upackage);
 
 						updatetext += "Update this mod?";
-						int result = JOptionPane.showConfirmDialog(ModManagerWindow.this, updatetext, "Mod update available",
-								JOptionPane.YES_NO_OPTION);
+						int result = JOptionPane.showConfirmDialog(ModManagerWindow.this, updatetext, "Mod update available", JOptionPane.YES_NO_OPTION);
 						if (result == JOptionPane.YES_OPTION) {
 							ModManager.debugLogger.writeMessage("Starting manual single-mod updater");
 							ModUpdateWindow muw = new ModUpdateWindow(upackage);
@@ -795,6 +779,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				ModManager.debugLogger.writeErrorWithException("Exception in the single mod update thread: ", e);
 			}
 		}
+
 	}
 
 	/**
@@ -893,13 +878,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 		// Title Panel
 		JPanel titlePanel = new JPanel(new BorderLayout());
-		titlePanel.add(new JLabel("Mass Effect 3 Mod Manager " + ModManager.VERSION + (ModManager.IS_DEBUG ? " [DEBUG MODE]" : ""),
-				SwingConstants.LEFT), BorderLayout.WEST);
+		titlePanel.add(new JLabel("Mass Effect 3 Mod Manager " + ModManager.VERSION + (ModManager.IS_DEBUG ? " [DEBUG MODE]" : ""), SwingConstants.LEFT), BorderLayout.WEST);
 
 		// BioGameDir Panel
 		cookedDirPanel = new JPanel(new BorderLayout());
-		TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
-				"Mass Effect 3 BIOGame Directory");
+		TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Mass Effect 3 BIOGame Directory");
 		fieldBiogameDir = new JTextField();
 		fieldBiogameDir.setText(getInitialBiogameDirText());
 		fieldBiogameDir.addFocusListener(new FocusListener() {
@@ -916,8 +899,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 		});
 		buttonBioGameDir = new JButton("Browse...");
-		buttonBioGameDir
-				.setToolTipText("<html>Browse and set the BIOGame directory.<br>This is located in the installation directory for Mass Effect 3.<br>Typically this is in the Origin Games folder.</html>");
+		buttonBioGameDir.setToolTipText(
+				"<html>Browse and set the BIOGame directory.<br>This is located in the installation directory for Mass Effect 3.<br>Typically this is in the Origin Games folder.</html>");
 		fieldBiogameDir.setColumns(37);
 		buttonBioGameDir.setPreferredSize(new Dimension(90, 14));
 
@@ -942,8 +925,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		JScrollPane listScroller = new JScrollPane(modList, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 
 		modlistFailedIndicatorLink = new JButton();
-		modlistFailedIndicatorLink.setText("<HTML><font color=#ff2020><u>" + invalidMods.size() + " mod" + (invalidMods.size() != 1 ? "s" : "")
-				+ " failed to load</u></font></HTML>");
+		modlistFailedIndicatorLink
+				.setText("<HTML><font color=#ff2020><u>" + invalidMods.size() + " mod" + (invalidMods.size() != 1 ? "s" : "") + " failed to load</u></font></HTML>");
 		modlistFailedIndicatorLink.setBorderPainted(false);
 		modlistFailedIndicatorLink.setBackground(UIManager.getColor("Panel.background"));
 		modlistFailedIndicatorLink.setFocusPainted(false);
@@ -1038,8 +1021,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		}
 		buttonStartGame = new JButton("Start Game");
 		buttonStartGame.addActionListener(this);
-		buttonStartGame
-				.setToolTipText("<html>Starts the game.<br>If LauncherWV DLC bypass is installed, it will launch instead to patch out the DLC verifiction test.<br>The game will then start.</html>");
+		buttonStartGame.setToolTipText(
+				"<html>Starts the game.<br>If LauncherWV DLC bypass is installed, it will launch instead to patch out the DLC verifiction test.<br>The game will then start.</html>");
 
 		buttonPanel.add(buttonApplyMod);
 		buttonPanel.add(buttonStartGame);
@@ -1065,8 +1048,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			if (modList.getSelectedIndex() == -1) {
 				buttonApplyMod.setToolTipText("Select a mod on the left");
 			} else {
-				buttonApplyMod
-						.setToolTipText("<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
+				buttonApplyMod.setToolTipText(
+						"<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
 
 			}
 		} else {
@@ -1090,11 +1073,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 		JMenu actionImportMenu = new JMenu("Import mod");
 		modManagementImportAlreadyInstalled = new JMenuItem("Import installed Custom DLC mod");
-		modManagementImportAlreadyInstalled
-				.setToolTipText("<html>Import an already installed DLC mod.<br>You can then manage that mod with Mod Manager.</html>");
+		modManagementImportAlreadyInstalled.setToolTipText("<html>Import an already installed DLC mod.<br>You can then manage that mod with Mod Manager.</html>");
 		modManagementImportFromArchive = new JMenuItem("Import mod from .7z/.rar/.zip");
-		modManagementImportFromArchive
-				.setToolTipText("<html>Import a mod that has been packaged for importing into Mod Manager.<br>For directions on how to make mods in this format, please see the Mod Manager moddesc page.</html>");
+		modManagementImportFromArchive.setToolTipText(
+				"<html>Import a mod that has been packaged for importing into Mod Manager.<br>For directions on how to make mods in this format, please see the Mod Manager moddesc page.</html>");
 
 		actionOptions = new JMenuItem("Options");
 		actionOptions.setToolTipText("Configure Mod Manager Options");
@@ -1108,8 +1090,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolTankmasterTLK = new JMenuItem("TankMaster ME2/ME3 TLK Tool");
 		toolTankmasterTLK.setToolTipText("Runs the bundled TLK tool provided by TankMaster");
 		toolsAutoTOCGame = new JMenuItem("Run AutoTOC on game");
-		toolsAutoTOCGame
-				.setToolTipText("<html>Updates TOC files for basegame, DLC (unpacked and modified SFAR), and custom DLC.<br>May help fix infinite loading issues</html>");
+		toolsAutoTOCGame.setToolTipText("<html>Updates TOC files for basegame, DLC (unpacked and modified SFAR), and custom DLC.<br>May help fix infinite loading issues</html>");
 
 		actionReload = new JMenuItem("Reload Mod Manager");
 		actionReload.setToolTipText("Reloads Mod Manager to refresh mods, mixins, and help documentation");
@@ -1141,8 +1122,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modManagementConflictDetector = new JMenuItem("Custom DLC Conflict Detector");
 		modManagementConflictDetector.setToolTipText("Scans installed custom DLC for file conflicts that may prevent them from working correctly");
 		modManagementCheckallmodsforupdate = new JMenuItem("Check eligible mods for updates");
-		modManagementCheckallmodsforupdate
-				.setToolTipText("Checks eligible mods for updates on ME3Tweaks and prompts to download an update if one is available");
+		modManagementCheckallmodsforupdate.setToolTipText("Checks eligible mods for updates on ME3Tweaks and prompts to download an update if one is available");
 		modManagementPatchLibary = new JMenuItem("MixIn Library");
 		modManagementPatchLibary.setToolTipText("Add premade mixins to mods using patches in your patch library");
 		modManagementOpenModsFolder = new JMenuItem("Open mods/ folder");
@@ -1184,8 +1164,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		if (!checkForKeybindsOverride()) {
 			ModManager.debugLogger.writeMessage("No keybinds file in the override directory (bioinput.xml)");
 			modutilsInstallCustomKeybinds.setEnabled(false);
-			modutilsInstallCustomKeybinds
-					.setToolTipText("<html>To enable installing custom keybinds put a<br>BioInput.xml file in the data/override/ directory.</html>");
+			modutilsInstallCustomKeybinds.setToolTipText("<html>To enable installing custom keybinds put a<br>BioInput.xml file in the data/override/ directory.</html>");
 		} else {
 			ModManager.debugLogger.writeMessage("Found keybinds file in the override directory (bioinput.xml)");
 			modutilsInstallCustomKeybinds.setToolTipText("<html>Replace BioInput.xml in the BASEGAME Coalesced file</html>");
@@ -1200,13 +1179,12 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modutilsInfoEditor.setToolTipText("Rename this mod and change the description shown in the descriptions window");
 
 		modDeltaMenu = new JMenu("0 available variants");
-		modDeltaMenu
-				.setToolTipText("<html>This mod has variants that allow quick changes to the mod without shipping a full new version.<br>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
+		modDeltaMenu.setToolTipText(
+				"<html>This mod has variants that allow quick changes to the mod without shipping a full new version.<br>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
 		modDeltaMenu.setVisible(false);
 
 		modNoDeltas = new JMenuItem("No included variants");
-		modNoDeltas
-				.setToolTipText("<html>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
+		modNoDeltas.setToolTipText("<html>Variants are Coalesced patches that can make small changes like turning on motion blur.<br>See the FAQ on how to create them.</html>");
 		modNoDeltas.setEnabled(false);
 
 		modutilsVerifyDeltas = new JMenuItem("Verify variants");
@@ -1259,11 +1237,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolsOpenME3Dir.setToolTipText("Opens a Windows Explorer window in the BIOGame Directory");
 
 		toolsInstallLauncherWV = new JMenuItem("Install LauncherWV DLC Bypass");
-		toolsInstallLauncherWV
-				.setToolTipText("<html>Installs an in-memory patcher giving you console and allowing modified DLC.<br>This does not does not modify files</html>");
+		toolsInstallLauncherWV.setToolTipText("<html>Installs an in-memory patcher giving you console and allowing modified DLC.<br>This does not does not modify files</html>");
 		toolsInstallBinkw32 = new JMenuItem("Install Binkw32 DLC Bypass");
-		toolsInstallBinkw32
-				.setToolTipText("<html>Installs a startup patcher giving you console and allowing modified DLC.<br>This modifies your game and is erased when doing an Origin Repair</html>");
+		toolsInstallBinkw32.setToolTipText(
+				"<html>Installs a startup patcher giving you console and allowing modified DLC.<br>This modifies your game and is erased when doing an Origin Repair</html>");
 		toolsUninstallBinkw32 = new JMenuItem("Uninstall Binkw32 DLC Bypass");
 		toolsUninstallBinkw32.setToolTipText("<html>Removes the Binkw32.dll startup patcher, reverting the original file</html>");
 
@@ -1274,8 +1251,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolsMountdlcEditor.setToolTipText("Allows you to modify or create new Mount.dlc files easily");
 
 		toolME3Config = new JMenuItem("ME3 Config Tool");
-		toolME3Config
-				.setToolTipText("<html>Opens the ME3 Configuration Utility that comes packaged with the game.<br>Lets you configure graphics and audio settings.</html>");
+		toolME3Config.setToolTipText("<html>Opens the ME3 Configuration Utility that comes packaged with the game.<br>Lets you configure graphics and audio settings.</html>");
 
 		toolsAutoTOCGame.addActionListener(this);
 		modManagementModMaker.addActionListener(this);
@@ -1326,16 +1302,13 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		backupMenu = new JMenu("Backup");
 
 		backupBackupDLC = new JMenuItem("Backup DLCs");
-		backupBackupDLC
-				.setToolTipText("Backs up your DLC to .bak files. When installing a mod it will ask if a .bak files does not exist if you want to backup");
+		backupBackupDLC.setToolTipText("Backs up your DLC to .bak files. When installing a mod it will ask if a .bak files does not exist if you want to backup");
 
 		backupBasegameUnpacked = new JMenuItem("Backup basegame/unpacked files");
-		backupBasegameUnpacked
-				.setToolTipText("An Unpacked and basegame file will be automatically backed up when Mod Manager replaces or removes that file");
+		backupBasegameUnpacked.setToolTipText("An Unpacked and basegame file will be automatically backed up when Mod Manager replaces or removes that file");
 
 		backupCreateGDB = new JMenuItem("Update game repair database");
-		backupCreateGDB
-				.setToolTipText("Creates/updates a database of checksums for basegame and unpacked DLC files for verifying restoring and backing up");
+		backupCreateGDB.setToolTipText("Creates/updates a database of checksums for basegame and unpacked DLC files for verifying restoring and backing up");
 
 		backupBackupDLC.addActionListener(this);
 		backupBasegameUnpacked.addActionListener(this);
@@ -1354,8 +1327,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreSelective.setToolTipText("Allows you to restore specific basegame, DLC, and unpacked files");
 
 		restoreRevertEverything = new JMenuItem("Restore everything");
-		restoreRevertEverything
-				.setToolTipText("<html>Restores all basegame files, deletes unpacked DLC files, and restores all SFAR files.<br>This will delete any non standard DLC folders.</html>");
+		restoreRevertEverything.setToolTipText(
+				"<html>Restores all basegame files, deletes unpacked DLC files, and restores all SFAR files.<br>This will delete any non standard DLC folders.</html>");
 
 		restoreDeleteUnpacked = new JMenuItem("Delete all unpacked DLC files");
 		restoreDeleteUnpacked
@@ -1377,8 +1350,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreRevertUnpacked.setToolTipText("<html>Restores all unpacked DLC files that have been modified by installing mods</html>");
 
 		restoreRevertBasegameUnpacked = new JMenuItem("Restore basegame + unpacked files");
-		restoreRevertBasegameUnpacked
-				.setToolTipText("<html>Restores all basegame and unpacked DLC files that have been modified by installing mods</html>");
+		restoreRevertBasegameUnpacked.setToolTipText("<html>Restores all basegame and unpacked DLC files that have been modified by installing mods</html>");
 
 		restoreVanillifyDLC = new JMenuItem("Vanillify game DLC");
 		restoreVanillifyDLC.setToolTipText("<html>Removes custom DLC, deletes unpacked files, restores SFARs.</html>");
@@ -1390,15 +1362,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		restoreRevertSPDLC.setToolTipText("<html>Restores all SP DLCs.<br>This does not remove custom DLC modules.</html>");
 
 		restoreRevertSPBaseDLC = new JMenuItem("Restore SP DLC SFARs + Basegame");
-		restoreRevertSPBaseDLC
-				.setToolTipText("<html>Restores all basegame files, and checks all SP DLC SFAR files.<br>This does not remove custom DLC modules.</html>");
+		restoreRevertSPBaseDLC.setToolTipText("<html>Restores all basegame files, and checks all SP DLC SFAR files.<br>This does not remove custom DLC modules.</html>");
 
 		restoreRevertMPDLC = new JMenuItem("Restore MP DLC SFARs");
 		restoreRevertMPDLC.setToolTipText("<html>Restores all MP DLC SFARs.<br>This does not remove custom DLC modules.</html>");
 
 		restoreRevertMPBaseDLC = new JMenuItem("Restore MP DLC SFARs + Basegame");
-		restoreRevertMPBaseDLC
-				.setToolTipText("<html>Restores all basegame files, and checks all Multiplayer DLC files.<br>This does not remove custom DLC modules.<br>If you are doing multiplayer mods, you should use this to restore</html>");
+		restoreRevertMPBaseDLC.setToolTipText(
+				"<html>Restores all basegame files, and checks all Multiplayer DLC files.<br>This does not remove custom DLC modules.<br>If you are doing multiplayer mods, you should use this to restore</html>");
 		restoreRevertCoal = new JMenuItem("Restore vanilla Coalesced.bin");
 		restoreRevertCoal.setToolTipText("<html>Restores the basegame coalesced file</html>");
 
@@ -1514,8 +1485,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				dirChooser.setCurrentDirectory(new File(fieldBiogameDir.getText()));
 			} else {
 				if (ModManager.logging) {
-					ModManager.debugLogger.writeMessage("Directory " + fieldBiogameDir.getText()
-							+ " does not exist, defaulting to working directory.");
+					ModManager.debugLogger.writeMessage("Directory " + fieldBiogameDir.getText() + " does not exist, defaulting to working directory.");
 				}
 				dirChooser.setCurrentDirectory(new java.io.File("."));
 			}
@@ -1549,8 +1519,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("ModMaker requires valid BIOGame directory to start");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 
 			}
 		} else if (e.getSource() == modManagementConflictDetector) {
@@ -1568,8 +1538,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Conflict detector requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modManagementFailedMods) {
 			new FailedModsWindow();
@@ -1579,8 +1549,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Backing up DLC requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1588,31 +1558,26 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			if (validateBIOGameDir()) {
 				String me3dir = (new File(fieldBiogameDir.getText())).getParent();
 				String backupLocation = ModManager.appendSlash(me3dir) + "cmmbackup";
-				JOptionPane
-						.showMessageDialog(
-								this,
-								"<html><div style=\"width:330px;\">Basegame and unpacked DLC files are automatically backed up by Mod Manager when a Mod Manager mod replaces or removes that file while being applied.<br>"
-										+ "The game repair database verifies the file being backed up matches the metadata in the database so it can restore back to that version later. When restoring, the backed up file is checked again to make sure it wasn't modified. Otherwise you may restore files of different sizes and the game will crash.<br>"
-										+ "This is why modifications outside of Mod Manager are not backed up and are not supported. If you want to use modifications outside of Mod Manager, update the game repair database after you make your changes outside of Mod Manager. Make sure your game is in a working state before you do this or you will restore to a broken snapshot.<br><br>"
-										+ "The backup files created by Mod Manager are placed in the following folder:<br>"
-										+ backupLocation
-										+ "<br><br>MixIns do not support modified files except for those modified by other non-finalizing MixIns.</div></html>",
-								"Backup of basegame/unpacked files", JOptionPane.INFORMATION_MESSAGE);
+				JOptionPane.showMessageDialog(this,
+						"<html><div style=\"width:330px;\">Basegame and unpacked DLC files are automatically backed up by Mod Manager when a Mod Manager mod replaces or removes that file while being applied.<br>"
+								+ "The game repair database verifies the file being backed up matches the metadata in the database so it can restore back to that version later. When restoring, the backed up file is checked again to make sure it wasn't modified. Otherwise you may restore files of different sizes and the game will crash.<br>"
+								+ "This is why modifications outside of Mod Manager are not backed up and are not supported. If you want to use modifications outside of Mod Manager, update the game repair database after you make your changes outside of Mod Manager. Make sure your game is in a working state before you do this or you will restore to a broken snapshot.<br><br>"
+								+ "The backup files created by Mod Manager are placed in the following folder:<br>" + backupLocation
+								+ "<br><br>MixIns do not support modified files except for those modified by other non-finalizing MixIns.</div></html>",
+						"Backup of basegame/unpacked files", JOptionPane.INFORMATION_MESSAGE);
 			} else {
 				labelStatus.setText("ModMaker requires valid BIOGame directory to start");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == backupCreateGDB) {
 			if (validateBIOGameDir()) {
 				createBasegameDB(fieldBiogameDir.getText());
 			} else {
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BioGame directory is not valid.\nMod Manager cannot update or create the game repair database.\nFix the BioGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nMod Manager cannot update or create the game repair database.\nFix the BioGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1621,8 +1586,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreCoalesced(fieldBiogameDir.getText());
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modDevStarterKit) {
@@ -1632,22 +1596,19 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.ALLDLC);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoredeleteAllCustomDLC) {
 			if (validateBIOGameDir()) {
-				if (JOptionPane.showConfirmDialog(this,
-						"This will delete all folders in the BIOGame/DLC folder that aren't known to be official.\nDelete all custom DLC?",
+				if (JOptionPane.showConfirmDialog(this, "This will delete all folders in the BIOGame/DLC folder that aren't known to be official.\nDelete all custom DLC?",
 						"Delete all Custom DLC", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 
 					restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.REMOVECUSTOMDLC);
 				}
 			} else {
 				labelStatus.setText("Can't remove custom DLC with invalid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreCustomDLCManager) {
@@ -1655,30 +1616,24 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				new CustomDLCWindow(fieldBiogameDir.getText());
 			} else {
 				labelStatus.setText("Custom DLC Manager requires valid BIOGame directory");
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BioGame directory is not valid.\nCustom DLC Manager requires a valid directory.\nFix the BioGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BioGame directory is not valid.\nCustom DLC Manager requires a valid directory.\nFix the BioGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreSelective) {
 			if (validateBIOGameDir()) {
 				new SelectiveRestoreWindow(fieldBiogameDir.getText());
 			} else {
 				labelStatus.setText("Custom Restore requires valid BIOGame directory");
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BioGame directory is not valid.\nCustom Restore requires a valid directory.\nFix the BioGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nCustom Restore requires a valid directory.\nFix the BioGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertBasegame) {
 			if (validateBIOGameDir()) {
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.BASEGAME);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertUnpacked) {
@@ -1686,8 +1641,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.UNPACKED);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertBasegameUnpacked) {
@@ -1695,24 +1649,20 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.UNPACKEDBASEGAME);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreVanillifyDLC) {
 			if (validateBIOGameDir()) {
-				if (JOptionPane
-						.showConfirmDialog(
-								this,
-								"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
-								"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+				if (JOptionPane.showConfirmDialog(this,
+						"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
+						"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 
 					restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.VANILLIFYDLC);
 				}
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertSPDLC) {
@@ -1720,8 +1670,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.SP);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 
@@ -1730,8 +1679,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.MP);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertSPBaseDLC) {
@@ -1739,8 +1687,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.SPBASE);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == restoreRevertMPBaseDLC) {
@@ -1748,8 +1695,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.MPBASE);
 			} else {
 				labelStatus.setText("Cannot restore files without valid BIOGame directory");
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
@@ -1757,38 +1703,31 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		if (e.getSource() == restoreRevertEverything) {
 			if (validateBIOGameDir()) {
 				if (validateBIOGameDir()) {
-					if (JOptionPane
-							.showConfirmDialog(
-									this,
-									"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
-									"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+					if (JOptionPane.showConfirmDialog(this,
+							"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
+							"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 
 						restoreCoalesced(fieldBiogameDir.getText());
 						restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.ALL);
 					}
 				} else {
 					labelStatus.setText("Cannot restore files without valid BIOGame directory");
-					JOptionPane
-							.showMessageDialog(
-									null,
-									"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
-									"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null,
+							"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+							"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		} else if (e.getSource() == restoreDeleteUnpacked) {
 			if (validateBIOGameDir()) {
-				if (JOptionPane
-						.showConfirmDialog(
-								this,
-								"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
-								"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
+				if (JOptionPane.showConfirmDialog(this,
+						"This will delete all unpacked DLC items, including backups of those files.\nThe backup files are deleted because you shouldn't restore unpacked files if your DLC isn't set up for unpacked files.\nMake sure you have your *original* SFARs backed up! Otherwise you will have to use Origin to download them again.\nAre you sure you want to continue?",
+						"Delete unpacked DLC files", JOptionPane.WARNING_MESSAGE) == JOptionPane.YES_OPTION) {
 					restoreDataFiles(fieldBiogameDir.getText(), RestoreMode.REMOVEUNPACKEDITEMS);
 				}
 			} else {
 				labelStatus.setText("Cannot delete files with invalid BIOGame directory");
 
-				JOptionPane.showMessageDialog(null,
-						"The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
+				JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot do any restorations.\nFix the BioGame directory before continuing.",
 						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == actionExitDebugMode) {
@@ -1859,8 +1798,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing a mod requires valid BIOGame path");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1871,11 +1810,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Starting the game requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BIOGame directory is not valid.\nMod Manager does not know where to launch the game executable.\nFix the BIOGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BIOGame directory is not valid.\nMod Manager does not know where to launch the game executable.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else
 
@@ -1977,17 +1914,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					}
 				} else {
 					ModManager.debugLogger.writeError("Config tool is missing! Not found at " + path);
-					JOptionPane.showMessageDialog(null, "The config tool executable doesn't exist where it should:\n" + path,
-							"Missing Config Tool exe", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null, "The config tool executable doesn't exist where it should:\n" + path, "Missing Config Tool exe", JOptionPane.ERROR_MESSAGE);
 				}
 			} else {
 				labelStatus.setText("ME3 Config tool requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BIOGame directory is not valid.\nCannot open the ME3 Config tool if Mod Manager doesn't know where Mass Effect 3 is.\nFix the BIOGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BIOGame directory is not valid.\nCannot open the ME3 Config tool if Mod Manager doesn't know where Mass Effect 3 is.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsUnpackDLC) {
 			if (validateBIOGameDir()) {
@@ -2004,11 +1938,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Unpacking DLC requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BIOGame directory is not valid.\nCannot unpack DLC without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BIOGame directory is not valid.\nCannot unpack DLC without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsMountdlcEditor) {
 			new MountFileEditorWindow();
@@ -2029,11 +1961,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Game AutoTOC requires a valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BIOGame directory is not valid.\nCannot update TOC files without a valid directory.\nFix the BIOGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BIOGame directory is not valid.\nCannot update TOC files without a valid directory.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modutilsAutoTOC) {
 			if (ModManager.validateNETFrameworkIsInstalled()) {
@@ -2066,11 +1996,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
 				labelStatus.setVisible(true);
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modutilsRestoreMod) {
 
@@ -2089,19 +2017,14 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
 				labelStatus.setVisible(true);
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
-								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"The BIOGame directory is not valid.\nCannot update ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
+						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modutilsDeleteMod) {
 			ModManager.debugLogger.writeMessage("User clicked Delete Mod on " + modModel.get(modList.getSelectedIndex()).getModName());
-			int result = JOptionPane.showConfirmDialog(
-					this,
-					"Deleting this mod will remove it from your filesystem.\nThis operation cannot be reversed.\nDelete "
-							+ modModel.get(modList.getSelectedIndex()).getModName() + "?", "Confirm Mod Deletion", JOptionPane.YES_NO_OPTION,
-					JOptionPane.WARNING_MESSAGE);
+			int result = JOptionPane.showConfirmDialog(this, "Deleting this mod will remove it from your filesystem.\nThis operation cannot be reversed.\nDelete "
+					+ modModel.get(modList.getSelectedIndex()).getModName() + "?", "Confirm Mod Deletion", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
 			if (result == JOptionPane.OK_OPTION) {
 				ModManager.debugLogger.writeMessage("Deleting mod: " + modModel.get(modList.getSelectedIndex()).getModPath());
 				FileUtils.deleteQuietly(new File(modModel.get(modList.getSelectedIndex()).getModPath()));
@@ -2111,8 +2034,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new KeybindsInjectionWindow(this, modModel.getElementAt(modList.getSelectedIndex()), false);
 		} else if (e.getSource() == modManagementCheckallmodsforupdate) {
 			if (!validateBIOGameDir()) {
-				JOptionPane.showMessageDialog(this,
-						"Your BIOGame directory is not correctly set.\nOnly non-ModMaker mods will be checked for updates.",
+				JOptionPane.showMessageDialog(this, "Your BIOGame directory is not correctly set.\nOnly non-ModMaker mods will be checked for updates.",
 						"Invalid BIOGame Directory", JOptionPane.WARNING_MESSAGE);
 			}
 			checkAllModsForUpdates(true);
@@ -2131,8 +2053,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Use of the patch library requires a valid BIOGame folder");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == modDeltaRevert) {
 			//if (validateBIOGameDir()) {
@@ -2182,8 +2104,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing DLC bypass requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsInstallBinkw32) {
 			if (validateBIOGameDir()) {
@@ -2192,8 +2114,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing DLC bypass requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		} else if (e.getSource() == toolsUninstallBinkw32) {
 			if (validateBIOGameDir()) {
@@ -2202,8 +2124,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} else {
 				labelStatus.setText("Installing DLC bypass requires valid BIOGame directory");
 				labelStatus.setVisible(true);
-				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory before continuing.", "Invalid BioGame Directory",
+						JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}
@@ -2246,11 +2168,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new AllModsUpdateWindow(this, isManualCheck, updatableMods);
 		} else {
 			if (isManualCheck) {
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"No mods are eligible for the Mod Manager update service.\nEligible mods include ModMaker mods and ones hosted on ME3Tweaks.com.",
-								"No updatable mods", JOptionPane.WARNING_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"No mods are eligible for the Mod Manager update service.\nEligible mods include ModMaker mods and ones hosted on ME3Tweaks.com.", "No updatable mods",
+						JOptionPane.WARNING_MESSAGE);
 			}
 			Wini ini;
 			try {
@@ -2265,8 +2185,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			} catch (InvalidFileFormatException e) {
 				e.printStackTrace();
 			} catch (IOException e) {
-				ModManager.debugLogger.writeErrorWithException(
-						"Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
+				ModManager.debugLogger.writeErrorWithException("Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
 			}
 		}
 	}
@@ -2318,8 +2237,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new BackupWindow(this, bioGameDir);
 		} else {
 			// Biogame is invalid
-			JOptionPane.showMessageDialog(null,
-					"The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
+			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
 					"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			labelStatus.setText("DLC backup failed");
 			labelStatus.setVisible(true);
@@ -2333,8 +2251,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			new BackupWindow(this, bioGameDir, dlcName);
 		} else {
 			// Biogame is invalid
-			JOptionPane.showMessageDialog(null,
-					"The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
+			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nDLC cannot be not backed up.\nFix the BioGame directory before continuing.",
 					"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 			labelStatus.setText("DLC backup failed");
 			labelStatus.setVisible(true);
@@ -2349,8 +2266,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		File coalesced = new File(ModManager.appendSlash(dirChooser.getSelectedFile().toString()) + "CookedPCConsole\\Coalesced.bin");
 		if (coalesced.exists()) {
 			String YesNo[] = { "Yes", "No" };
-			int saveDir = JOptionPane.showOptionDialog(null, "BioGame directory set to: " + dirChooser.getSelectedFile().toString()
-					+ "\nSave this path?", "Save BIOGame path?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
+			int saveDir = JOptionPane.showOptionDialog(null, "BioGame directory set to: " + dirChooser.getSelectedFile().toString() + "\nSave this path?", "Save BIOGame path?",
+					JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
 			if (saveDir == 0) {
 				Wini ini;
 				try {
@@ -2364,8 +2281,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				} catch (InvalidFileFormatException e) {
 					e.printStackTrace();
 				} catch (IOException e) {
-					ModManager.debugLogger.writeErrorWithException(
-							"Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
+					ModManager.debugLogger.writeErrorWithException("Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
 				}
 				labelStatus.setText("Saved BioGame directory to me3cmm.ini");
 				labelStatus.setVisible(true);
@@ -2373,8 +2289,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			fieldBiogameDir.setText(dirChooser.getSelectedFile().toString());
 			validateBIOGameDir();
 		} else {
-			JOptionPane.showMessageDialog(null, "Coalesced.bin not found in " + dirChooser.getSelectedFile().toString(), "Error",
-					JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null, "Coalesced.bin not found in " + dirChooser.getSelectedFile().toString(), "Error", JOptionPane.ERROR_MESSAGE);
 		}
 	}
 
@@ -2402,14 +2317,12 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	 */
 	private static void setBioDirHighlight(boolean highlight) {
 		if (highlight) {
-			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
-					"Mass Effect 3 BIOGame Directory (INVALID)", TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager
-							.getDefaults().getFont("titledBorder.font"), Color.RED);
+			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Mass Effect 3 BIOGame Directory (INVALID)",
+					TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager.getDefaults().getFont("titledBorder.font"), Color.RED);
 			ModManagerWindow.ACTIVE_WINDOW.cookedDirPanel.setBorder(cookedDirTitle);
 		} else {
-			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
-					"Mass Effect 3 BIOGame Directory", TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager.getDefaults()
-							.getFont("titledBorder.font"), new Color(0, 150, 0));
+			TitledBorder cookedDirTitle = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Mass Effect 3 BIOGame Directory",
+					TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, UIManager.getDefaults().getFont("titledBorder.font"), new Color(0, 150, 0));
 			ModManagerWindow.ACTIVE_WINDOW.cookedDirPanel.setBorder(cookedDirTitle);
 		}
 	}
@@ -2464,11 +2377,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} catch (InvalidFileFormatException e) {
 			ModManager.debugLogger.writeError("Invalid file format exception writing to settings ini.");
 		} catch (IOException e) {
-			ModManager.debugLogger.writeErrorWithException(
-					"I/O Exception attemping to get ME3 install directory. Could be a settings file not writing: ", e);
+			ModManager.debugLogger.writeErrorWithException("I/O Exception attemping to get ME3 install directory. Could be a settings file not writing: ", e);
 		} catch (Throwable e) {
-			ModManager.debugLogger.writeErrorWithException(
-					"Error occured while attempting to get/set the biogame directory! Could be the JNA crash.", e);
+			ModManager.debugLogger.writeErrorWithException("Error occured while attempting to get/set the biogame directory! Could be the JNA crash.", e);
 			return "C:\\Program Files (x86)\\Origin Games\\Mass Effect 3\\BIOGame";
 		}
 		ModManager.debugLogger.writeMessage("Directory that was fetched: " + setDir);
@@ -2528,9 +2439,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 				if ((defaultsfarMainFileExists || patch001farMainFileExists) && !backFile.exists()) {
 					String YesNo[] = { "Yes", "No" }; // Yes/no buttons
-					int showDLCBackup = JOptionPane.showOptionDialog(null, "<html>" + job.getJobName()
-							+ " DLC has not been backed up.<br>Back it up now?</hmtl>", "Backup DLC", JOptionPane.YES_NO_OPTION,
-							JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
+					int showDLCBackup = JOptionPane.showOptionDialog(null, "<html>" + job.getJobName() + " DLC has not been backed up.<br>Back it up now?</hmtl>", "Backup DLC",
+							JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, YesNo, YesNo[0]);
 					if (showDLCBackup == 0) {
 						autoBackupDLC(fieldBiogameDir.getText(), job.getJobName());
 					}
@@ -2573,8 +2483,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				fieldDescription.setCaretPosition(0);
 				buttonApplyMod.setEnabled(true);
 				if (ModManager.NET_FRAMEWORK_IS_INSTALLED) {
-					buttonApplyMod
-							.setToolTipText("<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
+					buttonApplyMod.setToolTipText(
+							"<html>Apply this mod to the game.<br>If another mod is already installed, restore your game first!<br>You can merge Mod Manager mods in the Tools menu.</html>");
 				} else {
 					buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework 4.5 or higher in order to install mods");
 				}
@@ -2592,8 +2502,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					} else {
 						moddevUpdateXMLGenerator.setEnabled(true);
 						moddevUpdateXMLGenerator.setText("Prepare " + selectedMod.getModName() + " for ME3Tweaks Updater Service");
-						moddevUpdateXMLGenerator
-								.setToolTipText("Compresses mod files for storage on ME3Tweaks and generates a mod manifest. Copies to clipboard when complete.");
+						moddevUpdateXMLGenerator.setToolTipText("Compresses mod files for storage on ME3Tweaks and generates a mod manifest. Copies to clipboard when complete.");
 
 					}
 				} else {
@@ -2604,8 +2513,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					moddevUpdateXMLGenerator.setEnabled(false);
 					moddevUpdateXMLGenerator.setToolTipText(selectedMod.getModName() + " does not have a ME3Tweaks update code");
 					moddevUpdateXMLGenerator.setText("Cannot prepare " + selectedMod.getModName() + " for ME3Tweaks Updater Service");
-					modutilsCheckforupdate
-							.setToolTipText("<html>Mod update eligibility requires a floating point version number<br>and an update code from ME3Tweaks</html>");
+					modutilsCheckforupdate.setToolTipText("<html>Mod update eligibility requires a floating point version number<br>and an update code from ME3Tweaks</html>");
 				}
 
 				UrlValidator urlValidator = new UrlValidator(new String[] { "http", "https" });
@@ -2661,8 +2569,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					}
 
 					modDeltaMenu.addSeparator();
-					modDeltaMenu.setText(selectedMod.getModDeltas().size() + " available variant"
-							+ (selectedMod.getModDeltas().size() != 1 ? "s" : ""));
+					modDeltaMenu.setText(selectedMod.getModDeltas().size() + " available variant" + (selectedMod.getModDeltas().size() != 1 ? "s" : ""));
 					modDeltaMenu.setVisible(true);
 					modNoDeltas.setVisible(false);
 					for (ModDelta delta : selectedMod.getModDeltas()) {
@@ -2707,11 +2614,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					// Copy
 					String destFile = ModManager.appendSlash(bioGameDir) + "CookedPCConsole\\Coalesced.bin";
 					if (new File(destFile).exists() == false) {
-						JOptionPane
-								.showMessageDialog(
-										null,
-										"Coalesced.bin to be restored was not found in the specified BIOGame\\CookedPCConsole directory.\nYou must fix the directory before you can restore Coalesced.",
-										"Coalesced not found", JOptionPane.ERROR_MESSAGE);
+						JOptionPane.showMessageDialog(null,
+								"Coalesced.bin to be restored was not found in the specified BIOGame\\CookedPCConsole directory.\nYou must fix the directory before you can restore Coalesced.",
+								"Coalesced not found", JOptionPane.ERROR_MESSAGE);
 						labelStatus.setText("Coalesced.bin not restored");
 						labelStatus.setVisible(true);
 						return false;
@@ -2726,11 +2631,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				} else {
 					labelStatus.setText("Coalesced.bin not restored.");
 					labelStatus.setVisible(true);
-					JOptionPane
-							.showMessageDialog(
-									null,
-									"Your backed up original Coalesced.bin file does not match the known original from Mass Effect 3.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.",
-									"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null,
+							"Your backed up original Coalesced.bin file does not match the known original from Mass Effect 3.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.",
+							"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
 					return false;
 				}
 			} catch (Exception e) {
@@ -2742,11 +2645,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} else {
 			labelStatus.setText("Coalesced.bin not restored");
 			labelStatus.setVisible(true);
-			JOptionPane
-					.showMessageDialog(
-							null,
-							"The backed up Coalesced.bin file (data/Coalesced.original) does not exist.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.\n\nThis error should have been caught but can be thrown due to file system changes \nwhile the program is open.",
-							"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null,
+					"The backed up Coalesced.bin file (data/Coalesced.original) does not exist.\nYou'll need to manually restore the original (or what you call your original).\nIf you lost your original you can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq.\nYour current Coalesced has not been changed.\n\nThis error should have been caught but can be thrown due to file system changes \nwhile the program is open.",
+					"Coalesced Backup Error", JOptionPane.ERROR_MESSAGE);
 
 		}
 		return false;
@@ -2770,8 +2671,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} else {
 			labelStatus.setText("Invalid BioGame Directory");
 			labelStatus.setVisible(true);
-			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid. Files cannot be restored.\nFix the directory and try again.",
-					"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null, "The BioGame directory is not valid. Files cannot be restored.\nFix the directory and try again.", "Invalid BioGame Directory",
+					JOptionPane.ERROR_MESSAGE);
 			return false;
 		}
 	}
@@ -2787,14 +2688,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			int minorBuildNum = EXEFileInfo.getMinorVersionOfProgram(executable.getAbsolutePath());
 			if (minorBuildNum > 5) {
 				ModManager.debugLogger.writeMessage("!!!!This user has >1.5 version of Mass Effect 3!!!!");
-				JOptionPane
-						.showMessageDialog(
-								this,
-								"<html><div style='width: 300px'>You have a version of Mass Effect 3 higher than 1.5 (1."
-										+ minorBuildNum
-										+ "), which is the main version most of the world uses.<br>"
-										+ "It seems BioWare has been slowly pushing this version out to some users starting in September 2013. Not all users will get this version.<br><br>If you encounter issues you may consider downgrading to the 1.5 EXE. If you play Multiplayer, you will only be able to connect to other 1.6 users, which are very few.<br>Check the ME3Tweaks forums for info on how to downgrade.</div></html>",
-								"Mass Effect 3 Rare Version Detected", JOptionPane.WARNING_MESSAGE);
+				JOptionPane.showMessageDialog(this,
+						"<html><div style='width: 300px'>You have a version of Mass Effect 3 higher than 1.5 (1." + minorBuildNum
+								+ "), which is the main version most of the world uses.<br>"
+								+ "It seems BioWare has been slowly pushing this version out to some users starting in September 2013. Not all users will get this version.<br><br>If you encounter issues you may consider downgrading to the 1.5 EXE. If you play Multiplayer, you will only be able to connect to other 1.6 users, which are very few.<br>Check the ME3Tweaks forums for info on how to downgrade.</div></html>",
+						"Mass Effect 3 Rare Version Detected", JOptionPane.WARNING_MESSAGE);
 			}
 		} catch (Exception e) {
 			//do nothing. Continue like the old mod manager did.
@@ -2819,8 +2717,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 		// check if the new one exists
 		if (!executable.exists()) {
-			JOptionPane.showMessageDialog(null, "Unable to find game executable in the specified directory:\n" + executable.getAbsolutePath()
-					+ "\nMake sure your BIOGame directory is correct.", "Unable to Launch Game", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null,
+					"Unable to find game executable in the specified directory:\n" + executable.getAbsolutePath() + "\nMake sure your BIOGame directory is correct.",
+					"Unable to Launch Game", JOptionPane.ERROR_MESSAGE);
 			return;
 		}
 		// Executable exists.
@@ -2869,11 +2768,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			return result;
 		}
-		JOptionPane
-				.showMessageDialog(
-						null,
-						"The BioGame directory is not valid.\nMod Manager cannot install the LauncherWV DLC bypass.\nFix the BioGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+		JOptionPane.showMessageDialog(null,
+				"The BioGame directory is not valid.\nMod Manager cannot install the LauncherWV DLC bypass.\nFix the BioGame directory before continuing.",
+				"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 		return false;
 	}
 
@@ -2888,11 +2785,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			return result;
 		}
-		JOptionPane
-				.showMessageDialog(
-						null,
-						"The BioGame directory is not valid.\nMod Manager cannot install Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+		JOptionPane.showMessageDialog(null, "The BioGame directory is not valid.\nMod Manager cannot install Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
+				"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 		return false;
 	}
 
@@ -2907,11 +2801,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			return result;
 		}
-		JOptionPane
-				.showMessageDialog(
-						null,
-						"The BioGame directory is not valid.\nMod Manager cannot revert the Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
-						"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
+		JOptionPane.showMessageDialog(null,
+				"The BioGame directory is not valid.\nMod Manager cannot revert the Binkw32.dll DLC bypass.\nFix the BioGame directory before continuing.",
+				"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 		return false;
 	}
 

--- a/src/com/me3tweaks/modmanager/StarterKitWindow.java
+++ b/src/com/me3tweaks/modmanager/StarterKitWindow.java
@@ -135,7 +135,7 @@ public class StarterKitWindow extends JDialog {
 		mountPriority.setToolTipText(
 				"<html>Mount priority of your mod. Official DLC ends around 3300.<br>Mods that have pcc files with the same name will only load the higher mount priority version.</html>");
 
-		internalTLKId.setInputVerifier(new PositiveIntVerifier());
+		internalTLKId.setInputVerifier(new PositiveTLKIntVerifier());
 		mountPriority.setInputVerifier(new PositiveIntVerifier());
 
 		c.gridy = 0;
@@ -235,6 +235,19 @@ public class StarterKitWindow extends JDialog {
 			try {
 				int value = Integer.parseInt(text);
 				return (value > 0 && value < 20000);
+			} catch (NumberFormatException e) {
+				return false;
+			}
+		}
+	}
+	
+	class PositiveTLKIntVerifier extends InputVerifier {
+		@Override
+		public boolean verify(JComponent input) {
+			String text = ((JTextField) input).getText();
+			try {
+				int value = Integer.parseInt(text);
+				return (value > 0 && value < Integer.MAX_VALUE / 2);
 			} catch (NumberFormatException e) {
 				return false;
 			}

--- a/src/com/me3tweaks/modmanager/StarterKitWindow.java
+++ b/src/com/me3tweaks/modmanager/StarterKitWindow.java
@@ -217,14 +217,14 @@ public class StarterKitWindow extends JDialog {
 		add(panel);
 
 		//DEBUG ONLY
-		modName.setText("Starter Kit Testing");
+/*		modName.setText("Starter Kit Testing");
 		internalDisplayName.setText("Starter Kit Testing");
 		internalTLKId.setText("6700000");
 		mountPriority.setText("4505");
 		internalDLCName.setText("StartKitTest");
 		modDeveloper.setText("Gatomade");
 		modSite.setText("http://example.com");
-		modDescription.setText("This is what a mod description looks like.\nIt has multiple lines.\nOf txt.");
+		modDescription.setText("This is what a mod description looks like.\nIt has multiple lines.\nOf txt.");*/
 		pack();
 	}
 

--- a/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
@@ -289,7 +289,7 @@ public class ModXMLTools {
 				File moddesc = new File(mod.getModPath() + "moddesc.ini");
 				//DECREMENT VERSION SO SERVER VERSION APPEARS AS UPDATE.
 				Wini ini = new Wini(moddesc);
-				ini.put("ModInfo", "modver", Math.max(0.001, mod.getVersion() - 0.001));
+				ini.put("ModInfo", "modver", Math.max(0.001, Math.floor((mod.getVersion() - 0.01) * 100) / 100));
 				ini.store(new File(sideloadoutputfolder + "moddesc.ini"));
 
 				String sideload7z = ModManager.appendSlash(new File(sideloadoutputfolder).getParent()) + foldername + "-sideload.7z";
@@ -541,7 +541,7 @@ public class ModXMLTools {
 					continue;
 				}
 				File blacklistedlocalfile = new File(modpath + blacklisted);
-				System.out.println("Checking for blacklisted file: "+blacklistedlocalfile+" exits? "+blacklistedlocalfile.exists());
+				System.out.println("Checking for blacklisted file: " + blacklistedlocalfile + " exits? " + blacklistedlocalfile.exists());
 
 				if (blacklistedlocalfile.exists()) {
 					ModManager.debugLogger.writeMessage("Blacklisted file exists and will be deleted: " + blacklisted);

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -499,6 +499,13 @@ public class Mod implements Comparable<Mod> {
 						return;
 					}
 
+					if (!destFolder.startsWith("DLC_")) {
+						setFailedReason(
+								"Mod specifies a CUSTOMDLC destination folder that doesn't start with DLC_. When installing this mod, this will do nothing because Mass Effect 3 will not load any DLC that does not start with DLC_." + destFolder);
+						ModManager.debugLogger.writeError("Custom DLC target folder doesn't start with DLC_: " + destFolder);
+						return;
+					}
+
 					if (sf.exists()) { //ignore errors is not present here.
 						List<File> sourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
 						for (File file : sourceFiles) {
@@ -568,7 +575,7 @@ public class Mod implements Comparable<Mod> {
 						String blacklistedfile = blacklistedTok.nextToken();
 						blacklistedfile = blacklistedfile.replaceAll("\\\\", "/");
 						ModManager.debugLogger.writeMessageConditionally("Blacklisted file for manifests: " + blacklistedfile, ModManager.LOG_MOD_INIT);
-						getBlacklistedFiles() .add(blacklistedfile);
+						getBlacklistedFiles().add(blacklistedfile);
 					}
 				}
 			}
@@ -872,7 +879,7 @@ public class Mod implements Comparable<Mod> {
 
 		// Add mod manager build version
 		modDisplayDescription += "\nTargets Mod Manager " + modCMMVer;
-		if (classicCode > 0 /*&& ModManager.IS_DEBUG*/) {
+		if (classicCode > 0 /* && ModManager.IS_DEBUG */) {
 			modDisplayDescription += "\nUpdate code: " + classicCode;
 		}
 		if (getSideloadOnlyTargets().size() > 0) {

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -511,7 +511,7 @@ public class Mod implements Comparable<Mod> {
 						for (File file : sourceFiles) {
 							String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
 							String destFilePath = ModManager.appendSlash(destFolder) + relativePath;
-							if (!(newJob.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath()), ResourceUtils.normalizeFilePath(destFilePath))
+							if (!(newJob.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath(),false), ResourceUtils.normalizeFilePath(destFilePath,false))
 									&& !ignoreLoadErrors)) {
 								setFailedReason("Mod specifies a CUSTOMDLC header, but a file in one of the source directories (" + sf
 										+ ") had a file that was unable to be added. This error should be encountered.");

--- a/src/com/me3tweaks/modmanager/utilities/ResourceUtils.java
+++ b/src/com/me3tweaks/modmanager/utilities/ResourceUtils.java
@@ -40,19 +40,20 @@ public class ResourceUtils {
 			ModManager.debugLogger.writeErrorWithException("I/O Exception while opening directory " + dir + ".", e);
 		}
 	}
-	
+
 	/**
 	 * Returns line number where carot is in a component that has a carot
-	 * @param component component to find carot position of
+	 * 
+	 * @param component
+	 *            component to find carot position of
 	 * @return line number
 	 */
-	public static int getLineAtCaret(JTextComponent component)
-    {
-         int caretPosition = component.getCaretPosition();
-         Element root = component.getDocument().getDefaultRootElement();
+	public static int getLineAtCaret(JTextComponent component) {
+		int caretPosition = component.getCaretPosition();
+		Element root = component.getDocument().getDefaultRootElement();
 
-         return root.getElementIndex( caretPosition ) + 1;
-    }
+		return root.getElementIndex(caretPosition) + 1;
+	}
 
 	public static String humanReadableByteCount(long bytes, boolean si) {
 		int unit = si ? 1000 : 1024;
@@ -62,25 +63,28 @@ public class ResourceUtils {
 		String pre = (si ? "kMGTPE" : "KMGTPE").charAt(exp - 1) + (si ? "" : "i");
 		return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
 	}
-	
+
 	/**
 	 * Appends stylized text to a textpane
-	 * @param tp Textpane
-	 * @param msg Message to append. Will automatically place newline at end.
-	 * @param c Color of text.
+	 * 
+	 * @param tp
+	 *            Textpane
+	 * @param msg
+	 *            Message to append. Will automatically place newline at end.
+	 * @param c
+	 *            Color of text.
 	 */
 	public static void appendToPane(JTextPane tp, String msg, Color c) {
 		StyleContext sc = StyleContext.getDefaultStyleContext();
-	    AttributeSet aset = sc.addAttribute(SimpleAttributeSet.EMPTY,
-	        StyleConstants.Foreground, c);
+		AttributeSet aset = sc.addAttribute(SimpleAttributeSet.EMPTY, StyleConstants.Foreground, c);
 
-	    int len = tp.getDocument().getLength(); // same value as
-	                       // getText().length();
-	    tp.setCaretPosition(len); // place caret at the end (with no selection)
+		int len = tp.getDocument().getLength(); // same value as
+		// getText().length();
+		tp.setCaretPosition(len); // place caret at the end (with no selection)
 
 		StyledDocument doc = tp.getStyledDocument();
 		try {
-			doc.insertString(doc.getLength(),msg+"\n", aset);
+			doc.insertString(doc.getLength(), msg + "\n", aset);
 		} catch (BadLocationException e) {
 			e.printStackTrace();
 		}
@@ -231,14 +235,14 @@ public class ResourceUtils {
 		if (buffer.length != 4) {
 			return -1;
 		}
-		return (buffer[0]<<24)&0xff000000|
-	       (buffer[1]<<16)&0x00ff0000|
-	       (buffer[2]<< 8)&0x0000ff00|
-	       (buffer[3]<< 0)&0x000000ff;
+		return (buffer[0] << 24) & 0xff000000 | (buffer[1] << 16) & 0x00ff0000 | (buffer[2] << 8) & 0x0000ff00 | (buffer[3] << 0) & 0x000000ff;
 	}
 
-	public static String normalizeFilePath(String absolutePath) {
-		return absolutePath.replaceAll("\\\\", "/");
+	public static String normalizeFilePath(String absolutePath, boolean backslash) {
+		if (!backslash) {
+			return absolutePath.replaceAll("\\\\", "/");
+		}
+		return absolutePath.replaceAll("/", "\\\\");
 	}
 
 	/*


### PR DESCRIPTION
This build (4.2.3) contains all the bugfixes that previous "minor updates" were pushed out from r1 to r5. Most users did not see this as they were not part of the soak test.

[All changes from the previous build still apply.](https://github.com/Mgamerz/me3modmanager/pull/16)

Changes from 4.2.3 ORIGINAL RELEASE:
- Custom DLC Installation will now delete the installed DLC before install. This will clear out old files.
- Removed debug autofill in starterkit generator
- GUI Transplanter 1.0.0.6 is now required. Older builds downloaded 1.0.0.5 which has severe bugs in the saving code and could crash the game. When mod manager checks for updates it will now dowlnoad updates in the background.
- Files made with the GUI compat generator will now verify post-transplant
- External processes will now print their output into Mod Manager log
- Fixes GUI library download links (was wrong because I was testing no-connectivity case)
- Validation in STarter Kit no longer will lock you into the TLK and mount priority fields.
- Log viewer now highlights errors in red
- Sideload generator will now decrement version number and truncate to 2 decimal places
- Mod CUSTOMDLC destfolders in moddesc target folders MUST now start with DLC_. They will fail to load otherwise.
- Update codes are now displayed in the mod description
