### PR TITLE
Mod Manager 4.2.4 Build 57

### DIFF
--- a/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
@@ -16,8 +16,16 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Random;
 import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -66,6 +74,9 @@ public class CustomDLCConflictWindow extends JDialog {
 	private String conflictingGUIMod;
 	private JPanel progressPanel;
 	private JLabel statusText;
+	private JPanel windowpanel;
+	public String transplanterpath;
+	public HashMap<String, CustomDLC> secondPriorityUIConflictFiles;
 
 	public CustomDLCConflictWindow() {
 		setupWindow();
@@ -94,10 +105,18 @@ public class CustomDLCConflictWindow extends JDialog {
 		//get conflicts, create table
 
 		HashMap<String, ArrayList<CustomDLC>> conflicts = ModManager.getCustomDLCConflicts(customDLCs, biogameDirectory + "DLC/");
-		int datasize = conflicts.entrySet().size();
+		HashMap<String, ArrayList<CustomDLC>> mountpriorityconflicts = new HashMap<String, ArrayList<CustomDLC>>();
+		for (Map.Entry<String, ArrayList<CustomDLC>> entry : conflicts.entrySet()) {
+			if (entry.getValue().size() <= 1) {
+				continue; //not priority conflict
+			}
+			mountpriorityconflicts.put(entry.getKey(), entry.getValue());
+		}
+
+		int datasize = mountpriorityconflicts.entrySet().size();
 		Object[][] data = new Object[datasize][3];
 		int i = 0;
-		for (Map.Entry<String, ArrayList<CustomDLC>> entry : conflicts.entrySet()) {
+		for (Map.Entry<String, ArrayList<CustomDLC>> entry : mountpriorityconflicts.entrySet()) {
 			String key = entry.getKey();
 			ArrayList<CustomDLC> value = entry.getValue();
 
@@ -137,7 +156,7 @@ public class CustomDLCConflictWindow extends JDialog {
 		table.getColumnModel().getColumn(COL_SUPERCEDING).setCellRenderer(centerRenderer);
 
 		JScrollPane scrollpane = new JScrollPane(table);
-		JPanel panel = new JPanel(new BorderLayout());
+		windowpanel = new JPanel(new BorderLayout());
 
 		String buttonText = "<html><center>Files listed below are Custom DLC files that have conflicts.<br>The Custom DLC with the highest mount priority will supercede others, and may cause the the superceded DLC to not work or cause game instability.<br><u><font color='#000099'>Click for info on how to toggle DLC in Mod Manager.</u></font></center></html>";
 		String message = "<html>To toggle Custom DLCs in Mod Manager, make sure all Custom DLC has been imported into Mod Manager.<br>This can be done through the Mod Management > Import Mods > Import installed Custom DLC mod.<br>Once imported, you can install it by simply applying the mod.<br>You can remove (disable) a mod by deleting it through the Custom DLC Manager, and then apply it again to enable it.</html>";
@@ -160,93 +179,275 @@ public class CustomDLCConflictWindow extends JDialog {
 				JOptionPane.showMessageDialog(CustomDLCConflictWindow.this, message, "Toggling Custom DLC in Mod Manager", JOptionPane.INFORMATION_MESSAGE);
 			}
 		});
-		panel.add(infoLinkButton, BorderLayout.NORTH);
-		panel.add(scrollpane, BorderLayout.CENTER);
+		windowpanel.add(infoLinkButton, BorderLayout.NORTH);
+		windowpanel.add(scrollpane, BorderLayout.CENTER);
 
-		HashMap<String, CustomDLC> secondPriorityUIConflictFiles = detectUIModConflicts(conflicts);
-		if (secondPriorityUIConflictFiles != null) {
-			guiPatchButton = new JButton("UI mod is conflicting with other mods", UIManager.getIcon("OptionPane.warningIcon"));
-			guiPatchButton.setToolTipText(
-					"<html>Mod Manager has detected that an installed GUI mod (SP Controller Support or Interface Scaling) is superceding other installed Custom DLCs.<br>Click for more info.</html>");
+		guiPatchButton = new JButton("UI mod is conflicting with other mods", UIManager.getIcon("OptionPane.warningIcon"));
+		guiPatchButton.setToolTipText(
+				"<html>Mod Manager has detected that an installed GUI mod (SP Controller Support or Interface Scaling) is superceding other installed Custom DLCs.<br>Click for more info.</html>");
+		guiPatchButton.setVisible(false);
+		guiPatchButton.addActionListener(new ActionListener() {
 
-			guiProgressBar = new JProgressBar();
-			guiProgressBar.setVisible(true);
-			guiProgressBar.setIndeterminate(true);
-			guiPatchButton.addActionListener(new ActionListener() {
-
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					int result = JOptionPane.showConfirmDialog(CustomDLCConflictWindow.this,
-							"An interface mod is superceding other installed Custom DLC mods.\n" + "This will disable features of those mods, which may cause game instability.\n"
-									+ "Mod Manager can generate a new mod that will use those superceding files with your interface\n"
-									+ "mod's UI files, which will fix this specific issue.\n\n"
-									+ "This generated mod will only apply to the current versions of the conflicting mods.\n"
-									+ "If you update any of them, you must uninstall the generated mod and regenerate it again.\n\n" + "Generate a GUI conflict compatibility mod?",
-							"Generate a compatibilty mod", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
-					if (result == JOptionPane.YES_OPTION) {
-						//generate
-						String modName = "MM GUI Compatibility";
-						boolean nameIsBad = true;
-						while (nameIsBad) {
-							String whatTheUserEntered = JOptionPane.showInputDialog(CustomDLCConflictWindow.this,
-									"Enter a name for the compatibilty mod.\nAlphanumeric (spaces/underscore allowed) only, no more than 20 characters.", "Enter mod name",
-									JOptionPane.QUESTION_MESSAGE);
-							if (whatTheUserEntered == null) {
-								return;
-							}
-							whatTheUserEntered = whatTheUserEntered.trim();
-							//space, and alphanumerics
-							boolean asciionly = whatTheUserEntered.chars()
-									.allMatch(c -> c == 0x20 || c == 0x5F || (c > 0x30 && c < 0x3A) || (c > 0x40 && c < 0x5B) || (c > 0x60 && c < 0x7B)); //what the f is this?
-							if (!asciionly) {
-								ModManager.debugLogger.writeError("Name is not ascii alphanumeric only: " + whatTheUserEntered);
-								continue;
-							}
-							if (whatTheUserEntered.length() > 20 || whatTheUserEntered.length() < 1) {
-								ModManager.debugLogger.writeError("Name is empty or too long: " + whatTheUserEntered);
-								continue;
-							}
-
-							//check if already exists
-							File patchFolder = new File(ModManager.getModsDir() + whatTheUserEntered);
-							if (patchFolder.exists() && patchFolder.isDirectory()) {
-								ModManager.debugLogger.writeError("Mod already exists, prompting user to overwrite: " + patchFolder);
-								String[] options = new String[] { "Delete existing mod", "Enter a new name" };
-								int renameresult = JOptionPane.showOptionDialog(CustomDLCConflictWindow.this,
-										"A mod named " + whatTheUserEntered + " already exists in Mod Manager.", "Name conflict", JOptionPane.OK_CANCEL_OPTION,
-										JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
-								if (renameresult == JOptionPane.NO_OPTION) {
-									continue;
-								} else {
-									FileUtils.deleteQuietly(patchFolder);
-								}
-							}
-
-							modName = whatTheUserEntered.trim();
-							nameIsBad = false;
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				int result = JOptionPane.showConfirmDialog(CustomDLCConflictWindow.this,
+						"An interface mod is superceding other installed Custom DLC mods, or another mod is using interfaces\nthat won't work with controllers.\n"
+								+ "These conflicts may cause game instability or you to become locked in an interface.\n"
+								+ "Mod Manager can generate a new mod that will inject controller interfaces into these files.\n"
+								+ "This generated mod will only apply to the current versions of the conflicting mods, so\n"
+								+ "if you update any of them, you must uninstall the generated mod and regenerate a new one.\n\n" + "Generate a GUI conflict compatibility mod?",
+						"Generate a compatibilty mod", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+				if (result == JOptionPane.YES_OPTION) {
+					//generate
+					String modName = "MM GUI Compatibility";
+					boolean nameIsBad = true;
+					while (nameIsBad) {
+						String whatTheUserEntered = JOptionPane.showInputDialog(CustomDLCConflictWindow.this,
+								"Enter a name for the compatibilty mod.\nAlphanumeric (spaces/underscore allowed) only, no more than 20 characters.", "Enter mod name",
+								JOptionPane.QUESTION_MESSAGE);
+						if (whatTheUserEntered == null) {
+							return;
 						}
-						progressPanel.setVisible(true);
-						guiPatchButton.setVisible(false);
-						GUICompatGeneratorThread gcgt = new GUICompatGeneratorThread(modName, biogameDirectory, secondPriorityUIConflictFiles);
-						gcgt.execute();
+						whatTheUserEntered = whatTheUserEntered.trim();
+						//space, and alphanumerics
+						boolean asciionly = whatTheUserEntered.chars()
+								.allMatch(c -> c == 0x20 || c == 0x5F || (c > 0x30 && c < 0x3A) || (c > 0x40 && c < 0x5B) || (c > 0x60 && c < 0x7B)); //what the f is this?
+						if (!asciionly) {
+							ModManager.debugLogger.writeError("Name is not ascii alphanumeric only: " + whatTheUserEntered);
+							continue;
+						}
+						if (whatTheUserEntered.length() > 20 || whatTheUserEntered.length() < 1) {
+							ModManager.debugLogger.writeError("Name is empty or too long: " + whatTheUserEntered);
+							continue;
+						}
+
+						//check if already exists
+						File patchFolder = new File(ModManager.getModsDir() + whatTheUserEntered);
+						if (patchFolder.exists() && patchFolder.isDirectory()) {
+							ModManager.debugLogger.writeError("Mod already exists, prompting user to overwrite: " + patchFolder);
+							String[] options = new String[] { "Delete existing mod", "Enter a new name" };
+							int renameresult = JOptionPane.showOptionDialog(CustomDLCConflictWindow.this, "A mod named " + whatTheUserEntered + " already exists in Mod Manager.",
+									"Name conflict", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
+							if (renameresult == JOptionPane.NO_OPTION) {
+								continue;
+							} else {
+								FileUtils.deleteQuietly(patchFolder);
+							}
+						}
+
+						modName = whatTheUserEntered.trim();
+						nameIsBad = false;
+					}
+					progressPanel.setVisible(true);
+					guiPatchButton.setVisible(false);
+					GUICompatGeneratorThread gcgt = new GUICompatGeneratorThread(modName, biogameDirectory, secondPriorityUIConflictFiles);
+					gcgt.execute();
+				}
+			}
+		});
+
+		JPanel guiPatchPanel = new JPanel(new BorderLayout());
+		guiPatchPanel.add(guiPatchButton, BorderLayout.NORTH);
+
+		progressPanel = new JPanel(new BorderLayout());
+		statusText = new JLabel("Preparing to create compatibilty mod", SwingConstants.CENTER);
+		guiProgressBar = new JProgressBar();
+		guiProgressBar.setVisible(true);
+		guiProgressBar.setIndeterminate(true);
+		progressPanel.add(guiProgressBar, BorderLayout.NORTH);
+		progressPanel.add(statusText, BorderLayout.SOUTH);
+		progressPanel.setVisible(false);
+		guiPatchPanel.add(progressPanel, BorderLayout.SOUTH);
+		windowpanel.add(guiPatchPanel, BorderLayout.SOUTH);
+
+		if (ModManager.isGUIModInstalled(biogameDirectory)) {
+			new CustomDLCGUIScanner(biogameDirectory, conflicts).execute();
+		}
+
+		windowpanel.setBorder(new EmptyBorder(5, 5, 5, 5));
+		add(windowpanel);
+		pack();
+	}
+
+	class CustomDLCGUIScanner extends SwingWorker<Void, ThreadCommand> {
+
+		private HashMap<String, ArrayList<CustomDLC>> dlcfilemap;
+		private String biogameDirectory;
+		private double numFilesToScan;
+	    private final AtomicInteger numFilesScanned = new AtomicInteger();
+
+		public CustomDLCGUIScanner(String biogameDirectory, HashMap<String, ArrayList<CustomDLC>> conflicts) {
+			this.dlcfilemap = conflicts;
+			this.biogameDirectory = biogameDirectory;
+			progressPanel.setVisible(true);
+			statusText.setText("Scanning Custom DLC files for GUI conflicts");
+		}
+
+		@Override
+		protected Void doInBackground() throws Exception {
+			secondPriorityUIConflictFiles = detectUIModConflicts(dlcfilemap);
+			HashMap<String, ArrayList<CustomDLC>> guiFilesWithNoSuperceding = detectNewFilesSupercedingUI(dlcfilemap);
+			if (guiFilesWithNoSuperceding != null) {
+				for (Entry<String, ArrayList<CustomDLC>> entry : guiFilesWithNoSuperceding.entrySet()) {
+					//add conflicts to gui conflict list since they have guis and aren't overridden by gui mod
+					secondPriorityUIConflictFiles.put(entry.getKey(), entry.getValue().get(0));
+				}
+			}
+			return null;
+		}
+
+		protected void done() {
+			if (secondPriorityUIConflictFiles != null) {
+				guiProgressBar.setVisible(false);
+				guiPatchButton.setVisible(true);
+				statusText.setText("A GUI mod conflicts with " + secondPriorityUIConflictFiles.entrySet().size() + " files");
+			}
+
+		}
+
+		/**
+		 * Detects files that contain interfaces but are not superceded by a
+		 * controller mod
+		 * 
+		 * @param dlcfilemap
+		 * @return
+		 */
+		private HashMap<String, ArrayList<CustomDLC>> detectNewFilesSupercedingUI(HashMap<String, ArrayList<CustomDLC>> dlcfilemap) {
+			// TODO Auto-generated method stub
+			transplanterpath = ModManager.getGUITransplanterCLI(true);
+			if (transplanterpath == null) {
+				return null;
+			}
+			for (Map.Entry<String, ArrayList<CustomDLC>> entry : dlcfilemap.entrySet()) {
+				System.out.println(entry.getKey() + " in " + entry.getValue().get(0));
+			}
+			HashMap<String, ArrayList<CustomDLC>> nonguimodfiles = new HashMap<>();
+			//filter out files where the gui mod is superceding, we don't care.
+			for (Map.Entry<String, ArrayList<CustomDLC>> entry : dlcfilemap.entrySet()) {
+				if (entry.getValue().size() != 1 || entry.getValue().get(0).isGUIMod()) {
+					continue; //not conflict... may be bad logic if two mods have same new file for some reason.
+				}
+				nonguimodfiles.put(entry.getKey(), entry.getValue());
+			}
+			numFilesToScan = nonguimodfiles.size();
+			ExecutorService downloadExecutor = Executors.newFixedThreadPool(4);
+			ArrayList<Future<GUIScanResult>> futures = new ArrayList<Future<GUIScanResult>>();
+			//submit jobs
+			for (Map.Entry<String, ArrayList<CustomDLC>> entry : nonguimodfiles.entrySet()) {
+				GUIScanTask gst = new GUIScanTask(entry.getKey(), entry.getValue());
+				futures.add(downloadExecutor.submit(gst));
+			}
+			downloadExecutor.shutdown();
+			HashMap<String, ArrayList<CustomDLC>> returnconflictfiles = new HashMap<>();
+			try {
+				downloadExecutor.awaitTermination(5, TimeUnit.MINUTES);
+				for (Future<GUIScanResult> f : futures) {
+					GUIScanResult result = f.get();
+					if (result == null) {
+						ModManager.debugLogger.writeError("A file failed to scan.");
+						throw new Exception("One or more files failed to scan.");
+					}
+					if (result.hasGUI) {
+						returnconflictfiles.put(result.filename, result.dlcs);
 					}
 				}
-			});
-
-			JPanel guiPatchPanel = new JPanel(new BorderLayout());
-			guiPatchPanel.add(guiPatchButton, BorderLayout.NORTH);
-
-			progressPanel = new JPanel(new BorderLayout());
-			statusText = new JLabel("Preparing to create compatibilty mod", SwingConstants.CENTER);
-			progressPanel.add(guiProgressBar, BorderLayout.NORTH);
-			progressPanel.add(statusText, BorderLayout.SOUTH);
-			progressPanel.setVisible(false);
-			guiPatchPanel.add(progressPanel, BorderLayout.SOUTH);
-			panel.add(guiPatchPanel, BorderLayout.SOUTH);
+			} catch (ExecutionException e) {
+				ModManager.debugLogger.writeErrorWithException("EXECUTION EXCEPTION WHILE SCANNING FILE (AFTER EXECUTOR FINISHED): ", e);
+				return null;
+			} catch (Exception e) {
+				ModManager.debugLogger.writeErrorWithException("UNKNOWN EXCEPTION OCCURED: ", e);
+				return null;
+			}
+			return returnconflictfiles;
 		}
-		panel.setBorder(new EmptyBorder(5, 5, 5, 5));
-		add(panel);
-		pack();
+
+		class GUIScanTask implements Callable<GUIScanResult> {
+			private String filepath;
+			private ArrayList<CustomDLC> dlcs;
+
+			public GUIScanTask(String filepath, ArrayList<CustomDLC> dlcs) {
+				this.filepath = filepath;
+				this.dlcs = dlcs;
+			}
+
+			@Override
+			public GUIScanResult call() throws Exception {
+				//scan file
+				String scanFile = biogameDirectory + "DLC/" + dlcs.get(0).getDlcName() + "/CookedPCConsole/" + filepath;
+				ArrayList<String> commandBuilder = new ArrayList<String>();
+				commandBuilder.add(transplanterpath);
+				commandBuilder.add("--guiscan");
+				commandBuilder.add("--inputfile");
+				commandBuilder.add(ResourceUtils.normalizeFilePath(scanFile, true));
+				String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
+				ModManager.debugLogger.writeMessage("Scanning for GFxMovieInfo export: " + scanFile);
+				int returncode = 2;
+				ProcessBuilder pb = new ProcessBuilder(command);
+				returncode = ModManager.runProcess(pb).getReturnCode();
+				
+				publish(new ThreadCommand("UPDATE_PROGRESS",null,numFilesScanned.incrementAndGet()));
+				if (returncode == 1) {
+					//FILE CONTAINS GUI!
+					ModManager.debugLogger.writeMessage("GUI Export found in non-GUI mod while GUI mod is installed: " + scanFile);
+					return new GUIScanResult(true, filepath, dlcs);
+				}
+				return new GUIScanResult(false, filepath, dlcs);
+			}
+		}
+
+		@Override
+		protected void process(List<ThreadCommand> chunks) {
+			for (ThreadCommand tc : chunks) {
+				String command = tc.getCommand();
+				switch (command) {
+				case "SHOW_SCANNER_PROGRESSBAR":
+					guiProgressBar.setVisible(true);
+					break;
+				case "UPDATE_SCANNER_TEXT":
+					
+					break;
+				case "UPDATE_PROGRESS":
+					System.err.println("PROGRESS UPDATIN "+(int) ((int) tc.getData()*100 / numFilesToScan));
+					guiProgressBar.setIndeterminate(false);
+					guiProgressBar.setVisible(true);
+					guiProgressBar.setValue((int) ((int) tc.getData()*100 / numFilesToScan));
+					break;
+				}
+			}
+		}
+
+		class GUIScanResult {
+			private boolean hasGUI;
+			private String filename;
+			private ArrayList<CustomDLC> dlcs;
+
+			public GUIScanResult(boolean hasGUI, String filename, ArrayList<CustomDLC> dlcs) {
+				super();
+				this.hasGUI = hasGUI;
+				this.filename = filename;
+				this.dlcs = dlcs;
+			}
+
+			public boolean isHasGUI() {
+				return hasGUI;
+			}
+
+			public void setHasGUI(boolean hasGUI) {
+				this.hasGUI = hasGUI;
+			}
+
+			public String getFilename() {
+				return filename;
+			}
+
+			public void setFilename(String filename) {
+				this.filename = filename;
+			}
+
+			public GUIScanResult() {
+
+			}
+		}
 	}
 
 	class GUICompatGeneratorThread extends SwingWorker<Boolean, ThreadCommand> {
@@ -257,16 +458,16 @@ public class CustomDLCConflictWindow extends JDialog {
 		private Lock lock = new ModManager.Lock();
 		private boolean userAcceptedFirstFailMessage = false;
 
-		public GUICompatGeneratorThread(String modName, String biogameDirectory, HashMap<String, CustomDLC> secondPriorityUIConflictFiles2) {
+		public GUICompatGeneratorThread(String modName, String biogameDirectory, HashMap<String, CustomDLC> secondPriorityUIConflictFiles) {
 			this.modName = modName;
 			this.biogameDirectory = biogameDirectory;
-			this.secondPriorityUIConflictFiles = secondPriorityUIConflictFiles2;
+			this.secondPriorityUIConflictFiles = secondPriorityUIConflictFiles;
 		}
 
 		@Override
 		protected Boolean doInBackground() throws Exception {
 			String guilibrarypath = ModManager.getGUILibraryFor(conflictingGUIMod, true);
-			String transplanterpath = ModManager.getGUITransplanterCLI(true);
+			transplanterpath = ModManager.getGUITransplanterCLI(true);
 			if (guilibrarypath == null) {
 				publish(new ThreadCommand("MISSING_GUI_LIBRARY"));
 				return false;
@@ -470,7 +671,7 @@ public class CustomDLCConflictWindow extends JDialog {
 					guiProgressBar.setIndeterminate(false);
 					Double val = (double) tc.getData();
 					val *= 100;
-					System.out.println("PROGRESS IS " + val);
+					guiProgressBar.setVisible(true);
 					guiProgressBar.setValue(val.intValue());
 					break;
 				}
@@ -508,7 +709,8 @@ public class CustomDLCConflictWindow extends JDialog {
 	/**
 	 * Detects if the conflicts are caused by one of the following mods: -
 	 * DLC_CON_XBX (SP Controller Support) - DLC_CON_UIScaling (Interface
-	 * Scaling Mod) - DLC_CON_UIScaling_Shared (Interface Scaling Add-On)
+	 * Scaling Mod) - DLC_CON_UIScaling_Shared (Interface Scaling Add-On).
+	 * 
 	 * 
 	 * @param conflicts
 	 *            hashmap of conflict files and the list of dlc they appear in
@@ -520,11 +722,13 @@ public class CustomDLCConflictWindow extends JDialog {
 		HashMap<String, CustomDLC> secondPriorityUIConflictFiles = new HashMap<>();
 		for (Map.Entry<String, ArrayList<CustomDLC>> entry : conflicts.entrySet()) {
 			ArrayList<CustomDLC> conflictingDLCs = entry.getValue();
-			CustomDLC str = conflictingDLCs.get(conflictingDLCs.size() - 1);
-			if (knownGUImods.contains(str.getDlcName())) {
-				ModManager.debugLogger.writeMessage("GUI mod " + str + " superceeding: " + entry.getKey());
-				conflictingGUIMod = conflictingDLCs.get(conflictingDLCs.size() - 1).getDlcName();
-				secondPriorityUIConflictFiles.put(entry.getKey(), conflictingDLCs.get(conflictingDLCs.size() - 2));
+			if (conflictingDLCs.size() > 1) {
+				CustomDLC str = conflictingDLCs.get(conflictingDLCs.size() - 1);
+				if (knownGUImods.contains(str.getDlcName())) {
+					ModManager.debugLogger.writeMessage("GUI mod " + str + " superceeding: " + entry.getKey());
+					conflictingGUIMod = conflictingDLCs.get(conflictingDLCs.size() - 1).getDlcName();
+					secondPriorityUIConflictFiles.put(entry.getKey(), conflictingDLCs.get(conflictingDLCs.size() - 2));
+				}
 			}
 		}
 		if (secondPriorityUIConflictFiles.size() > 0) {

--- a/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
@@ -33,6 +33,7 @@ import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -45,6 +46,7 @@ import com.me3tweaks.modmanager.objects.MountFile;
 import com.me3tweaks.modmanager.objects.MountFlag;
 import com.me3tweaks.modmanager.objects.ProcessResult;
 import com.me3tweaks.modmanager.objects.ThreadCommand;
+import com.me3tweaks.modmanager.ui.MultiLineTableCell;
 import com.me3tweaks.modmanager.utilities.EXEFileInfo;
 import com.me3tweaks.modmanager.utilities.ResourceUtils;
 
@@ -72,7 +74,7 @@ public class CustomDLCConflictWindow extends JDialog {
 	}
 
 	private void setupWindow() {
-		setPreferredSize(new Dimension(500, 500));
+		setPreferredSize(new Dimension(600, 500));
 		setTitle("Custom DLC Conflicts");
 		setIconImages(ModManager.ICONS);
 		setModalityType(ModalityType.APPLICATION_MODAL);
@@ -101,10 +103,10 @@ public class CustomDLCConflictWindow extends JDialog {
 
 			//write values to table data
 			data[i][COL_FILENAME] = key;
-			data[i][COL_SUPERCEDING] = value.get(value.size() - 1).getDlcName();
+			data[i][COL_SUPERCEDING] = value.get(value.size() - 1).getDlcName() + " (" + value.get(value.size() - 1).getMountFile().getMountPriority() + ")";
 			String superceeded = "";
 			for (int x = 0; x <= value.size() - 2; x++) {
-				superceeded += value.get(x).getDlcName() + " ";
+				superceeded += value.get(x).getDlcName() + " (" + value.get(x).getMountFile().getMountPriority() + ")\n";
 			}
 
 			data[i][COL_SUPERCEDED] = superceeded;
@@ -113,9 +115,18 @@ public class CustomDLCConflictWindow extends JDialog {
 
 		String[] columnNames = { "Filename", "Superceding DLC", "Superceeded DLC" };
 		DefaultTableModel model = new DefaultTableModel(data, columnNames);
+		final MultiLineTableCell mltc = new MultiLineTableCell();
 		JTable table = new JTable(model) {
 			public boolean isCellEditable(int row, int column) {
 				return false;
+			}
+
+			public TableCellRenderer getCellRenderer(int row, int column) {
+				if (column == COL_SUPERCEDED) {
+					return mltc;
+				} else {
+					return super.getCellRenderer(row, column);
+				}
 			}
 		};
 		table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
@@ -126,7 +137,6 @@ public class CustomDLCConflictWindow extends JDialog {
 		table.getColumnModel().getColumn(COL_SUPERCEDING).setCellRenderer(centerRenderer);
 
 		JScrollPane scrollpane = new JScrollPane(table);
-
 		JPanel panel = new JPanel(new BorderLayout());
 
 		String buttonText = "<html><center>Files listed below are Custom DLC files that have conflicts.<br>The Custom DLC with the highest mount priority will supercede others, and may cause the the superceded DLC to not work or cause game instability.<br><u><font color='#000099'>Click for info on how to toggle DLC in Mod Manager.</u></font></center></html>";

--- a/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
@@ -297,10 +297,13 @@ public class CustomDLCConflictWindow extends JDialog {
 		}
 
 		protected void done() {
+			guiProgressBar.setVisible(false);
 			if (secondPriorityUIConflictFiles != null) {
-				guiProgressBar.setVisible(false);
 				guiPatchButton.setVisible(true);
 				statusText.setText("A GUI mod conflicts with " + secondPriorityUIConflictFiles.entrySet().size() + " files");
+			} else {
+				guiPatchButton.setVisible(false);
+				statusText.setText("No GUI mod file conflicts");
 			}
 
 		}
@@ -518,6 +521,7 @@ public class CustomDLCConflictWindow extends JDialog {
 
 			skg.execute();
 			publish(new ThreadCommand("SET_STATUS_TEXT", "Generating Starter Kit for " + modName));
+			publish(new ThreadCommand("SET_PROGRESSBAR_VISIBLE"));
 
 			synchronized (skg.lock) {
 				while (!skg.completed) {

--- a/src/com/me3tweaks/modmanager/FailedModsWindow.java
+++ b/src/com/me3tweaks/modmanager/FailedModsWindow.java
@@ -116,6 +116,7 @@ public class FailedModsWindow extends JDialog implements ListSelectionListener {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
 				Mod mod = failedModsModel.get(failedModList.getSelectedIndex());
+				mod = new Mod(mod); //make clone
 				if (mod.getModMakerCode() <= 0 || ModManagerWindow.validateBIOGameDir()) {
 					if (mod.getModMakerCode() <= 0 || ModManager.validateNETFrameworkIsInstalled()) {
 						ModManager.debugLogger.writeMessage("Running (restore mode) for failed mod " + mod.getModName());

--- a/src/com/me3tweaks/modmanager/FolderBatchWindow.java
+++ b/src/com/me3tweaks/modmanager/FolderBatchWindow.java
@@ -62,7 +62,8 @@ public class FolderBatchWindow extends JDialog {
 			JButton compressAllPcc = new JButton("Compress all PCC files");
 			JButton sideloadAllModMaker = new JButton("Sideload all ModMaker XML files");
 
-			compileAllTLK.setToolTipText("<html>Treats each .xml file in the folder as a TankMaster TLK manifest.<br>Will attempt to compile all of them.</html>");
+			compileAllTLK
+					.setToolTipText("<html>Treats each .xml file in the folder as a TankMaster TLK manifest.<br>Will attempt to compile all of them.</html>");
 			decompileAllTLK.setToolTipText("<html>Decompiles all TLK files using the TankMaster compiler tool included with Mod Manager.</html>");
 			decompileAllCoalesced
 					.setToolTipText("<html>Decompils all Coalesced.bin files (will use header info) using the TankMaster compiler tool included with Mod Manager.</html>");
@@ -158,9 +159,64 @@ public class FolderBatchWindow extends JDialog {
 		} else {
 			String extension = FilenameUtils.getExtension(droppedFile.getAbsolutePath());
 			switch (extension) {
+			case "pcc": {
+				JLabel headerLabel = new JLabel("<html>You dropped an PCC file onto Mod Manager.<br>" + droppedFile
+						+ "<br>Select what operation to perform with this file.</html>");
+				panel.add(headerLabel, c);
+
+				JButton decompressPCC = new JButton("Decompress PCC");
+				JButton compressPCC = new JButton("Compress PCC");
+
+				decompressPCC.addActionListener(new ActionListener() {
+
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						String name = FilenameUtils.getName(droppedFile.getAbsolutePath());
+						ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Decompressing " + name);
+						ProcessResult pr = ModManager.decompressPCC(droppedFile, droppedFile);
+						if (pr.getReturnCode() == 0) {
+							ModManager.debugLogger.writeMessage("Deompressed " + name);
+							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Decompressed " + name);
+						} else {
+							ModManager.debugLogger.writeMessage("Failed to decompress " + name + "(" + pr.getReturnCode() + ")");
+							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Failed to decompress " + name + "(" + pr.getReturnCode() + ")");
+
+						}
+						dispose();
+					}
+				});
+
+				compressPCC.addActionListener(new ActionListener() {
+
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						String name = FilenameUtils.getName(droppedFile.getAbsolutePath());
+						ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Compressing " + name);
+						ProcessResult pr = ModManager.compressPCC(droppedFile, droppedFile);
+						if (pr.getReturnCode() == 0) {
+							ModManager.debugLogger.writeMessage("Compressed " + name);
+							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Compressed " + name);
+						} else {
+							ModManager.debugLogger.writeMessage("Failed to compressed " + name + "(" + pr.getReturnCode() + ")");
+							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Failed to compress " + name + "(" + pr.getReturnCode() + ")");
+
+						}
+						dispose();
+					}
+				});
+
+				c.gridy++;
+				panel.add(decompressPCC, c);
+				c.gridy++;
+
+				panel.add(compressPCC, c);
+				c.gridy++;
+
+				break;
+			}
 			case "xml":
-				JLabel headerLabel = new JLabel(
-						"<html>You dropped an XML file onto Mod Manager.<br>" + droppedFile + "<br>Select what operation to perform with this file.</html>");
+				JLabel headerLabel = new JLabel("<html>You dropped an XML file onto Mod Manager.<br>" + droppedFile
+						+ "<br>Select what operation to perform with this file.</html>");
 				panel.add(headerLabel, c);
 
 				JButton compileTLK = new JButton("Compile TLK (TLK Manifest (Tankmaster only))");

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -71,14 +71,14 @@ import com.sun.jna.platform.win32.WinReg;
 
 public class ModManager {
 
-	public static final String VERSION = "4.2.3";
-	public static long BUILD_NUMBER = 56L;
-	public static final String BUILD_DATE = "5/14/2016";
+	public static final String VERSION = "4.2.4";
+	public static long BUILD_NUMBER = 57L;
+	public static final String BUILD_DATE = "5/21/2016";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
-	public static final double MODMAKER_VERSION_SUPPORT = 2.0; // max modmaker
+	public static final double MODMAKER_VERSION_SUPPORT = 2.1; // max modmaker
 																// version
 	public static final double MODDESC_VERSION_SUPPORT = 4.2; // max supported
 																// cmmver in

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -73,9 +73,9 @@ public class ModManager {
 
 	public static final String VERSION = "4.2.4";
 	public static long BUILD_NUMBER = 57L;
-	public static final String BUILD_DATE = "5/27/2016";
+	public static final String BUILD_DATE = "6/1/2016";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = true;
+	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 2.1; // max modmaker
@@ -89,8 +89,8 @@ public class ModManager {
 	public static long LAST_AUTOUPDATE_CHECK;
 	public static final int MIN_REQUIRED_ME3EXPLORER_MAIN = 2;
 	public static final int MIN_REQUIRED_ME3EXPLORER_MINOR = 0;
-	public final static int MIN_REQUIRED_ME3EXPLORER_REV = 3;
-	public static final int MIN_REQUIRED_ME3GUITRANSPLANTER_BUILD = 6; //1.0.0.X
+	public final static int MIN_REQUIRED_ME3EXPLORER_REV = 6;
+	public static final int MIN_REQUIRED_ME3GUITRANSPLANTER_BUILD = 7; //1.0.0.X
 	private final static int MIN_REQUIRED_NET_FRAMEWORK_RELNUM = 378389; //4.5.0
 	public static boolean USE_GAME_TOCFILES_INSTEAD = false;
 	public static ArrayList<Image> ICONS;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -1557,7 +1557,7 @@ public class ModManager {
 				// System.out.println("Searching for file: " +
 				// searchSubDirDesc);
 				if (searchSubDirDesc.exists()) {
-					Patch validatingPatch = new Patch(searchSubDirDesc.getAbsolutePath());
+					Patch validatingPatch = new Patch(searchSubDirDesc.getAbsolutePath(), ModManager.appendSlash(subdirs[i].toString()) + "patch.jsf");
 					if (validatingPatch.isValid()) {
 						validPatches.add(validatingPatch);
 					}

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -73,9 +73,9 @@ public class ModManager {
 
 	public static final String VERSION = "4.2.4";
 	public static long BUILD_NUMBER = 57L;
-	public static final String BUILD_DATE = "5/21/2016";
+	public static final String BUILD_DATE = "5/27/2016";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = true;
+	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 2.1; // max modmaker

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -956,6 +956,13 @@ public class ModManager {
 		return getToolsDir() + "GUITransplanter/";
 	}
 
+	/**
+	 * Downloads Transplanter if not already downloaded. Returns path if
+	 * downloaded, null if not found locally after download attempt.
+	 * 
+	 * @param download
+	 * @return
+	 */
 	public static String getGUITransplanterCLI(boolean download) {
 		File transplanterexe = new File(getGUITransplanterDir() + "Transplanter-CLI.exe");
 		if (!transplanterexe.exists() && download) {
@@ -1060,6 +1067,7 @@ public class ModManager {
 
 	/**
 	 * Returns the mixinlibrary folder.
+	 * 
 	 * @return ME3CMM/mixinlibrary/
 	 */
 	public static String getPatchesDir() {
@@ -1688,6 +1696,7 @@ public class ModManager {
 
 	/**
 	 * Returns directory that contains folders of patches
+	 * 
 	 * @return /mixinlibrary/patches/
 	 */
 	public static String getPatchLibraryDir() {
@@ -1796,7 +1805,7 @@ public class ModManager {
 			int returncode = process.waitFor();
 			long endTime = System.currentTimeMillis();
 			ModManager.debugLogger.writeMessage("Process finished with code " + returncode + ", took " + (endTime - startTime) + " ms.");
-			ModManager.debugLogger.writeMessage("Process output: "+writer.toString());
+			ModManager.debugLogger.writeMessage("Process output: " + writer.toString());
 			writer.close();
 			return new ProcessResult(returncode, null);
 		} catch (IOException | InterruptedException e) {
@@ -1980,20 +1989,6 @@ public class ModManager {
 					filesMap.put(filename, dlcFileAppearsIn);
 				}
 			}
-
-			//remove non-conflicts
-			ArrayList<String> keysToRemove = new ArrayList<String>();
-			for (Map.Entry<String, ArrayList<CustomDLC>> entry : filesMap.entrySet()) {
-				String key = entry.getKey();
-				ArrayList<CustomDLC> value = entry.getValue();
-				if (value.size() <= 1) {
-					//not a conflict
-					keysToRemove.add(key);
-				}
-			}
-			for (String key : keysToRemove) {
-				filesMap.remove(key);
-			}
 			return filesMap;
 		} catch (Exception e) {
 			ModManager.debugLogger.writeErrorWithException("Error getting DLC conflict list:", e);
@@ -2025,12 +2020,17 @@ public class ModManager {
 		return foldernames;
 	}
 
-	
 	/**
 	 * Gets the path to the GUI library specified by the DLC name
-	 * @param dlcname DLC to get library for
-	 * @param download Download library if library not found. If set to false, this will return the library path, if true it will return null if the library can't be downloaded.
-	 * @return library path or null if download is true and library can't be downloaded
+	 * 
+	 * @param dlcname
+	 *            DLC to get library for
+	 * @param download
+	 *            Download library if library not found. If set to false, this
+	 *            will return the library path, if true it will return null if
+	 *            the library can't be downloaded.
+	 * @return library path or null if download is true and library can't be
+	 *         downloaded
 	 */
 	public static String getGUILibraryFor(String dlcname, boolean download) {
 		String libraryPath = getUILibraryPath();
@@ -2108,5 +2108,25 @@ public class ModManager {
 	 */
 	private static String getUILibraryPath() {
 		return getDataDir() + "UILibrary" + File.separator;
+	}
+
+	/**
+	 * Returns true if DLC_CON_XBX, DLC_CON_UIScaling, or
+	 * DLC_CON_UIScaling_Shared is present in the DLC directory.
+	 * 
+	 * @param biogameDirectory
+	 *            biogame dir
+	 * @return true if folder exists, false otherwise
+	 */
+	public static boolean isGUIModInstalled(String biogameDirectory) {
+		String dlcfolder = appendSlash(biogameDirectory) + "DLC/";
+		for (String dlc : KNOWN_GUI_CUSTOMDLC_MODS) {
+			File f = new File(dlcfolder + dlc);
+			ModManager.debugLogger.writeMessage("Scanning for UI mod: " + f);
+			if (f.exists() && f.isDirectory()) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -75,7 +75,7 @@ public class ModManager {
 	public static long BUILD_NUMBER = 57L;
 	public static final String BUILD_DATE = "5/27/2016";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 2.1; // max modmaker
@@ -1058,6 +1058,10 @@ public class ModManager {
 		return appendSlash(file.getAbsolutePath());
 	}
 
+	/**
+	 * Returns the mixinlibrary folder.
+	 * @return ME3CMM/mixinlibrary/
+	 */
 	public static String getPatchesDir() {
 		File file = new File(getDataDir() + "mixinlibrary/");
 		file.mkdirs();
@@ -1682,6 +1686,10 @@ public class ModManager {
 		}
 	}
 
+	/**
+	 * Returns directory that contains folders of patches
+	 * @return /mixinlibrary/patches/
+	 */
 	public static String getPatchLibraryDir() {
 		return getPatchesDir() + "patches/";
 	}

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -830,6 +830,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 						case "rar":
 							new ModImportArchiveWindow(ModManagerWindow.this, files[0].toString());
 							break;
+						case "pcc":
 						case "xml":
 							new FolderBatchWindow(ModManagerWindow.this, files[0]);
 							break;
@@ -839,6 +840,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 						case "tlk":
 							TLKTool.decompileTLK(files[0]);
 							break;
+							
 						case "bin":
 							//read magic at beginning to find out what type of file this is
 							try {

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -114,7 +114,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	JMenu actionMenu, modMenu, modManagementMenu, devMenu, modDeltaMenu, toolsMenu, backupMenu, restoreMenu, sqlMenu, helpMenu, openToolMenu;
 	JMenuItem actionExitDebugMode, actionModMaker, actionVisitMe, actionOptions, actionReload, actionExit;
 	JMenuItem modManagementImportFromArchive, modManagementImportAlreadyInstalled, modManagementConflictDetector, modManagementModMaker, modManagementFailedMods,
-			modManagementPatchLibary;
+			modManagementPatchLibary,modManagementClearPatchLibraryCache;
 	JMenuItem modutilsHeader, modutilsInfoEditor, modNoDeltas, modutilsVerifyDeltas, modutilsInstallCustomKeybinds, modutilsAutoTOC, modutilsCheckforupdate, modutilsRestoreMod,
 			modutilsDeleteMod;
 	JMenuItem toolME3Explorer, toolsOpenME3Dir, toolsInstallLauncherWV, toolsInstallBinkw32, toolsUninstallBinkw32, toolsMountdlcEditor, toolsMergeMod, toolME3Config;
@@ -1129,6 +1129,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modManagementPatchLibary.setToolTipText("Add premade mixins to mods using patches in your patch library");
 		modManagementOpenModsFolder = new JMenuItem("Open mods/ folder");
 		modManagementOpenModsFolder.setToolTipText("Opens the mods/ folder so you can inspect and add/remove mods");
+		modManagementClearPatchLibraryCache = new JMenuItem("Clear MixIn cache");
+		modManagementClearPatchLibraryCache.setToolTipText("<html>Clears the decompressed MixIn library cache.<br>This will make Mod Manager fetch the original files again as MixIns require them.<br>Use this if MixIns are having issues.</html>");
 
 		int numFailedMods = getInvalidMods().size();
 		modManagementFailedMods = new JMenuItem(numFailedMods + " mod" + (numFailedMods != 1 ? "s" : "") + " failed to load");
@@ -1147,8 +1149,11 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modManagementMenu.add(modManagementCheckallmodsforupdate);
 		modManagementMenu.add(modManagementPatchLibary);
 		modManagementMenu.add(modManagementOpenModsFolder);
+		modManagementMenu.addSeparator();
+		modManagementMenu.add(modManagementClearPatchLibraryCache);
 		menuBar.add(modManagementMenu);
 
+		modManagementClearPatchLibraryCache.addActionListener(this);
 		modManagementOpenModsFolder.addActionListener(this);
 		modManagementFailedMods.addActionListener(this);
 		modManagementImportFromArchive.addActionListener(this);
@@ -1850,6 +1855,16 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			ResourceUtils.openDir(ModManager.getTankMasterCompilerDir());
 		} else if (e.getSource() == modManagementOpenModsFolder) {
 			ResourceUtils.openDir(ModManager.getModsDir());
+		} else if (e.getSource() == modManagementClearPatchLibraryCache) {
+			File libraryDir = new File(ModManager.getPatchesDir()+"source");
+			if (libraryDir.exists() ){
+				boolean deleted =FileUtils.deleteQuietly(libraryDir);
+				labelStatus.setText("MixIn cache deleted");
+				ModManager.debugLogger.writeMessage("Deleted mixin cache "+libraryDir+ ": "+deleted);
+			} else {
+				ModManager.debugLogger.writeMessage("No mixin cache: "+libraryDir);
+				labelStatus.setText("No MixIn cache to delete");
+			}
 		} else if (e.getSource() == toolTankmasterTLK) {
 			if (ModManager.validateNETFrameworkIsInstalled()) {
 				updateApplyButton();
@@ -2008,6 +2023,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			if (mod.getModMakerCode() <= 0 || validateBIOGameDir()) {
 				if (mod.getModMakerCode() <= 0 || ModManager.validateNETFrameworkIsInstalled()) {
 					ModManager.debugLogger.writeMessage("Running (restore mode) single mod update check on " + mod.getModName());
+					mod = new Mod(mod); //create clone
 					mod.setVersion(0.001);
 					new SingleModUpdateCheckThread(mod).execute();
 				} else {

--- a/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
@@ -188,7 +188,9 @@ public class PatchApplicationWindow extends JDialog {
 								case Patch.APPLY_FAILED_OTHERERROR:
 									JOptionPane.showMessageDialog(PatchApplicationWindow.this, patch.getPatchName()+" failed to apply because a generic error occured. Report this to FemShep if you keep having this issue.", "MixIn failed to apply", JOptionPane.ERROR_MESSAGE);
 									break;
-							}
+								case Patch.APPLY_FAILED_SIZE_CHANGED:
+									JOptionPane.showMessageDialog(PatchApplicationWindow.this, patch.getPatchName()+" was applied but the filesize of the output file changed,\nbut this MixIn was not marked as a finalizer.", "MixIn incorrectly marked", JOptionPane.ERROR_MESSAGE);
+									break;							}
 						}
 					}
 				}

--- a/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
@@ -71,7 +71,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 		ModManager.debugLogger.writeMessage("Loading mixin library interface");
 		setupWindow();
 		setLocationRelativeTo(ModManagerWindow.ACTIVE_WINDOW);
-		new ME3TweaksLibraryUpdater(ModManagerWindow.ACTIVE_WINDOW.getPatchList(), false).execute();
+		new ME3TweaksLibraryUpdater(null, ModManagerWindow.ACTIVE_WINDOW.getPatchList(), false).execute();
 		setVisible(true);
 	}
 
@@ -114,11 +114,11 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 		this.automated_mod = mod;
 		this.dynamicMixIns = dynamicMixIns;
 		if (hasMissingMixIn) {
-			new ME3TweaksLibraryUpdater(ModManagerWindow.ACTIVE_WINDOW.getPatchList(), true).execute();
+			new ME3TweaksLibraryUpdater(callingDialog,ModManagerWindow.ACTIVE_WINDOW.getPatchList(), true).execute();
 			setupAutomatedWindow(callingDialog);
 			setVisible(true);
 		} else {
-			advertiseInstalls(automated_requiredMixinIds, automated_mod);
+			advertiseInstalls(callingDialog, automated_requiredMixinIds, automated_mod);
 			dispose();
 		}
 	}
@@ -141,7 +141,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 		this.setLocationRelativeTo(callingDialog);
 	}
 
-	private void advertiseInstalls(ArrayList<Integer> mixinIds, Mod mod) {
+	private void advertiseInstalls(JDialog callingDialog, ArrayList<Integer> mixinIds, Mod mod) {
 		//Build patch array, build prompt text
 		String str = "This mod wants to apply the following MixIns from ME3Tweaks:";
 		ArrayList<Patch> patches = new ArrayList<Patch>();
@@ -186,7 +186,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 			if (!mod.isValidMod()) {
 				return; // this shouldn't be reachable anyways
 			}
-			PatchApplicationWindow paw = new PatchApplicationWindow(this, patches, mod);
+			PatchApplicationWindow paw = new PatchApplicationWindow(callingDialog, patches, mod);
 			ArrayList<Patch> failedpatches = paw.getFailedPatches();
 			if (failedpatches.size() > 0) {
 				String rstr = "The following MixIns failed to apply:\n";
@@ -352,8 +352,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 			new AutoTocWindow(mod, AutoTocWindow.LOCALMOD_MODE, ModManagerWindow.ACTIVE_WINDOW.fieldBiogameDir.getText());
 			ArrayList<Patch> failedpatches = paw.getFailedPatches();
 			if (failedpatches.size() <= 0) {
-				JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "All mixins were applied.", "MixIns applied",
-						JOptionPane.INFORMATION_MESSAGE);
+				JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "All mixins were applied.", "MixIns applied", JOptionPane.INFORMATION_MESSAGE);
 			} else {
 				String str = "The following MixIns failed to apply:\n";
 				for (Patch p : failedpatches) {
@@ -373,10 +372,12 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 		boolean modmakerMode;
 		boolean atLeast1New = false;
 		ArrayList<Patch> patches;
+		private JDialog callingDialog;
 
-		public ME3TweaksLibraryUpdater(ArrayList<Patch> patches, boolean isInModMakerMode) {
+		public ME3TweaksLibraryUpdater(JDialog callingDialog, ArrayList<Patch> patches, boolean isInModMakerMode) {
 			this.modmakerMode = isInModMakerMode;
 			this.patches = patches;
+			this.callingDialog = callingDialog;
 		}
 
 		@Override
@@ -434,8 +435,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 						}
 
 						if (localpatch.getPatchVersion() < serverpack.getPatchver()) {
-							ModManager.debugLogger.writeMessage("Local MixIn " + serverpack.getPatchname()
-									+ " is out of date, adding to download queue");
+							ModManager.debugLogger.writeMessage("Local MixIn " + serverpack.getPatchname() + " is out of date, adding to download queue");
 							continue;
 						}
 
@@ -445,8 +445,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 						break;
 					}
 					if (needsDownloaded) {
-						ModManager.debugLogger.writeMessage("Server MixIn " + serverpack.getPatchname()
-								+ " is not present locally, adding to download queue");
+						ModManager.debugLogger.writeMessage("Server MixIn " + serverpack.getPatchname() + " is not present locally, adding to download queue");
 						packsToDownload.add(serverpack);
 					}
 				}
@@ -467,7 +466,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 					String patchDesc = Patch.generatePatchDesc(pack);
 					FileUtils.writeStringToFile(new File(targetFolderStr + "patchdesc.ini"), patchDesc);
 
-					Patch p = new Patch(targetFolderStr + "patchdesc.ini",targetFolderStr + "patch.jsf");
+					Patch p = new Patch(targetFolderStr + "patchdesc.ini", targetFolderStr + "patch.jsf");
 					publish(new ThreadCommand("REMOVE_LOCAL_LIST_PATCH", null, p));
 					publish(new ThreadCommand("ADD_PATCH", null, p));
 				}
@@ -536,7 +535,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 					JOptionPane.showMessageDialog(null, errorStr, "Missing MixIns", JOptionPane.WARNING_MESSAGE);
 				}
 				dispose();
-				advertiseInstalls(automated_requiredMixinIds, automated_mod);
+				advertiseInstalls(callingDialog, automated_requiredMixinIds, automated_mod);
 			}
 		}
 
@@ -574,6 +573,11 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 				this.minVersion = 1;
 			}
 		}
+	}
+
+	public Object getApplyLock() {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
@@ -467,7 +467,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 					String patchDesc = Patch.generatePatchDesc(pack);
 					FileUtils.writeStringToFile(new File(targetFolderStr + "patchdesc.ini"), patchDesc);
 
-					Patch p = new Patch(targetFolderStr + "patchdesc.ini");
+					Patch p = new Patch(targetFolderStr + "patchdesc.ini",targetFolderStr + "patch.jsf");
 					publish(new ThreadCommand("REMOVE_LOCAL_LIST_PATCH", null, p));
 					publish(new ThreadCommand("ADD_PATCH", null, p));
 				}

--- a/src/com/me3tweaks/modmanager/TLKTool.java
+++ b/src/com/me3tweaks/modmanager/TLKTool.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -59,8 +60,9 @@ public class TLKTool {
 	}
 
 	public static void main(String[] args) throws Exception {
+		parseJPatchString("a7a3fe0028efd0a7a600001644a7a3fe002c3b4c");
 		//replacementScan();
-		compileTLK("E:\\MPTLK\\mp5");
+		//compileTLK("E:\\MPTLK\\mp5");
 		//decompileTLK("E:\\MPTLK\\mp5");
 		//comparisonScan();
 		//initialScanTankmaster();
@@ -71,6 +73,53 @@ public class TLKTool {
 		//compileTLK("E:\\Google Drive\\SP Controller Support\\TLK\\moonshine_tlk\\");
 		//String folderpath = "C:\\Users\\\Desktop\\tlk\\BIOGame_ITA\\";
 		//combineIntoSingleFile(folderpath);
+	}
+
+	private static void parseJPatchString(String string) {
+		final char ESC = 0xA7;
+		final char EQL = 0xA3;
+		final char MOD = 0xA6;
+		byte[] data = DatatypeConverter.parseHexBinary(string);
+		int bytepos = 0;
+		int twoprev = 0;
+		int prev = 0;
+		int current = 0;
+		boolean readingdata = false;
+		int op = -1;
+		for (byte b : data) {
+			int val = b & 0xFF;
+			twoprev = prev;
+			prev = current;
+			current = val;
+			
+			if (current == ESC) {
+				System.out.println("Read ESC at "+bytepos);
+			}
+			
+			if (readingdata) {
+				switch(op) {
+				case MOD:
+					//read until end
+					break;
+				}
+			}
+			
+			if (current == MOD && prev == ESC && twoprev != ESC) {
+				System.out.println("Read OP MOD at "+bytepos);
+				readingdata = true;
+				bytepos++;
+				continue;
+			}
+			if (current == EQL && prev == ESC && twoprev != ESC) {
+				System.out.println("Read OP EQL at "+bytepos);
+				readingdata = true;
+				bytepos++;
+				continue;
+			}
+			
+			
+			bytepos++;
+		}
 	}
 
 	/**

--- a/src/com/me3tweaks/modmanager/TLKTool.java
+++ b/src/com/me3tweaks/modmanager/TLKTool.java
@@ -2,6 +2,7 @@ package com.me3tweaks.modmanager;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -9,6 +10,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Scanner;
+import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,7 +63,7 @@ public class TLKTool {
 	}
 
 	public static void main(String[] args) throws Exception {
-		parseJPatchString("a7a3fe0028efd0a7a600001644a7a3fe002c3b4c");
+		performFix();
 		//replacementScan();
 		//compileTLK("E:\\MPTLK\\mp5");
 		//decompileTLK("E:\\MPTLK\\mp5");
@@ -73,6 +76,18 @@ public class TLKTool {
 		//compileTLK("E:\\Google Drive\\SP Controller Support\\TLK\\moonshine_tlk\\");
 		//String folderpath = "C:\\Users\\\Desktop\\tlk\\BIOGame_ITA\\";
 		//combineIntoSingleFile(folderpath);
+	}
+
+	private static void performFix() throws FileNotFoundException {
+		Scanner scanner = new Scanner(new File("C:\\Users\\Michael\\Desktop\\set.txt"));
+		while (scanner.hasNextLine()){
+			String line = scanner.nextLine();
+			StringTokenizer stk = new StringTokenizer(line," ");
+			String id = stk.nextToken();
+			String cat = stk.nextToken();
+			String out = "UPDATE dynamicmixinlibrary SET category = "+cat+" WHERE id = "+id+";";
+			System.out.println(out);
+		}
 	}
 
 	private static void parseJPatchString(String string) {

--- a/src/com/me3tweaks/modmanager/modmaker/DynamicPatch.java
+++ b/src/com/me3tweaks/modmanager/modmaker/DynamicPatch.java
@@ -1,0 +1,64 @@
+package com.me3tweaks.modmanager.modmaker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.apache.commons.io.FileUtils;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import com.me3tweaks.modmanager.ModManager;
+import com.me3tweaks.modmanager.objects.Patch;
+import com.sun.org.apache.xml.internal.security.exceptions.Base64DecodingException;
+import com.sun.org.apache.xml.internal.security.utils.Base64;
+
+/**
+ * Patch that can be compiled and applied on the fly
+ * 
+ * @author mjperez
+ *
+ */
+public class DynamicPatch {
+	Patch finalPatch;
+
+	/**
+	 * Creates a dynamic mixin object from a node in modmaker xml
+	 * 
+	 * @param dynamicmixinNode
+	 *            node to create dynamic patch object from.
+	 * @throws DOMException 
+	 * @throws Base64DecodingException 
+	 * @throws IOException 
+	 */
+	public DynamicPatch(Node dynamicmixinNode) throws Base64DecodingException, DOMException, IOException {
+		NamedNodeMap map = dynamicmixinNode.getAttributes();
+		byte[] datatowrite = Base64.decode(dynamicmixinNode.getTextContent());
+		File outputfile = new File(ModManager.getTempDir()+"dynamicpatch-"+UUID.randomUUID().toString()+".jsf");
+		FileUtils.writeByteArrayToFile(outputfile, datatowrite);
+		finalPatch = new Patch();
+		finalPatch.setTargetPath(map.getNamedItem("targetpath").getTextContent());
+		finalPatch.setTargetModule(map.getNamedItem("targetpath").getTextContent());
+		finalPatch.setPatchPath("");
+		finalPatch.setValid(true);
+		finalPatch.setFinalizer(false);
+		finalPatch.setPatchName(map.getNamedItem("name").getTextContent());
+		finalPatch.setPatchDescription("Automatically generated ModMaker MixIn");
+		finalPatch.setPatchFolderPath("");
+		finalPatch.setTargetSize(Long.parseLong(map.getNamedItem("targetsize").getTextContent()));
+		finalPatch.setPatchVersion(1);
+		finalPatch.setPatchCMMVer(ModManager.MODDESC_VERSION_SUPPORT);
+		finalPatch.setPatchAuthor("ME3Tweaks ModMaker Dynamic MixIn");
+		finalPatch.setMe3tweaksid(0);
+	}
+
+	public Patch getFinalPatch() {
+		return finalPatch;
+	}
+
+	public void setFinalPatch(Patch finalPatch) {
+		this.finalPatch = finalPatch;
+	}
+
+}

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -1,7 +1,6 @@
 package com.me3tweaks.modmanager.modmaker;
 
 import java.awt.BorderLayout;
-import java.awt.Container;
 import java.awt.Dimension;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -9,6 +8,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,6 +61,7 @@ import com.me3tweaks.modmanager.PatchLibraryWindow;
 import com.me3tweaks.modmanager.objects.Mod;
 import com.me3tweaks.modmanager.objects.ModDelta;
 import com.me3tweaks.modmanager.objects.ThreadCommand;
+import com.me3tweaks.modmanager.utilities.ResourceUtils;
 import com.me3tweaks.modmanager.valueparsers.biodifficulty.Category;
 import com.me3tweaks.modmanager.valueparsers.enemytype.EnemyType;
 import com.me3tweaks.modmanager.valueparsers.id.ID;
@@ -68,7 +69,6 @@ import com.me3tweaks.modmanager.valueparsers.possessionwaves.Difficulty;
 import com.me3tweaks.modmanager.valueparsers.sharedassignment.SharedDifficulty;
 import com.me3tweaks.modmanager.valueparsers.waveclass.WaveClass;
 import com.me3tweaks.modmanager.valueparsers.wavelist.Wave;
-import com.sun.org.apache.xml.internal.security.exceptions.Base64DecodingException;
 
 @SuppressWarnings("serial")
 public class ModMakerCompilerWindow extends JDialog {
@@ -171,15 +171,18 @@ public class ModMakerCompilerWindow extends JDialog {
 				//nothing
 			}
 			String link = null;
+			String lzmalink = null;
 			if (mmcode > 0) {
 				//Download
 				ModManager.debugLogger.writeMessage("================DOWNLOADING MOD INFORMATION==============");
+				//ATTEMPT LZMA
 				if (ModManager.IS_DEBUG) {
 					link = "http://webdev-c9-mgamerz.c9.io/modmaker/download.php?id=" + code;
 				} else {
 					link = "https://me3tweaks.com/modmaker/download.php?id=" + code;
 				}
-				ModManager.debugLogger.writeMessage("Fetching mod from " + link);
+				lzmalink = link + "&method=lzma";
+				ModManager.debugLogger.writeMessage("Fetching mod from " + lzmalink);
 			} else {
 				//Sideload
 				ModManager.debugLogger.writeMessage("================SKIP DOWNLOAD, USING SIDELOAD METHOD==============");
@@ -188,7 +191,37 @@ public class ModMakerCompilerWindow extends JDialog {
 			try {
 				String modDelta = null;
 				if (mmcode > 0) {
-					modDelta = IOUtils.toString(new URL(link));
+					try {
+						String downloadedfile = ModManager.getTempDir()+code+".xml";
+						File lzmafile = new File(downloadedfile+".lzma");
+						publish(new ThreadCommand("UPDATE_INFO", "<html>Downloading mod delta from ME3Tweaks</html>"));
+						FileUtils.copyURLToFile(new URL(lzmalink), lzmafile);
+						publish(new ThreadCommand("UPDATE_INFO", "<html>Decompressing mod delta</html>"));
+						if (ResourceUtils.decompressLZMAFile(lzmafile.getAbsolutePath(), null)) {
+							//decompressed OK
+							modDelta = FileUtils.readFileToString(new File(downloadedfile));
+							FileUtils.deleteQuietly(new File(downloadedfile));
+							FileUtils.deleteQuietly(lzmafile);
+						} else {
+							FileUtils.deleteQuietly(new File(downloadedfile));
+							FileUtils.deleteQuietly(lzmafile);
+							throw new IOException("Failed to decompress LZMA file, falling back...");
+						}
+					} catch (IOException e) {
+						FileUtils.deleteQuietly(new File(ModManager.getTempDir()+code+".xml"));
+						FileUtils.deleteQuietly(new File(ModManager.getTempDir()+code+".xml.lzma"));
+						try {
+							ModManager.debugLogger.writeMessage("I/O Exception using LZMA link, falling back to decompressed link...");
+							publish(new ThreadCommand("UPDATE_INFO", "<html>Downloading mod delta from ME3Tweaks</html>"));
+							modDelta = IOUtils.toString(new URL(link), StandardCharsets.UTF_8);
+						} catch (IOException ex) {
+							ModManager.debugLogger.writeErrorWithException("I/O Exception using LZMA and fallback links, giving up. ", ex);
+							dispose();
+							publish(new ThreadCommand("ERROR", "<html>Unable to download ME3Tweaks ModMaker mod:<br>" + ex.getMessage() + "</html>"));
+							running = false;
+							return;
+						}
+					}
 				} else {
 					//load sideload
 					modDelta = FileUtils.readFileToString(new File(code));
@@ -196,6 +229,7 @@ public class ModMakerCompilerWindow extends JDialog {
 				//File downloaded = new File(DOWNLOADED_XML_FILENAME);
 				//downloaded.delete();
 				//FileUtils.copyURLToFile(new URL(link), downloaded);
+				publish(new ThreadCommand("UPDATE_INFO", "<html>Parsing Mod Delta</html>"));
 				ModManager.debugLogger.writeMessage("Mod delta downloaded to memory");
 				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 				ModManager.debugLogger.writeMessage("Loading mod delta into document into memory.");
@@ -214,33 +248,38 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (MalformedURLException e) {
 				running = false;
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while preparing to compile the mod:\n" + e.getMessage()
-						+ "\nCheck the Mod Manager log for more info (in the help menu).", "Pre-compilation error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
+						"An error occured while preparing to compile the mod:\n" + e.getMessage() + "\nCheck the Mod Manager log for more info (in the help menu).",
+						"Pre-compilation error", JOptionPane.ERROR_MESSAGE);
 				new ModManagerWindow(false);
 			} catch (IOException e) {
 				running = false;
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while preparing to compile the mod:\n" + e.getMessage()
-						+ "\nCheck the Mod Manager log for more info (in the help menu).", "Pre-compilation error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
+						"An error occured while preparing to compile the mod:\n" + e.getMessage() + "\nCheck the Mod Manager log for more info (in the help menu).",
+						"Pre-compilation error", JOptionPane.ERROR_MESSAGE);
 				new ModManagerWindow(false);
 			} catch (ParserConfigurationException e) {
 				running = false;
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while preparing to compile the mod:\n" + e.getMessage()
-						+ "\nCheck the Mod Manager log for more info (in the help menu).", "Pre-compilation error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
+						"An error occured while preparing to compile the mod:\n" + e.getMessage() + "\nCheck the Mod Manager log for more info (in the help menu).",
+						"Pre-compilation error", JOptionPane.ERROR_MESSAGE);
 
 				new ModManagerWindow(false);
 			} catch (SAXException e) {
 				running = false;
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while preparing to compile the mod:\n" + e.getMessage()
-						+ "\nCheck the Mod Manager log for more info (in the help menu).", "Pre-compilation error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
+						"An error occured while preparing to compile the mod:\n" + e.getMessage() + "\nCheck the Mod Manager log for more info (in the help menu).",
+						"Pre-compilation error", JOptionPane.ERROR_MESSAGE);
 				new ModManagerWindow(false);
 			} catch (Exception e) {
 				running = false;
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while preparing to compile the mod:\n" + e.getMessage()
-						+ "\nCheck the Mod Manager log for more info (in the help menu).", "Pre-compilation error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
+						"An error occured while preparing to compile the mod:\n" + e.getMessage() + "\nCheck the Mod Manager log for more info (in the help menu).",
+						"Pre-compilation error", JOptionPane.ERROR_MESSAGE);
 				dispose();
 				//new ModManagerWindow(false);
 			}
@@ -302,13 +341,10 @@ public class ModMakerCompilerWindow extends JDialog {
 			modMakerVersion = Double.parseDouble(modModMakerVersion);
 			if (modMakerVersion > ModManager.MODMAKER_VERSION_SUPPORT) {
 				//ERROR! We can't compile this version.
-				ModManager.debugLogger
-						.writeError("This version of mod manager does not support the server version of ModMaker that was used to compile this mod delta.");
-				ModManager.debugLogger
-						.writeError("FATAL ERROR: This version supports up to ModMaker version: " + ModManager.MODMAKER_VERSION_SUPPORT);
+				ModManager.debugLogger.writeError("This version of mod manager does not support the server version of ModMaker that was used to compile this mod delta.");
+				ModManager.debugLogger.writeError("FATAL ERROR: This version supports up to ModMaker version: " + ModManager.MODMAKER_VERSION_SUPPORT);
 				ModManager.debugLogger.writeError("FATAL ERROR: This mod was built with ModMaker version: " + modModMakerVersion);
-				publish(new ThreadCommand(
-						"ERROR",
+				publish(new ThreadCommand("ERROR",
 						"<html>This mod was built with a newer version of ModMaker than this version of Mod Manager can support.<br>You need to download the latest copy of Mod Manager to compile this mod.</html>"));
 				error = true;
 				return;
@@ -337,8 +373,8 @@ public class ModMakerCompilerWindow extends JDialog {
 							dp = new DynamicPatch(dynamicmixinNode);
 							dynamicMixins.add(dp);
 							ModManager.debugLogger.writeMessage("Mod contains dynamic mixin: " + dp.getFinalPatch().getPatchName());
-						} catch (Base64DecodingException | DOMException | IOException e) {
-							ModManager.debugLogger.writeErrorWithException("Error preparing dynamic mixin, skipping:" , e);
+						} catch (DOMException | IOException e) {
+							ModManager.debugLogger.writeErrorWithException("Error preparing dynamic mixin, skipping:", e);
 						}
 					}
 				}
@@ -523,11 +559,11 @@ public class ModMakerCompilerWindow extends JDialog {
 
 		new DecompilerWorker(requiredCoals, currentStepProgress).execute();
 	} /*
-	 * 
-	 * /** Decompiles a coalesced into .xml files using tankmaster's tools.
-	 * 
-	 * @author Michael
-	 */
+		 * 
+		 * /** Decompiles a coalesced into .xml files using tankmaster's tools.
+		 * 
+		 * @author Michael
+		 */
 
 	class DecompilerWorker extends SwingWorker<Void, Integer> {
 		private ArrayList<String> coalsToDecompile;
@@ -591,10 +627,9 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (ExecutionException e) {
 				ModManager.debugLogger.writeMessage("Error occured in DecompilerWorker():");
 				ModManager.debugLogger.writeException(e);
-				JOptionPane
-						.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while decompiling coalesced files:\n" + e.getMessage()
-								+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error",
-								JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
+						"An error occured while decompiling coalesced files:\n" + e.getMessage() + "\n\nYou should report this to FemShep via the Forums link in the help menu.",
+						"Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block
@@ -635,11 +670,11 @@ public class ModMakerCompilerWindow extends JDialog {
 				//ProcessBuilder compileProcessBuilder = new ProcessBuilder(
 				//		compilerPath, "--xml2bin", path + "\\coalesceds\\"
 				//				+ FilenameUtils.removeExtension(coal)+".xml");
-				ProcessBuilder compileProcessBuilder = new ProcessBuilder(compilerPath, path + "\\coalesceds\\" + FilenameUtils.removeExtension(coal)
-						+ "\\" + FilenameUtils.removeExtension(coal) + ".xml", "--mode=ToBin");
+				ProcessBuilder compileProcessBuilder = new ProcessBuilder(compilerPath,
+						path + "\\coalesceds\\" + FilenameUtils.removeExtension(coal) + "\\" + FilenameUtils.removeExtension(coal) + ".xml", "--mode=ToBin");
 				//log it
-				ModManager.debugLogger.writeMessage("Executing compile command: " + compilerPath + " " + path + "\\coalesceds\\"
-						+ FilenameUtils.removeExtension(coal) + "\\" + FilenameUtils.removeExtension(coal) + ".xml --mode=ToBin");
+				ModManager.debugLogger.writeMessage("Executing compile command: " + compilerPath + " " + path + "\\coalesceds\\" + FilenameUtils.removeExtension(coal) + "\\"
+						+ FilenameUtils.removeExtension(coal) + ".xml --mode=ToBin");
 				compileProcessBuilder.redirectErrorStream(true);
 				compileProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
 				Process compileProcess = compileProcessBuilder.start();
@@ -666,10 +701,8 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (ExecutionException e) {
 				ModManager.debugLogger.writeMessage("Error occured in CompilerWorker():");
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
-						"An error occured while trying to recompile modified coalesced xml files into a coalesced.bin file:\n" + e.getMessage()
-								+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to recompile modified coalesced xml files into a coalesced.bin file:\n"
+						+ e.getMessage() + "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block
@@ -709,10 +742,8 @@ public class ModMakerCompilerWindow extends JDialog {
 					if (!ModManager.hasPristineCoalesced(coal, ME3TweaksUtils.FILENAME)) {
 						ME3TweaksUtils.downloadPristineCoalesced(coal, ME3TweaksUtils.FILENAME);
 					}
-					FileUtils.copyFile(new File(ModManager.getPristineCoalesced(coal, ME3TweaksUtils.FILENAME)),
-							new File(ModManager.getCompilingDir() + "coalesceds/" + coal));
-					ModManager.debugLogger.writeMessage("Copied pristine coalesced of " + coal + " to: "
-							+ (new File("coalesceds/" + coal)).getAbsolutePath());
+					FileUtils.copyFile(new File(ModManager.getPristineCoalesced(coal, ME3TweaksUtils.FILENAME)), new File(ModManager.getCompilingDir() + "coalesceds/" + coal));
+					ModManager.debugLogger.writeMessage("Copied pristine coalesced of " + coal + " to: " + (new File("coalesceds/" + coal)).getAbsolutePath());
 					coalsCompeted++;
 					this.publish(coalsCompeted);
 				} catch (IOException e) {
@@ -740,10 +771,8 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (ExecutionException e) {
 				ModManager.debugLogger.writeMessage("Error occured in CoalDownloadWorker():");
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
-						"An error occured while trying to download pristine Coalesced files from ME3Tweaks:\n" + e.getMessage()
-								+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to download pristine Coalesced files from ME3Tweaks:\n" + e.getMessage()
+						+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block
@@ -796,8 +825,7 @@ public class ModMakerCompilerWindow extends JDialog {
 				if (coalNode.getNodeType() == Node.ELEMENT_NODE) {
 					String intCoalName = coalNode.getNodeName(); //get the coal name so we can figure out what folder to look in.
 					ModManager.debugLogger.writeMessage("Read coalecesed ID: " + intCoalName);
-					ModManager.debugLogger.writeMessage("---------------------MODMAKER COMPILER START OF " + intCoalName
-							+ "-------------------------");
+					ModManager.debugLogger.writeMessage("---------------------MODMAKER COMPILER START OF " + intCoalName + "-------------------------");
 
 					String foldername = FilenameUtils.removeExtension(ME3TweaksUtils.internalNameToCoalFilename(intCoalName));
 					NodeList filesNodeList = coalNode.getChildNodes();
@@ -807,10 +835,9 @@ public class ModMakerCompilerWindow extends JDialog {
 							//we now have a file ID such as biogame.
 							//We need to load that XML file now.
 							String iniFileName = fileNode.getNodeName() + ".xml";
-							ModManager.debugLogger.writeMessage("Loading Coalesced XML fragment into memory: " + ModManager.getCompilingDir()
-									+ "coalesceds\\" + foldername + "\\" + iniFileName);
-							Document iniFile = dbFactory.newDocumentBuilder().parse(
-									"file:///" + ModManager.getCompilingDir() + "coalesceds\\" + foldername + "\\" + iniFileName);
+							ModManager.debugLogger
+									.writeMessage("Loading Coalesced XML fragment into memory: " + ModManager.getCompilingDir() + "coalesceds\\" + foldername + "\\" + iniFileName);
+							Document iniFile = dbFactory.newDocumentBuilder().parse("file:///" + ModManager.getCompilingDir() + "coalesceds\\" + foldername + "\\" + iniFileName);
 							iniFile.getDocumentElement().normalize();
 							ModManager.debugLogger.writeMessage("Loaded " + iniFile.getDocumentURI() + " into memory.");
 							//ModManager.printDocument(iniFile, System.out);
@@ -959,9 +986,9 @@ public class ModMakerCompilerWindow extends JDialog {
 										}
 										if (!pathfound) {
 											dispose();
-											JOptionPane.showMessageDialog(null, "<html>Could not find the path " + path + " to property.<br>Module: "
-													+ intCoalName + "<br>File: " + iniFileName + "</html>", "Compiling Error",
-													JOptionPane.ERROR_MESSAGE);
+											JOptionPane.showMessageDialog(null,
+													"<html>Could not find the path " + path + " to property.<br>Module: " + intCoalName + "<br>File: " + iniFileName + "</html>",
+													"Compiling Error", JOptionPane.ERROR_MESSAGE);
 											error = true;
 											return null;
 										}
@@ -970,8 +997,9 @@ public class ModMakerCompilerWindow extends JDialog {
 										//we didn't find what we wanted...
 										dispose();
 										error = true;
-										JOptionPane.showMessageDialog(null, "<html>Could not find the path " + path + " to property.<br>Module: "
-												+ intCoalName + "<br>File: " + iniFileName + "</html>", "Compiling Error", JOptionPane.ERROR_MESSAGE);
+										JOptionPane.showMessageDialog(null,
+												"<html>Could not find the path " + path + " to property.<br>Module: " + intCoalName + "<br>File: " + iniFileName + "</html>",
+												"Compiling Error", JOptionPane.ERROR_MESSAGE);
 										return null;
 									}
 									if (operation.equals("addition")) {
@@ -1037,8 +1065,8 @@ public class ModMakerCompilerWindow extends JDialog {
 												if (itemToModify.getAttribute("type").equals(matchontype)) {
 													//potential array value candidate...
 													boolean match = false;
-													ModManager.debugLogger.writeMessage("Found type candidate (" + matchontype
-															+ ") for arrayreplace: " + itemToModify.getTextContent());
+													ModManager.debugLogger
+															.writeMessage("Found type candidate (" + matchontype + ") for arrayreplace: " + itemToModify.getTextContent());
 													switch (arrayType) {
 													//Must use individual matching algorithms so we can figure out if something matches.
 													case "exactvalue": {
@@ -1142,15 +1170,12 @@ public class ModMakerCompilerWindow extends JDialog {
 													}
 														break;
 													default:
-														ModManager.debugLogger.writeError("ERROR: Unknown matching algorithm: " + arrayType
-																+ ". does this client need updated? Aborting this stat update.");
-														JOptionPane
-																.showMessageDialog(
-																		null,
-																		"<html>Unknown matching algorithm from ME3Tweaks: "
-																				+ arrayType
-																				+ ".<br>You should check for updates to Mod Manager.<br>This mod will not fully compile.</html>",
-																		"Compiling Error", JOptionPane.ERROR_MESSAGE);
+														ModManager.debugLogger.writeError(
+																"ERROR: Unknown matching algorithm: " + arrayType + ". does this client need updated? Aborting this stat update.");
+														JOptionPane.showMessageDialog(null,
+																"<html>Unknown matching algorithm from ME3Tweaks: " + arrayType
+																		+ ".<br>You should check for updates to Mod Manager.<br>This mod will not fully compile.</html>",
+																"Compiling Error", JOptionPane.ERROR_MESSAGE);
 														break;
 													} //end matching algorithm switch
 													if (match) {
@@ -1169,13 +1194,10 @@ public class ModMakerCompilerWindow extends JDialog {
 														default:
 															ModManager.debugLogger.writeMessage("ERROR: Unknown matching algorithm: " + arrayType
 																	+ " does this client need updated? Aborting this stat update.");
-															JOptionPane
-																	.showMessageDialog(
-																			null,
-																			"<html>Unknown operation from ME3Tweaks: "
-																					+ operation
-																					+ ".<br>You should check for updates to Mod Manager.<br>This mod will not fully compile.</html>",
-																			"Compiling Error", JOptionPane.ERROR_MESSAGE);
+															JOptionPane.showMessageDialog(null,
+																	"<html>Unknown operation from ME3Tweaks: " + operation
+																			+ ".<br>You should check for updates to Mod Manager.<br>This mod will not fully compile.</html>",
+																	"Compiling Error", JOptionPane.ERROR_MESSAGE);
 															break;
 														} //end operation [switch]
 														break;
@@ -1249,9 +1271,8 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (ExecutionException e) {
 				ModManager.debugLogger.writeMessage("Error occured in MergeWorker():");
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to merge mod delta into coalesced files:\n"
-						+ e.getMessage() + "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to merge mod delta into coalesced files:\n" + e.getMessage()
+						+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block
@@ -1329,8 +1350,8 @@ public class ModMakerCompilerWindow extends JDialog {
 
 						String compilerPath = ModManager.getTankMasterTLKDir() + "MassEffect3.TlkEditor.exe";
 						commandBuilder.add(compilerPath);
-						commandBuilder.add(ModManager.appendSlash(ModManagerWindow.ACTIVE_WINDOW.fieldBiogameDir.getText()) + "CookedPCConsole\\"
-								+ tlkShortNameToFileName(tlkType));
+						commandBuilder
+								.add(ModManager.appendSlash(ModManagerWindow.ACTIVE_WINDOW.fieldBiogameDir.getText()) + "CookedPCConsole\\" + tlkShortNameToFileName(tlkType));
 						commandBuilder.add(ModManager.appendSlash(tlkdir.getAbsolutePath().toString()) + "BIOGame_" + tlkType + ".xml");
 						commandBuilder.add("--mode");
 						commandBuilder.add("ToXml");
@@ -1374,8 +1395,8 @@ public class ModMakerCompilerWindow extends JDialog {
 								if (!indexMap.containsKey(index)) {
 									//load the required XML file into memory, store its nodelist
 									ModManager.debugLogger.writeMessage("Loading TLK XML (index " + index + ") " + tlkType + " into memory.");
-									String tlkIndexedFrag = ModManager.appendSlash(tlkdir.getAbsolutePath().toString()) + "BIOGame_" + tlkType + "\\"
-											+ "BIOGame_" + tlkType + index + ".xml"; //tankmaster's compiler splits it into files.
+									String tlkIndexedFrag = ModManager.appendSlash(tlkdir.getAbsolutePath().toString()) + "BIOGame_" + tlkType + "\\" + "BIOGame_" + tlkType + index
+											+ ".xml"; //tankmaster's compiler splits it into files.
 									DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 									Document tlkXMLFile = dBuilder.parse("file:///" + tlkIndexedFrag);
 									tlkXMLFile.getDocumentElement().normalize();
@@ -1483,10 +1504,8 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (ExecutionException e) {
 				ModManager.debugLogger.writeError("Error occured in TLKWorker():");
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
-						"An error occured while trying to decompile the TLK (translations) file:\n" + e.getMessage()
-								+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to decompile the TLK (translations) file:\n" + e.getMessage()
+						+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block
@@ -1562,16 +1581,14 @@ public class ModMakerCompilerWindow extends JDialog {
 					ModManager.debugLogger.writeError("ERROR! Didn't move " + reqcoal + " to the proper mod element directory. Could already exist.");
 				}
 				//copy pcconsoletoc
-				File tocFile = new File(ModManager.getCompilingDir() + "toc\\" + ME3TweaksUtils.coalFilenameToInternalName(reqcoal)
-						+ "\\PCConsoleTOC.bin");
+				File tocFile = new File(ModManager.getCompilingDir() + "toc\\" + ME3TweaksUtils.coalFilenameToInternalName(reqcoal) + "\\PCConsoleTOC.bin");
 				File destToc = new File(compCoalDir + "\\PCConsoleTOC.bin");
 				destToc.delete();
 				ModManager.debugLogger.writeMessage("Moving TOC file: " + tocFile.getAbsolutePath() + " to " + destToc.getAbsolutePath());
 				if (tocFile.renameTo(destToc)) {
 					ModManager.debugLogger.writeMessage("Moved " + reqcoal + " TOC to proper mod element directory");
 				} else {
-					ModManager.debugLogger.writeError("ERROR! Didn't move " + reqcoal
-							+ " TOC to the proper mod element directory. Could already exist.");
+					ModManager.debugLogger.writeError("ERROR! Didn't move " + reqcoal + " TOC to the proper mod element directory. Could already exist.");
 				}
 
 				//copy tlk
@@ -1582,18 +1599,15 @@ public class ModMakerCompilerWindow extends JDialog {
 					for (String tlkFilename : tlkFiles) {
 						File compiledTLKFile = new File(ModManager.getCompilingDir() + "tlk\\" + "BIOGame_" + tlkFilename + ".tlk");
 						if (!compiledTLKFile.exists()) {
-							ModManager.debugLogger.writeMessage("TLK file " + compiledTLKFile
-									+ " is missing, might not have been selected for compilation. skipping.");
+							ModManager.debugLogger.writeMessage("TLK file " + compiledTLKFile + " is missing, might not have been selected for compilation. skipping.");
 							continue;
 						}
 						File destTLKFile = new File(compCoalDir + "\\BIOGame_" + tlkFilename + ".tlk");
-						ModManager.debugLogger.writeMessage("Moving TLK file: " + compiledTLKFile.getAbsolutePath() + " to "
-								+ destTLKFile.getAbsolutePath());
+						ModManager.debugLogger.writeMessage("Moving TLK file: " + compiledTLKFile.getAbsolutePath() + " to " + destTLKFile.getAbsolutePath());
 						if (compiledTLKFile.renameTo(destTLKFile)) {
 							ModManager.debugLogger.writeMessage("Moved " + compiledTLKFile + " TLK to BASEGAME directory");
 						} else {
-							ModManager.debugLogger.writeError("Didn't move " + compiledTLKFile
-									+ " TLK to the BASEGAME directory. Could already exist.");
+							ModManager.debugLogger.writeError("Didn't move " + compiledTLKFile + " TLK to the BASEGAME directory. Could already exist.");
 						}
 					}
 				}
@@ -1656,29 +1670,25 @@ public class ModMakerCompilerWindow extends JDialog {
 			if (languages.size() > 0 && !requiredCoals.contains("Coalesced.bin")) {
 				File compCoalDir = new File(moddir.toString() + "\\" + ME3TweaksUtils.coalFilenameToInternalName("Coalesced.bin")); //MP4, PATCH2 folders in mod package
 				compCoalDir.mkdirs();
-				ini.put(ME3TweaksUtils.coalFilenameToHeaderName("Coalesced.bin"), "moddir",
-						ME3TweaksUtils.coalFilenameToInternalName("Coalesced.bin"));
+				ini.put(ME3TweaksUtils.coalFilenameToHeaderName("Coalesced.bin"), "moddir", ME3TweaksUtils.coalFilenameToInternalName("Coalesced.bin"));
 
 				//MOVE THE TLK FILES
 				for (String tlkFilename : languages) {
 					File compiledTLKFile = new File(ModManager.getCompilingDir() + "tlk\\" + "BIOGame_" + tlkFilename + ".tlk");
 					if (!compiledTLKFile.exists()) {
-						ModManager.debugLogger.writeMessage("TLK file " + compiledTLKFile
-								+ " is missing, might not have been selected for compilation. skipping.");
+						ModManager.debugLogger.writeMessage("TLK file " + compiledTLKFile + " is missing, might not have been selected for compilation. skipping.");
 						continue;
 					}
 					File destTLKFile = new File(compCoalDir + "\\BIOGame_" + tlkFilename + ".tlk");
 					if (compiledTLKFile.renameTo(destTLKFile)) {
 						ModManager.debugLogger.writeMessage("Moved " + compiledTLKFile + " TLK to BASEGAME directory");
 					} else {
-						ModManager.debugLogger
-								.writeMessage("Didn't move " + compiledTLKFile + " TLK to the BASEGAME directory. Could already exist.");
+						ModManager.debugLogger.writeMessage("Didn't move " + compiledTLKFile + " TLK to the BASEGAME directory. Could already exist.");
 					}
 				}
 
 				//MOVE PCCONSOLETOC.bin
-				File tocFile = new File(ModManager.getCompilingDir() + "toc\\" + ME3TweaksUtils.coalFilenameToInternalName("Coalesced.bin")
-						+ "\\PCConsoleTOC.bin");
+				File tocFile = new File(ModManager.getCompilingDir() + "toc\\" + ME3TweaksUtils.coalFilenameToInternalName("Coalesced.bin") + "\\PCConsoleTOC.bin");
 				File destToc = new File(compCoalDir + "\\PCConsoleTOC.bin");
 				destToc.delete();
 				if (tocFile.renameTo(destToc)) {
@@ -1736,12 +1746,9 @@ public class ModMakerCompilerWindow extends JDialog {
 			//SOMETHING WENT WRONG!
 			ModManager.debugLogger.writeMessage("Mod failed validation. Setting error flag to true.");
 			error = true;
-			JOptionPane
-					.showMessageDialog(
-							this,
-							modName
-									+ " was not successfully created.\nCheck the debugging file me3cmm_last_run_log.txt,\nand make sure debugging is enabled in Help>About.\nContact FemShep if you need help via the forums.",
-							"Mod Not Created", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(this,
+					modName + " was not successfully created.\nCheck the debugging file me3cmm_last_run_log.txt,\nand make sure debugging is enabled in Help>About.\nContact FemShep if you need help via the forums.",
+					"Mod Not Created", JOptionPane.ERROR_MESSAGE);
 		}
 		/*
 		 * File file = new File(DOWNLOADED_XML_FILENAME); file.delete();
@@ -1757,8 +1764,8 @@ public class ModMakerCompilerWindow extends JDialog {
 				try {
 					FileUtils.deleteDirectory(new File(mod.getModPath()));
 				} catch (IOException e) {
-					JOptionPane.showMessageDialog(this, "The old version of this mod could not be deleted.\nBoth versions will remain.",
-							"Could not delete old mod", JOptionPane.WARNING_MESSAGE);
+					JOptionPane.showMessageDialog(this, "The old version of this mod could not be deleted.\nBoth versions will remain.", "Could not delete old mod",
+							JOptionPane.WARNING_MESSAGE);
 					ModManager.debugLogger.writeError("Unable to delete old-named directory");
 					ModManager.debugLogger.writeException(e);
 				}
@@ -1767,10 +1774,13 @@ public class ModMakerCompilerWindow extends JDialog {
 
 		if (!error) {
 			//PROCESS MIXINS
-			if (requiredMixinIds.size() > 0) {
+			if (requiredMixinIds.size() > 0 || dynamicMixins.size() > 0) {
 				currentOperationLabel.setText("Preparing MixIns");
 				ModManager.debugLogger.writeMessage("Mod delta recommends MixIns, running PatchLibraryWindow()");
 				new PatchLibraryWindow(this, requiredMixinIds, dynamicMixins, newMod);
+				for (DynamicPatch dp : dynamicMixins) {
+					FileUtils.deleteQuietly(dp.getOutputfile());
+				}
 			}
 			finishModMaker(newMod);
 		} else {
@@ -1835,8 +1845,7 @@ public class ModMakerCompilerWindow extends JDialog {
 					if (!ModManager.hasPristineTOC(toc, ME3TweaksUtils.FILENAME)) {
 						ME3TweaksUtils.downloadPristineTOC(toc, ME3TweaksUtils.FILENAME);
 					}
-					File destTOC = new File(ModManager.getCompilingDir() + "toc/" + ME3TweaksUtils.coalFilenameToInternalName(toc)
-							+ "/PCConsoleTOC.bin"); //head should be same as standard folder
+					File destTOC = new File(ModManager.getCompilingDir() + "toc/" + ME3TweaksUtils.coalFilenameToInternalName(toc) + "/PCConsoleTOC.bin"); //head should be same as standard folder
 					FileUtils.copyFile(new File(ModManager.getPristineTOC(toc, ME3TweaksUtils.FILENAME)), destTOC);
 					ModManager.debugLogger.writeMessage("Copied pristine TOC of COALESCED DLC(" + toc + ") to: " + destTOC.getAbsolutePath());
 					tocsCompleted++;
@@ -1859,8 +1868,7 @@ public class ModMakerCompilerWindow extends JDialog {
 
 			progress.setIndeterminate(false);
 			if (numtoc > numCompleted.get(0)) {
-				currentOperationLabel.setText("Downloading " + ME3TweaksUtils.coalFilenameToInternalName(tocsToDownload.get(numCompleted.get(0)))
-						+ "/PCConsoleTOC.bin");
+				currentOperationLabel.setText("Downloading " + ME3TweaksUtils.coalFilenameToInternalName(tocsToDownload.get(numCompleted.get(0))) + "/PCConsoleTOC.bin");
 			}
 			progress.setValue((int) (100 / (numtoc / (float) numCompleted.get(0))));
 		}
@@ -1872,9 +1880,8 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (ExecutionException e) {
 				ModManager.debugLogger.writeMessage("Error occured in TOCDownloadWorker():");
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to download the TOC files for the mod:\n"
-						+ e.getMessage() + "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error",
-						JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to download the TOC files for the mod:\n" + e.getMessage()
+						+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -56,6 +56,7 @@ import org.xml.sax.SAXException;
 import com.me3tweaks.modmanager.AutoTocWindow;
 import com.me3tweaks.modmanager.KeybindsInjectionWindow;
 import com.me3tweaks.modmanager.ModManager;
+import com.me3tweaks.modmanager.ModManager.Lock;
 import com.me3tweaks.modmanager.ModManagerWindow;
 import com.me3tweaks.modmanager.PatchLibraryWindow;
 import com.me3tweaks.modmanager.objects.Mod;
@@ -1777,7 +1778,7 @@ public class ModMakerCompilerWindow extends JDialog {
 			if (requiredMixinIds.size() > 0 || dynamicMixins.size() > 0) {
 				currentOperationLabel.setText("Preparing MixIns");
 				ModManager.debugLogger.writeMessage("Mod delta recommends MixIns, running PatchLibraryWindow()");
-				new PatchLibraryWindow(this, requiredMixinIds, dynamicMixins, newMod);
+				PatchLibraryWindow plw = new PatchLibraryWindow(this,requiredMixinIds, dynamicMixins, newMod);
 				for (DynamicPatch dp : dynamicMixins) {
 					FileUtils.deleteQuietly(dp.getOutputfile());
 				}
@@ -1938,5 +1939,9 @@ public class ModMakerCompilerWindow extends JDialog {
 		default:
 			return null;
 		}
+	}
+
+	public JLabel getCurrentTaskLabel() {
+		return currentOperationLabel;
 	}
 }

--- a/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
@@ -197,7 +197,7 @@ public class AllModsUpdateWindow extends JDialog {
 					}
 					String updatetext = upackages.size() + " mod" + (upackages.size() == 1 ? " has" : "s have") + " available updates on ME3Tweaks:\n";
 					for (UpdatePackage upackage : upackages) {
-						ModManager.debugLogger.writeMessage("Parsing upackage " + upackage.getServerModName()+ ", Preparing user prompt.");
+						ModManager.debugLogger.writeMessage("Parsing upackage " + upackage.getServerModName() + ", Preparing user prompt.");
 						updatetext += getVersionUpdateString(upackage);
 					}
 					updatetext += "Update these mods?";
@@ -318,18 +318,29 @@ public class AllModsUpdateWindow extends JDialog {
 	}
 
 	/**
-	 * Returns a standard Verision X => new Version (size, num files deleted) string
-	 * @param upackage update package
+	 * Returns a standard Verision X => new Version (size, num files deleted)
+	 * string
+	 * 
+	 * @param upackage
+	 *            update package
 	 * @return nice string
 	 */
 	public static String getVersionUpdateString(UpdatePackage upackage) {
-		int numFilesToDelete = upackage.getFilesToDelete().size();
+		if (upackage.getMod().getModMakerCode() > 0) {
+			//modmaker mod
+			return " - " + upackage.getMod().getModName() + " " + upackage.getMod().getVersion() + " => " + upackage.getVersion() + " (ModMaker mod)\n";
+		} else {
+			//classic
+			int numFilesToDelete = 0;
+			if (upackage.getFilesToDelete() != null) {
+				numFilesToDelete = upackage.getFilesToDelete().size();
+			}
 
-		String updateSizeMB = upackage.getUpdateSizeMB();
-		String filesToDeleteStr = numFilesToDelete > 0 ? ", " + numFilesToDelete + " item" + (numFilesToDelete != 1 ? "s" : "") + " to delete" : "";
+			String updateSizeMB = upackage.getUpdateSizeMB();
+			String filesToDeleteStr = numFilesToDelete > 0 ? ", " + numFilesToDelete + " item" + (numFilesToDelete != 1 ? "s" : "") + " to delete" : "";
 
-		String updatetext = " - " + upackage.getMod().getModName() + " " + upackage.getMod().getVersion() + " => " + upackage.getVersion()
-				+ (upackage.isModmakerupdate() ? "" : " (" + updateSizeMB + " download" + filesToDeleteStr + ")") + "\n";
-		return updatetext;
+			return " - " + upackage.getMod().getModName() + " " + upackage.getMod().getVersion() + " => " + upackage.getVersion()
+					+ (upackage.isModmakerupdate() ? "" : " (" + updateSizeMB + " download" + filesToDeleteStr + ")") + "\n";
+		}
 	}
 }

--- a/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
@@ -97,8 +97,10 @@ public class ModXMLTools {
 			for (String blf : mod.getBlacklistedFiles()) {
 				File f = new File(mod.getModPath() + blf);
 				if (f.exists()) {
-					ModManager.debugLogger.writeError("A blacklisted file " + f
-							+ " exists in mod folder. Blacklisted files will be deleted when the mod is applied. Remove this file from your distribution or remove the blacklisting in moddesc");
+					ModManager.debugLogger
+							.writeError("A blacklisted file "
+									+ f
+									+ " exists in mod folder. Blacklisted files will be deleted when the mod is applied. Remove this file from your distribution or remove the blacklisting in moddesc");
 					publish(new ThreadCommand("Mod has a blacklisted file (check moddesc)", "ERROR"));
 					return "";
 				}
@@ -109,7 +111,8 @@ public class ModXMLTools {
 				UrlValidator urlValidator = new UrlValidator(schemes);
 				if (!urlValidator.isValid(mod.getSideloadURL())) {
 					if (mod.getSideloadOnlyTargets().size() > 0) {
-						ModManager.debugLogger.writeError("Mod has invalid sideload URL, and some files are marked for sideloading only. Aborting manifest generation");
+						ModManager.debugLogger
+								.writeError("Mod has invalid sideload URL, and some files are marked for sideloading only. Aborting manifest generation");
 						publish(new ThreadCommand("Invalid Sideload URL. Manifest requires valid sideload URL", null));
 						return "";
 					} else {
@@ -128,8 +131,8 @@ public class ModXMLTools {
 
 			}
 
-			File manifestFile = new File(
-					System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator + "Manifests" + File.separator + foldername + ".xml");
+			File manifestFile = new File(System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator + "Manifests"
+					+ File.separator + foldername + ".xml");
 
 			//SIMULATE REVERSE UPDATE
 			//CHECK FOR FILE EXISTENCE IN MOD UPDATE FOLDER, LZMA HASHES.
@@ -158,6 +161,13 @@ public class ModXMLTools {
 							assert f.exists();
 							updatedfiles.add(f);
 						}
+						for (String str : up.getFilesToDelete()) {
+							File f = new File(mod.getModPath() + File.separator + str);
+							if (f.exists()) {
+								//reverse - new files have been added
+								updatedfiles.add(f);
+							}
+						}
 					} else {
 						//no update.
 						ModManager.debugLogger.writeMessage("No files to update. Exiting update service mod preparer thread.");
@@ -180,12 +190,12 @@ public class ModXMLTools {
 			//Compressing mod to /serverupdate
 
 			long startTime = System.currentTimeMillis();
-			String sideloadoutputfolder = System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator + "Sideload" + File.separator + foldername
-					+ File.separator;
-			String compressedfulloutputfolder = System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator + "Full" + File.separator + foldername
-					+ File.separator;
-			String compressedupdateoutputfolder = System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator + "UpdateDelta" + File.separator
-					+ foldername + File.separator;
+			String sideloadoutputfolder = System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator + "Sideload"
+					+ File.separator + foldername + File.separator;
+			String compressedfulloutputfolder = System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator + "Full"
+					+ File.separator + foldername + File.separator;
+			String compressedupdateoutputfolder = System.getProperty("user.dir") + File.separator + "ME3TweaksUpdaterService" + File.separator
+					+ "UpdateDelta" + File.separator + foldername + File.separator;
 
 			if (!manifestFile.exists()) {
 				compressedupdateoutputfolder = compressedfulloutputfolder; //don't use update folder
@@ -210,7 +220,8 @@ public class ModXMLTools {
 				String outputFile = compressedupdateoutputfolder + relativePath + ".lzma";
 				new File(outputFile).getParentFile().mkdirs();
 
-				String[] procargs = { ModManager.getToolsDir() + "lzma.exe", "e", srcFile, outputFile, "-d26", "-mt" + Runtime.getRuntime().availableProcessors() };
+				String[] procargs = { ModManager.getToolsDir() + "lzma.exe", "e", srcFile, outputFile, "-d26",
+						"-mt" + Runtime.getRuntime().availableProcessors() };
 				ProcessBuilder p = new ProcessBuilder(procargs);
 				ModManager.runProcess(p);
 				processed++;
@@ -294,8 +305,8 @@ public class ModXMLTools {
 
 				String sideload7z = ModManager.appendSlash(new File(sideloadoutputfolder).getParent()) + foldername + "-sideload.7z";
 				FileUtils.deleteQuietly(new File(sideload7z));
-				String[] procargs = { "cmd", "/c", "start", "Building Sideload Package", ModManager.getToolsDir() + "7za", "a", "-r", "-mx9", "-mmt", sideload7z,
-						sideloadoutputfolder };
+				String[] procargs = { "cmd", "/c", "start", "Building Sideload Package", ModManager.getToolsDir() + "7za", "a", "-r", "-mx9", "-mmt",
+						sideload7z, sideloadoutputfolder };
 				ProcessBuilder p = new ProcessBuilder(procargs);
 				ModManager.runProcess(p);
 			}
@@ -404,8 +415,8 @@ public class ModXMLTools {
 		ArrayList<Mod> modmakerMods = new ArrayList<>();
 		ArrayList<Mod> classicMods = new ArrayList<>();
 		for (Mod mod : mods) {
-			ModManager.debugLogger.writeMessage(mod.getModMakerCode() > 0 ? mod.getModMakerCode() + " " + mod.getModName() + " " + mod.getVersion() + "(ModMaker)"
-					: mod.getClassicUpdateCode() + " " + mod.getModName() + " " + mod.getVersion() + " (Classic)");
+			ModManager.debugLogger.writeMessage(mod.getModMakerCode() > 0 ? mod.getModMakerCode() + " " + mod.getModName() + " " + mod.getVersion()
+					+ "(ModMaker)" : mod.getClassicUpdateCode() + " " + mod.getModName() + " " + mod.getVersion() + " (Classic)");
 			if (mod.getModMakerCode() > 0) {
 				modmakerMods.add(mod);
 			} else {
@@ -458,10 +469,12 @@ public class ModXMLTools {
 			double serverModVer = Double.parseDouble(modElem.getAttribute("version"));
 			String serverModName = modElem.getAttribute("name");
 			if (mod.getVersion() >= serverModVer) {
-				ModManager.debugLogger.writeMessage(mod.getModName() + " up to date. Local version: " + mod.getVersion() + " Server Version: " + serverModVer);
+				ModManager.debugLogger.writeMessage(mod.getModName() + " up to date. Local version: " + mod.getVersion() + " Server Version: "
+						+ serverModVer);
 				return null; // not an update
 			} else {
-				ModManager.debugLogger.writeMessage(mod.getModName() + " - ModMaker Mod is outdated, local:" + mod.getVersion() + " server: " + serverModVer);
+				ModManager.debugLogger.writeMessage(mod.getModName() + " - ModMaker Mod is outdated, local:" + mod.getVersion() + " server: "
+						+ serverModVer);
 				return new UpdatePackage(mod, serverModName, serverModVer);
 			}
 		} else {
@@ -536,8 +549,9 @@ public class ModXMLTools {
 				String blacklisted = fileElem.getTextContent();
 				if (blacklisted.contains("..")) {
 					//Malicious attempt possible
-					ModManager.debugLogger.writeError("Server indicates a file with path .. is blacklisted. The file path indicated on the server is: " + blacklisted
-							+ "\nThis may be a malicious piece of data from the server. This file will be skipped");
+					ModManager.debugLogger
+							.writeError("Server indicates a file with path .. is blacklisted. The file path indicated on the server is: "
+									+ blacklisted + "\nThis may be a malicious piece of data from the server. This file will be skipped");
 					continue;
 				}
 				File blacklistedlocalfile = new File(modpath + blacklisted);
@@ -567,8 +581,8 @@ public class ModXMLTools {
 				// check size
 				if (localFile.length() != mf.getSize()) {
 					newFiles.add(mf);
-					ModManager.debugLogger
-							.writeMessage(mf.getRelativePath() + " size has changed (local: " + localFile.length() + " | server: " + mf.getSize() + "), adding to update list");
+					ModManager.debugLogger.writeMessage(mf.getRelativePath() + " size has changed (local: " + localFile.length() + " | server: "
+							+ mf.getSize() + "), adding to update list");
 					continue;
 				}
 
@@ -608,7 +622,8 @@ public class ModXMLTools {
 				}
 			}
 
-			ModManager.debugLogger.writeMessage("Update check complete, number of outdated/missing files: " + newFiles.size() + ", files to remove: " + filesToRemove.size());
+			ModManager.debugLogger.writeMessage("Update check complete, number of outdated/missing files: " + newFiles.size() + ", files to remove: "
+					+ filesToRemove.size());
 			if (newFiles.size() == 0 && filesToRemove.size() == 0) {
 				//server lists update, but local copy matches server
 				return null;
@@ -620,8 +635,8 @@ public class ModXMLTools {
 			for (ManifestModFile mf : newFiles) {
 				if (mf.isSideloadOnly()) {
 					//REQUIRES SIDELOAD!
-					ModManager.debugLogger.writeError(
-							"This mod has a file marked for update that the developer has specified as sideload-only. The update cannot proceed until all sideload only files match their server counterparts. Advertising sideload update. The URL for the sideloading is "
+					ModManager.debugLogger
+							.writeError("This mod has a file marked for update that the developer has specified as sideload-only. The update cannot proceed until all sideload only files match their server counterparts. Advertising sideload update. The URL for the sideloading is "
 									+ sideloadURL);
 					up.setRequiresSideload(true);
 				}

--- a/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
@@ -162,7 +162,7 @@ public class ModXMLTools {
 							updatedfiles.add(f);
 						}
 						for (String str : up.getFilesToDelete()) {
-							File f = new File(mod.getModPath() + File.separator + str);
+							File f = new File(str);
 							if (f.exists()) {
 								//reverse - new files have been added
 								updatedfiles.add(f);
@@ -177,7 +177,7 @@ public class ModXMLTools {
 				} catch (Exception e) {
 					ModManager.debugLogger.writeErrorWithException("Error loading old manifest. Performing a full compression. Error: ", e);
 					for (File f : newversionfiles) {
-						updatedfiles.add(f);
+						updatedfiles.add(f); //variants check
 					}
 				}
 			} else {
@@ -226,6 +226,8 @@ public class ModXMLTools {
 				ModManager.runProcess(p);
 				processed++;
 			}
+			
+			
 
 			//Update the full distribution folder (assuming we are doing a delta build)
 			if (!compressedfulloutputfolder.equals(compressedupdateoutputfolder)) {
@@ -246,8 +248,18 @@ public class ModXMLTools {
 				}
 				if (up != null) {
 					for (String delfile : up.getFilesToDelete()) {
-						ModManager.debugLogger.writeMessage("Deleting unnecessary file from full server package: " + delfile);
-						FileUtils.deleteQuietly(new File(compressedfulloutputfolder + delfile));
+						File newfile = new File(compressedfulloutputfolder + delfile);
+						if (newfile.exists()) {
+							/*
+							 * ModManager.debugLogger.writeMessage(
+							 * "Deleting unnecessary file from full server package: "
+							 * + delfile); FileUtils.deleteQuietly(new
+							 * File(compressedfulloutputfolder + delfile));
+							 * FileUtils.copyFile(new File(delfile), new
+							 * File(compressedfulloutputfolder + delfile));
+							 */
+							System.out.println("Update package says to delete existing file: " + delfile);
+						}
 					}
 				}
 			}

--- a/src/com/me3tweaks/modmanager/objects/CustomDLC.java
+++ b/src/com/me3tweaks/modmanager/objects/CustomDLC.java
@@ -1,5 +1,9 @@
 package com.me3tweaks.modmanager.objects;
 
+import java.util.Arrays;
+
+import com.me3tweaks.modmanager.ModManager;
+
 public class CustomDLC implements Comparable<CustomDLC> {
 	@Override
 	public String toString() {
@@ -34,5 +38,9 @@ public class CustomDLC implements Comparable<CustomDLC> {
 	@Override
 	public int compareTo(CustomDLC o) {
 		return new Integer(mountFile.getMountPriority()).compareTo(o.getMountFile().getMountPriority());
+	}
+	
+	public boolean isGUIMod() {
+		return Arrays.asList(ModManager.KNOWN_GUI_CUSTOMDLC_MODS).contains(dlcName);
 	}
 }

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -678,7 +678,7 @@ public class Mod implements Comparable<Mod> {
 					if (!patchDesc.exists()) {
 						continue;
 					}
-					Patch subPatch = new Patch(patchDesc.getAbsolutePath());
+					Patch subPatch = new Patch(patchDesc.getAbsolutePath(),ModManager.appendSlash(path) + "patch.jsf");
 					if (subPatch.isValid()) {
 						ModManager.debugLogger.writeMessageConditionally("Valid patch: " + subPatch.getPatchName() + ", importing to library and processing",
 								ModManager.LOG_MOD_INIT);

--- a/src/com/me3tweaks/modmanager/objects/Patch.java
+++ b/src/com/me3tweaks/modmanager/objects/Patch.java
@@ -103,6 +103,7 @@ public class Patch implements Comparable<Patch> {
 				isValid = false;
 				return;
 			}
+			patchPath = patchFile.getAbsolutePath();
 
 			ModManager.debugLogger.writeMessageConditionally("Patch Folder: " + patchFolderPath, ModManager.LOG_PATCH_INIT);
 			ModManager.debugLogger.writeMessageConditionally("Patch Name: " + patchName, ModManager.LOG_PATCH_INIT);
@@ -364,7 +365,7 @@ public class Patch implements Comparable<Patch> {
 			ArrayList<String> commandBuilder = new ArrayList<String>();
 			commandBuilder.add(ModManager.getToolsDir() + "jptch.exe");
 			commandBuilder.add(stagingFile.getAbsolutePath());
-			commandBuilder.add(getPatchFolderPath() + "patch.jsf");
+			commandBuilder.add(patchPath);
 			commandBuilder.add(modSourceFile);
 			StringBuilder sb = new StringBuilder();
 			for (String arg : commandBuilder) {

--- a/src/com/me3tweaks/modmanager/objects/Patch.java
+++ b/src/com/me3tweaks/modmanager/objects/Patch.java
@@ -40,10 +40,10 @@ public class Patch implements Comparable<Patch> {
 	private String patchAuthor;
 	private int me3tweaksid;
 
-	public Patch(String descriptorPath) {
+	public Patch(String descriptorPath, String patchPath) {
 		ModManager.debugLogger.writeMessage("Loading patch: " + descriptorPath);
 		readPatch(descriptorPath);
-		setPatchPath(descriptorPath);
+		setPatchPath(patchPath);
 	}
 
 	/**
@@ -209,7 +209,7 @@ public class Patch implements Comparable<Patch> {
 			return null;
 		}
 		ModManager.debugLogger.writeMessage("Reloading imported patch");
-		return new Patch(destinationDir + File.separator + "patchdesc.ini");
+		return new Patch(destinationDir + File.separator + "patchdesc.ini", destinationDir + File.separator + "patch.jsf");
 	}
 
 	/**
@@ -370,7 +370,7 @@ public class Patch implements Comparable<Patch> {
 			File sourceFile = new File(modSourceFile);
 			if (sourceFile.length() != targetSize) {
 				ModManager.debugLogger
-						.writeError("Source file is the wrong size! This patch only applies to files of size "+targetSize+ " but the file is "+sourceFile.length());
+						.writeError("Source file is the wrong size! This patch only applies to files of size " + targetSize + " but the file is " + sourceFile.length());
 				return APPLY_FAILED_SOURCE_FILE_WRONG_SIZE;
 			}
 			//rename file (so patch doesn't continuously recalculate itself)
@@ -409,7 +409,7 @@ public class Patch implements Comparable<Patch> {
 				return APPLY_FAILED_SIZE_CHANGED;
 			}
 
-			ModManager.debugLogger.writeMessage("File has been patched. Output size is "+sourceFile.length());
+			ModManager.debugLogger.writeMessage("File has been patched. Output size is " + sourceFile.length());
 			return APPLY_SUCCESS;
 		} catch (IOException e) {
 			// TODO Auto-generated catch block

--- a/src/com/me3tweaks/modmanager/objects/Patch.java
+++ b/src/com/me3tweaks/modmanager/objects/Patch.java
@@ -29,7 +29,8 @@ public class Patch implements Comparable<Patch> {
 	public static final int APPLY_FAILED_MODDESC_NOT_UPDATED = 1;
 	public static final int APPLY_FAILED_SOURCE_FILE_WRONG_SIZE = 2;
 	public static final int APPLY_FAILED_NO_SOURCE_FILE = 3;
-	String targetPath, targetModule, patchPath;
+	String targetPath, targetModule;
+	private String patchPath;
 	boolean isValid = false, finalizer = false;
 
 	String patchName, patchDescription, patchFolderPath;
@@ -41,7 +42,7 @@ public class Patch implements Comparable<Patch> {
 	public Patch(String descriptorPath) {
 		ModManager.debugLogger.writeMessage("Loading patch: " + descriptorPath);
 		readPatch(descriptorPath);
-		patchPath = descriptorPath;
+		setPatchPath(descriptorPath);
 	}
 
 	/**
@@ -52,7 +53,7 @@ public class Patch implements Comparable<Patch> {
 	public Patch(Patch patch) {
 		targetPath = patch.targetPath;
 		targetModule = patch.targetModule;
-		patchPath = patch.patchPath;
+		setPatchPath(patch.getPatchPath());
 		isValid = patch.isValid;
 		finalizer = patch.finalizer;
 		patchName = patch.patchName;
@@ -61,8 +62,15 @@ public class Patch implements Comparable<Patch> {
 		targetSize = patch.targetSize;
 		patchVersion = patch.patchVersion;
 		patchCMMVer = patch.patchCMMVer;
-		patchAuthor = patch.patchAuthor;
-		me3tweaksid = patch.me3tweaksid;
+		setPatchAuthor(patch.getPatchAuthor());
+		setMe3tweaksid(patch.getMe3tweaksid());
+	}
+
+	/**
+	 * Empty constructor, only use if you are planning to manually add all required fields.
+	 */
+	public Patch() {
+		
 	}
 
 	private void readPatch(String path) {
@@ -81,8 +89,8 @@ public class Patch implements Comparable<Patch> {
 			patchName = patchini.get("PatchInfo", "patchname");
 			try {
 				String idstr = patchini.get("PatchInfo", "me3tweaksid");
-				me3tweaksid = Integer.parseInt(idstr);
-				ModManager.debugLogger.writeMessageConditionally("Patch ID on ME3Tweaks: " + me3tweaksid, ModManager.LOG_PATCH_INIT);
+				setMe3tweaksid(Integer.parseInt(idstr));
+				ModManager.debugLogger.writeMessageConditionally("Patch ID on ME3Tweaks: " + getMe3tweaksid(), ModManager.LOG_PATCH_INIT);
 			} catch (NumberFormatException e) {
 				ModManager.debugLogger.writeError("me3tweaksid is not an integer, setting to 0");
 			}
@@ -106,8 +114,8 @@ public class Patch implements Comparable<Patch> {
 				patchCMMVer = Float.parseFloat(patchini.get("ModManager", "cmmver"));
 				patchCMMVer = (double) Math.round(patchCMMVer * 10) / 10; //tenth rounding;
 				ModManager.debugLogger.writeMessageConditionally("Patch Targets Mod Manager: " + patchCMMVer, ModManager.LOG_PATCH_INIT);
-				patchAuthor = patchini.get("PatchInfo", "patchdev");
-				ModManager.debugLogger.writeMessageConditionally("Patch Developer (if any) " + patchAuthor, ModManager.LOG_PATCH_INIT);
+				setPatchAuthor(patchini.get("PatchInfo", "patchdev"));
+				ModManager.debugLogger.writeMessageConditionally("Patch Developer (if any) " + getPatchAuthor(), ModManager.LOG_PATCH_INIT);
 				String strPatchVersion = patchini.get("PatchInfo", "patchver");
 				if (strPatchVersion != null) {
 					patchVersion = Float.parseFloat(strPatchVersion);
@@ -495,7 +503,7 @@ public class Patch implements Comparable<Patch> {
 		sb.append("INSERT INTO mixinlibrary VALUES (\n\tnull,\n");
 		sb.append("\t\"" + patchName + "\",\n");
 		sb.append("\t\"" + patchDescription + "\",\n");
-		sb.append("\t\"" + ((patchAuthor == null) ? "FemShep" : patchAuthor) + "\",\n");
+		sb.append("\t\"" + ((getPatchAuthor() == null) ? "FemShep" : getPatchAuthor()) + "\",\n");
 		sb.append("\t" + patchVersion + ",\n");
 		if (patchCMMVer < 4.0) {
 			patchCMMVer = 4.0;
@@ -529,5 +537,21 @@ public class Patch implements Comparable<Patch> {
 
 	public int getMe3tweaksid() {
 		return me3tweaksid;
+	}
+
+	public void setPatchAuthor(String patchAuthor) {
+		this.patchAuthor = patchAuthor;
+	}
+
+	public void setMe3tweaksid(int me3tweaksid) {
+		this.me3tweaksid = me3tweaksid;
+	}
+
+	public String getPatchPath() {
+		return patchPath;
+	}
+
+	public void setPatchPath(String patchPath) {
+		this.patchPath = patchPath;
 	}
 }

--- a/src/com/me3tweaks/modmanager/ui/MultiLineTableCell.java
+++ b/src/com/me3tweaks/modmanager/ui/MultiLineTableCell.java
@@ -1,0 +1,85 @@
+package com.me3tweaks.modmanager.ui;
+
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.font.FontRenderContext;
+import java.awt.font.LineBreakMeasurer;
+import java.awt.font.TextLayout;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+import java.text.BreakIterator;
+
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+
+public class MultiLineTableCell implements TableCellRenderer {
+	class CellArea extends DefaultTableCellRenderer {
+		/**
+		 * 
+		 */
+		private static final long serialVersionUID = 1L;
+		private String text;
+		protected int rowIndex;
+		protected int columnIndex;
+		protected JTable table;
+		protected Font font;
+		private int paragraphStart, paragraphEnd;
+		private LineBreakMeasurer lineMeasurer;
+
+		public CellArea(String s, JTable tab, int row, int column, boolean isSelected) {
+			text = s;
+			rowIndex = row;
+			columnIndex = column;
+			table = tab;
+			font = table.getFont();
+			if (isSelected) {
+				setForeground(table.getSelectionForeground());
+				setBackground(table.getSelectionBackground());
+			}
+		}
+
+		public void paintComponent(Graphics gr) {
+			super.paintComponent(gr);
+			if (text != null && !text.isEmpty()) {
+				Graphics2D g = (Graphics2D) gr;
+				if (lineMeasurer == null) {
+					AttributedCharacterIterator paragraph = new AttributedString(text).getIterator();
+					paragraphStart = paragraph.getBeginIndex();
+					paragraphEnd = paragraph.getEndIndex();
+					FontRenderContext frc = g.getFontRenderContext();
+					lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getWordInstance(), frc);
+				}
+				float breakWidth = (float) table.getColumnModel().getColumn(columnIndex).getWidth();
+				float drawPosY = 0;
+				// Set position to the index of the first character in the paragraph.
+				lineMeasurer.setPosition(paragraphStart);
+				// Get lines until the entire paragraph has been displayed.
+				while (lineMeasurer.getPosition() < paragraphEnd) {
+					// Retrieve next layout. A cleverer program would also cache
+					// these layouts until the component is re-sized.
+					TextLayout layout = lineMeasurer.nextLayout(breakWidth);
+					// Compute pen x position. If the paragraph is right-to-left we
+					// will align the TextLayouts to the right edge of the panel.
+					// Note: this won't occur for the English text in this sample.
+					// Note: drawPosX is always where the LEFT of the text is placed.
+					float drawPosX = layout.isLeftToRight() ? 0 : breakWidth - layout.getAdvance();
+					// Move y-coordinate by the ascent of the layout.
+					drawPosY += layout.getAscent();
+					// Draw the TextLayout at (drawPosX, drawPosY).
+					layout.draw(g, drawPosX, drawPosY);
+					// Move y-coordinate in preparation for next layout.
+					drawPosY += layout.getDescent() + layout.getLeading();
+				}
+				table.setRowHeight(rowIndex, (int) drawPosY);
+			}
+		}
+	}
+
+	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+		CellArea area = new CellArea(value.toString(), table, row, column, isSelected);
+		return area;
+	}
+}


### PR DESCRIPTION
Mod Manager 4.2.4 supports ModMaker 2.1 (lots of new content coming your way) and fixes multiple bugs reported by other mod developers.

**NEW FEATURES**
- Mod Manager supports ModMaker 2.1: dynamic mixins. This is not yet live on ME3Tweaks.
- Clear MixIn cache via the Mod Management Menu (will force Mod Manager to re-fetch source files for mixins. will be slower on next appliciation but will use proper files if you sourced an already modified one)
- Drop a PCC onto Mod Manager to either compress or decompress it

**FEATURE UPDATES**
- Mixins now report more errors if something changed that shouldn't have
- GUI mod compatibility generator now can detect files that have GUIs but are not superceded by the mod, which should fix issues reported by Expanded Galaxy Mod users (regenerate the pack). It also fixes a bug that could cause the game to crash (1.0.0.7 GUI Transplanter)
- MixIn applying window now shows the number of remaining patches to apply
- Mod Manager now enforces a minimum GUI Transplanter tool version listed internally and will refuse to work with lower versions
- ModMaker mods are now compressed on the server and will decompress once downloaded. This should significantly speed up fetching the mod delta. If not compressed on server it will fall back to standard XML
- NEW REQUIRED ME3EXPLORER VERSION: 2.0.6. 2.0.6 has significant improvements in saving time which results in a much faster decompression of game files. This should WAYYYYYYYYYY improve patches to SFXGame.pcc, from a matter of minutes to a matter of seconds.

**BUGFIXES**
- AutoTOC had an error (check logs) reported that the number of toc'd files was not the same as the expected amount for non-custom dlc tasks. This bug occured in tasks that had more than 11 files. This issue should be fixed and the error message should no longer occur
- Mod Manifest generator now includes files that have been added to the mod since the previous delta build
- Mods that check for updates now use a clone of the mod so they don't mess up the version number internally in mod manager. Mods after sideload will still show the wrong version until mod manager is reloaded again (to force update check)
