### PR TITLE
ModMaker 4.3.1 Build 60

### DIFF
--- a/src/com/me3tweaks/modmanager/ASIModWindow.java
+++ b/src/com/me3tweaks/modmanager/ASIModWindow.java
@@ -117,6 +117,8 @@ public class ASIModWindow extends JDialog {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				ModManagerWindow.ACTIVE_WINDOW.toolsInstallBinkw32asi.doClick();
+				dispose();
+				new ASIModWindow(gamedir);
 			}
 		};
 

--- a/src/com/me3tweaks/modmanager/ASIModWindow.java
+++ b/src/com/me3tweaks/modmanager/ASIModWindow.java
@@ -84,7 +84,7 @@ public class ASIModWindow extends JDialog {
 	public ASIModWindow(String gamedir) {
 		ModManager.debugLogger.writeMessage("Opening ASI window.");
 		this.gamedir = ModManager.appendSlash(gamedir);
-		String asidir = gamedir + "Binaries/win32/asi";
+		String asidir = this.gamedir + "Binaries/win32/asi";
 		asiDir = new File(asidir);
 		if (!asiDir.exists()) {
 			asiDir.mkdirs();
@@ -284,6 +284,7 @@ public class ASIModWindow extends JDialog {
 			try {
 				iam.setHash(MD5Checksum.getMD5Checksum(ModManager.appendSlash(asiDir.getAbsolutePath()) + installed));
 				installedASIs.add(iam);
+				ModManager.debugLogger.writeMessage("Detected installed ASI mod: " + iam.toLogString());
 			} catch (Exception e1) {
 				ModManager.debugLogger.writeErrorWithException("ASI mod is installed but unable to get hash: " + installed, e1);
 			}
@@ -689,6 +690,7 @@ public class ASIModWindow extends JDialog {
 				//install ASI
 				File installdest = new File(ModManager.appendSlash(asiDir.getAbsolutePath()) + mod.getInstallName() + "-v" + mod.getVersion() + ".asi");
 				FileUtils.deleteQuietly(installdest);
+				ModManager.debugLogger.writeMessage("Installing ASI mod " + dest + " => " + installdest);
 				FileUtils.copyFile(dest, installdest);
 				ModManager.debugLogger.writeMessage("ASI mod " + mod.getName() + " v" + mod.getVersion() + " was installed");
 			} catch (FileNotFoundException e) {

--- a/src/com/me3tweaks/modmanager/AutoTocWindow.java
+++ b/src/com/me3tweaks/modmanager/AutoTocWindow.java
@@ -176,6 +176,9 @@ public class AutoTocWindow extends JDialog {
 
 			@Override
 			public Boolean call() throws Exception {
+				if (job.getJobType() == ModJob.BALANCE_CHANGES) {
+					return true; //no toc
+				}
 				if (job.getJobType() == ModJob.CUSTOMDLC) {
 					if (mode == AutoTocWindow.INSTALLED_MODE) {
 						completed.incrementAndGet();
@@ -195,22 +198,22 @@ public class AutoTocWindow extends JDialog {
 						for (String arg : command) {
 							sb.append(arg + " ");
 						}
-						ModManager.debugLogger.writeMessage("Performing a CUSTOM DLC TOC update with command: " + sb.toString());
+						ModManager.debugLogger.writeMessage("["+job.getJobName()+"]Performing a CUSTOM DLC TOC update with command: " + sb.toString());
 						int returncode = 1;
 						ProcessBuilder pb = new ProcessBuilder(command);
 						ProcessResult pr = ModManager.runProcess(pb);
 						returncode = pr.getReturnCode();
 						if (returncode != 0 || pr.hadError()) {
-							ModManager.debugLogger.writeError("ME3Explorer returned a non 0 code (or threw error): " + returncode);
+							ModManager.debugLogger.writeError("["+job.getJobName()+"]ME3Explorer returned a non 0 code (or threw error): " + returncode);
 						} else {
 							completed.incrementAndGet();
-							ModManager.debugLogger.writeMessage("Number of completed tasks: " + completed + ", num left to do: " + (numtoc - completed.get()));
+							ModManager.debugLogger.writeMessage("["+job.getJobName()+"]Number of completed tasks: " + completed + ", num left to do: " + (numtoc - completed.get()));
 							publish(Integer.toString(completed.get()));
 						}
 					}
 					return true;
 				}
-				ModManager.debugLogger.writeMessage("======AutoTOC job on module " + job.getJobName() + "=======");
+				ModManager.debugLogger.writeMessage("["+job.getJobName()+"]======AutoTOC job on module " + job.getJobName() + "=======");
 				boolean hasTOC = false;
 				if (mode == LOCALMOD_MODE) {
 					//see if has toc file
@@ -229,7 +232,7 @@ public class AutoTocWindow extends JDialog {
 						updatedGameTOCs.put(job.getJobName(), tocPath);
 						hasTOC = true;
 					} else {
-						ModManager.debugLogger.writeError("Unable to get module's PCConsoleTOC file: " + job.getJobName() + ". This update will be skipped.");
+						ModManager.debugLogger.writeError("["+job.getJobName()+"]Unable to get module's PCConsoleTOC file: " + job.getJobName() + ". This update will be skipped.");
 					}
 				}
 
@@ -243,7 +246,7 @@ public class AutoTocWindow extends JDialog {
 					//batchJobs.add(tbd);
 
 					//break into batches
-					ModManager.debugLogger.writeMessage("Number of files in this job: "+(job.newFiles.size() + job.addFiles.size()-1));
+					ModManager.debugLogger.writeMessage("["+job.getJobName()+"]Number of files in this job: "+(job.newFiles.size() + job.addFiles.size()-1));
 					for (String newFile : job.newFiles) {
 						String filename = FilenameUtils.getName(newFile);
 						if (filename.equals("PCConsoleTOC.bin")) {
@@ -283,7 +286,7 @@ public class AutoTocWindow extends JDialog {
 					String tocPath = modulePath + "PCConsoleTOC.bin";
 					if (updatedGameTOCs.containsKey(job.getJobName())) {
 						tocPath = updatedGameTOCs.get(job.getJobName());
-						ModManager.debugLogger.writeMessage("TOCing Alternative File: " + tocPath);
+						ModManager.debugLogger.writeMessage("["+job.getJobName()+"]TOCing Alternative File: " + tocPath);
 					}
 					//feed jobs into me3explorer for processing
 					for (TocBatchDescriptor batchJob : batchJobs) {
@@ -298,7 +301,7 @@ public class AutoTocWindow extends JDialog {
 						}
 						String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
 
-						ModManager.debugLogger.writeMessage("Performing a batch TOC update on the following files:");
+						ModManager.debugLogger.writeMessage("["+job.getJobName()+"]Performing a batch TOC update on the following files:");
 						String str = "";
 						for (SimpleEntry<String, Long> nsp : batchJob.getNameSizePairs()) {
 							str += nsp.getKey() + " " + nsp.getValue();
@@ -311,19 +314,20 @@ public class AutoTocWindow extends JDialog {
 						ProcessResult pr = ModManager.runProcess(pb);
 						returncode = pr.getReturnCode();
 						if (returncode != 0 || pr.hadError()) {
-							ModManager.debugLogger.writeError("ME3Explorer returned a non 0 code (or threw error): " + returncode);
+							ModManager.debugLogger.writeError("["+job.getJobName()+"]ME3Explorer returned a non 0 code (or threw error): " + returncode);
 							return false;
 						} else {
 							int numcompleteinbatch = batchJob.getNameSizePairs().size();
 							
 							completed.addAndGet(numcompleteinbatch);
 							ModManager.debugLogger.writeMessage(
-									"Batch tasks done: " + numcompleteinbatch + ", Number of all completed tasks: " + completed + ", num left to do: " + (numtoc - completed.get()));
+									"["+job.getJobName()+"]Batch tasks done: " + numcompleteinbatch + ", Number of all completed tasks: " + completed + ", num left to do: " + (numtoc - completed.get()));
 							publish(Integer.toString(completed.get()));
 						}
 					}
 					return true;
 				}
+				
 				return false;
 			}
 		}

--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -1141,9 +1141,22 @@ public class ModInstallWindow extends JDialog {
 					callingWindow.labelStatus.setText(" " + mod.getModName() + " installed");
 					for (ModJob job : jobs) {
 						if (job.getJobType() == ModJob.BALANCE_CHANGES) {
-							if (!ASIModWindow.IsASIModGroupInstalled(5)) { //update group 5 = Balance Changes on ME3Tweaks
-								ModManager.debugLogger.writeMessage("Balance changes ASI is not installed. Advertising install");
-								int result = JOptionPane.showConfirmDialog(ModInstallWindow.this, "This mod contains edits to the balance changes file.\nFor these edits to take effect you need to have the Balance Changes Replacer ASI mod installed.\nOpen the ASI management window to install this?","ASI mod required", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+							if (ModManager.checkIfASIBinkBypassIsInstalled(bioGameDir)) {
+								if (!ASIModWindow.IsASIModGroupInstalled(5)) { //update group 5 = Balance Changes on ME3Tweaks
+									ModManager.debugLogger.writeMessage("Balance changes ASI is not installed. Advertising install");
+									int result = JOptionPane.showConfirmDialog(ModInstallWindow.this,
+											"This mod contains edits to the balance changes file.\nFor these edits to take effect you need to have the Balance Changes Replacer ASI mod installed.\nOpen the ASI management window to install this?",
+											"ASI mod required", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+									if (result == JOptionPane.YES_OPTION) {
+										new ASIModWindow(new File(bioGameDir).getParent());
+									}
+								}
+							} else {
+								//loader not in
+								ModManager.debugLogger.writeMessage("ASI loader not installed. Advertising install");
+								int result = JOptionPane.showConfirmDialog(ModInstallWindow.this,
+										"This mod contains edits to the balance changes file.\nFor these edits to take effect you need to have the binkw32 ASI loader installed as well as the Balance Changes Replacer ASI.\nOpen the ASI management window to install these?",
+										"ASI Loader + ASI mod required", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
 								if (result == JOptionPane.YES_OPTION) {
 									new ASIModWindow(new File(bioGameDir).getParent());
 								}

--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -285,6 +285,9 @@ public class ModInstallWindow extends JDialog {
 				case ModJob.CUSTOMDLC:
 					result = processCustomDLCJob(job);
 					break;
+				case ModJob.BALANCE_CHANGES:
+					result = processBalanceChangesJob(job);
+					break;
 				}
 				//end of each callable...
 				if (result) {
@@ -297,7 +300,6 @@ public class ModInstallWindow extends JDialog {
 				publish(Integer.toString(completed.get()));
 				return result;
 			}
-
 		}
 
 		/**
@@ -342,6 +344,10 @@ public class ModInstallWindow extends JDialog {
 			}
 
 			for (ModJob job : jobs) {
+				if (job.getJobType() == ModJob.BALANCE_CHANGES) {
+					ModManager.debugLogger.writeMessage("Skipping GRDB check for balance changes job");
+					continue;
+				}
 				publish("Checking GDB: " + job.getJobName());
 				if (job.getJobType() == ModJob.BASEGAME) {
 					//BGDB files are required
@@ -493,7 +499,7 @@ public class ModInstallWindow extends JDialog {
 					Files.copy(newfilepath, installPath, StandardCopyOption.REPLACE_EXISTING);
 					if (job.getAddFilesReadOnlyTargets().contains(fileToAddTarget)) {
 						installFile.setReadOnly();
-						ModManager.debugLogger.writeMessage("Set read only: "+installFile);
+						ModManager.debugLogger.writeMessage("Set read only: " + installFile);
 					}
 					completedTaskSteps++;
 					ModManager.debugLogger.writeMessage("Installed mod file: " + fileToAdd + " => " + installFile);
@@ -520,6 +526,45 @@ public class ModInstallWindow extends JDialog {
 				FileUtils.deleteQuietly(unpacked);
 				completedTaskSteps++;
 				ModManager.debugLogger.writeMessage("Deleted game file: " + unpacked);
+			}
+			return true;
+		}
+
+		private boolean processBalanceChangesJob(ModJob job) {
+			ModManager.debugLogger.writeMessage("===Processing a balance changes job===");
+			completedTaskSteps = 0;
+			taskSteps = job.getFilesToReplace().size() + job.getFilesToAdd().size() + job.getFilesToRemoveTargets().size();
+			publish("Processing balance changes files...");
+			File bgdir = new File(ModManager.appendSlash(bioGameDir));
+			String me3dir = ModManager.appendSlash(bgdir.getParent());
+
+			// Prep replacement job
+			{
+				ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
+				ArrayList<String> newFiles = job.getFilesToReplace();
+				int numFilesToReplace = filesToReplace.size();
+				ModManager.debugLogger.writeMessage("Number of files to replace in the basegame (balance changes): " + numFilesToReplace);
+				for (int i = 0; i < numFilesToReplace; i++) {
+					String fileToReplace = filesToReplace.get(i);
+					String newFile = newFiles.get(i);
+
+					// install file.
+					File unpacked = new File(me3dir + fileToReplace);
+					Path originalpath = Paths.get(unpacked.toString());
+					try {
+						publish(ModType.BASEGAME + ": Installing " + FilenameUtils.getName(newFile));
+						Path newfilepath = Paths.get(newFile);
+						if (!unpacked.getParentFile().exists()) {
+							unpacked.getParentFile().mkdirs();
+						}
+						Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
+						completedTaskSteps++;
+						ModManager.debugLogger.writeMessage("Installed mod file: " + newFile + " => " + unpacked);
+					} catch (IOException e) {
+						ModManager.debugLogger.writeException(e);
+						return false;
+					}
+				}
 			}
 			return true;
 		}
@@ -1075,7 +1120,7 @@ public class ModInstallWindow extends JDialog {
 				ModManager.debugLogger.writeException(e);
 				hasException = true;
 			}
-			
+
 			if (ModManager.POST_INSTALL_AUTOTOC_INSTEAD) {
 				ModManager.debugLogger.writeMessage("Running Game-Wide AutoTOC after mod install");
 				new AutoTocWindow(bioGameDir);
@@ -1094,6 +1139,17 @@ public class ModInstallWindow extends JDialog {
 				} else {
 					// we're good
 					callingWindow.labelStatus.setText(" " + mod.getModName() + " installed");
+					for (ModJob job : jobs) {
+						if (job.getJobType() == ModJob.BALANCE_CHANGES) {
+							if (!ASIModWindow.IsASIModGroupInstalled(5)) { //update group 5 = Balance Changes on ME3Tweaks
+								ModManager.debugLogger.writeMessage("Balance changes ASI is not installed. Advertising install");
+								int result = JOptionPane.showConfirmDialog(ModInstallWindow.this, "This mod contains edits to the balance changes file.\nFor these edits to take effect you need to have the Balance Changes Replacer ASI mod installed.\nOpen the ASI management window to install this?","ASI mod required", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+								if (result == JOptionPane.YES_OPTION) {
+									new ASIModWindow(new File(bioGameDir).getParent());
+								}
+							}
+						}
+					}
 				}
 			} else {
 				if (!hasException) {

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -72,18 +72,19 @@ import com.sun.jna.platform.win32.WinReg;
 
 public class ModManager {
 
-	public static final String VERSION = "4.3";
-	public static long BUILD_NUMBER = 59L;
+	public static final String VERSION = "4.3.1";
+	public static long BUILD_NUMBER = 60L;
 	public static final String BUILD_DATE = "8/7/2016";
 	public static DebugLogger debugLogger;
-	public static boolean IS_DEBUG = true;
+	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
-	public static final double MODMAKER_VERSION_SUPPORT = 2.1; // max modmaker
+	public static final double MODMAKER_VERSION_SUPPORT = 2.2; // max modmaker
 																// version
 	public static final double MODDESC_VERSION_SUPPORT = 4.3; // max supported
 																// cmmver in
 																// moddesc
+	public static boolean MOD_MANAGER_UPDATE_READY = false; //if true, don't delete temp
 	public static boolean AUTO_APPLY_MODMAKER_MIXINS = false;
 	public static boolean AUTO_UPDATE_MODS = true;
 	public static boolean CHECKED_FOR_UPDATE_THIS_SESSION = false;
@@ -105,6 +106,7 @@ public class ModManager {
 	public static boolean LOG_MOD_INIT = false;
 	public static boolean LOG_PATCH_INIT = false;
 	public static boolean PERFORM_DOT_NET_CHECK = true;
+	public static boolean MODMAKER_CONTROLLER_MOD_ADDINS = false;
 	protected final static int COALESCED_MAGIC_NUMBER = 1836215654;
 	public final static String[] KNOWN_GUI_CUSTOMDLC_MODS = { "DLC_CON_XBX", "DLC_CON_UIScaling", "DLC_CON_UIScaling_Shared" };
 
@@ -307,7 +309,7 @@ public class ModManager {
 						SKIP_UPDATES_UNTIL_BUILD = 0;
 					}
 				}
-
+				{
 				// AutoTOC game files after install
 				String autotocPostInstallStr = settingsini.get("Settings", "runautotocpostinstall");
 				int autotocPostInstallInt = 0;
@@ -325,6 +327,26 @@ public class ModManager {
 					} catch (NumberFormatException e) {
 						debugLogger.writeError("Number format exception reading the autotoc post install flag - defaulting to disabled");
 						POST_INSTALL_AUTOTOC_INSTEAD = false;
+					}
+				}}
+				
+				// AutoTOC game files after install
+				String controllerModUserStr = settingsini.get("Settings", "controllermoduser");
+				int controllerModUserInt = 0;
+				if (controllerModUserStr != null && !controllerModUserStr.equals("")) {
+					try {
+						controllerModUserInt = Integer.parseInt(controllerModUserStr);
+						if (controllerModUserInt > 0) {
+							// logging is on
+							debugLogger.writeMessage("ModMaker Controller Mod add-ins enabled");
+							MODMAKER_CONTROLLER_MOD_ADDINS = true;
+						} else {
+							debugLogger.writeMessage("ModMaker Controller Mod add-ins disabled");
+							MODMAKER_CONTROLLER_MOD_ADDINS = false;
+						}
+					} catch (NumberFormatException e) {
+						debugLogger.writeError("Number format exception reading the controller mod user flag - defaulting to disabled");
+						MODMAKER_CONTROLLER_MOD_ADDINS  = false;
 					}
 				}
 
@@ -396,6 +418,11 @@ public class ModManager {
 				new NetFrameworkMissingWindow(
 						"Mod Manager was unable to detect a usable .NET Framework. Mod Manager requires Microsoft .NET Framework 4.5 or higher in order to function properly. ");
 			}
+			
+			if (checkIfCMMPatchIsTooLong()) {
+				JOptionPane.showMessageDialog(null, "Mod Manager has detected that it running from a location with a long filepath.\nMod Manager caches files using their relative game directory path.\nYou may consider moving Mod Manager higher up this file system's hierarchy\nto avoid issues with Windows path limitations.", "Windows Path Limitation Warning", JOptionPane.WARNING_MESSAGE);
+			}
+			
 			ModManager.debugLogger.writeMessage("========End of startup=========");
 		} catch (Throwable e) {
 			Wini ini;
@@ -612,84 +639,6 @@ public class ModManager {
 		return new ModList(availableMods, failedMods);
 	}
 
-	/*
-	 * public static ArrayList<Mod> getCMM3ModsFromDirectory() { File fileDir =
-	 * new File(getModsDir()); // This filter only returns directories
-	 * FileFilter fileFilter = new FileFilter() { public boolean accept(File
-	 * file) { return file.isDirectory(); } }; File[] subdirs =
-	 * fileDir.listFiles(fileFilter);
-	 * 
-	 * //Got a list of subdirs. Now loop them to find all moddesc.ini files
-	 * ArrayList<Mod> availableMod = new ArrayList<Mod>(); for (int i = 0; i <
-	 * subdirs.length; i++) { File searchSubDirDesc = new
-	 * File(ModManager.appendSlash(subdirs[i].toString()) + "moddesc.ini"); if
-	 * (searchSubDirDesc.exists()) { Mod validatingMod = new
-	 * Mod(ModManager.appendSlash(subdirs[i].getAbsolutePath()) +
-	 * "moddesc.ini"); if (validatingMod.isValidMod() && validatingMod.modCMMVer
-	 * >= 3) { availableMod.add(validatingMod); } } }
-	 * 
-	 * 
-	 * for (Mod i:availableMod){
-	 * ModManagerWindow.listDescriptors.put(i.getModName(),i); }
-	 * 
-	 * return availableMod; }
-	 */
-
-	/**
-	 * Checks for a file called Coalesced.original. If it exists, it will exit
-	 * this method, otherwise it will backup the current Coalesced and check
-	 * it's MD5 again the known original Coalesced.
-	 * 
-	 */
-	/*
-	 * public static boolean checkDoOriginal(String origDir) { String
-	 * patch3CoalescedHash = "540053c7f6eed78d92099cf37f239e8e"; // This // is
-	 * // Patch // 3 // Coalesced's // hash File cOriginal = new
-	 * File(ModManager.getDataDir() + "Coalesced.original"); if
-	 * (cOriginal.exists() == false) { // Attempt to copy an original try {
-	 * String coalDirHash =
-	 * MD5Checksum.getMD5Checksum(ModManager.appendSlash(origDir) +
-	 * "CookedPCConsole\\Coalesced.bin"); ModManager.debugLogger.writeMessage(
-	 * "Patch 3 Coalesced Original Hash: " + coalDirHash);
-	 * ModManager.debugLogger.writeMessage("Current Patch 3 Coalesced Hash: " +
-	 * patch3CoalescedHash);
-	 * 
-	 * if (!coalDirHash.equals(patch3CoalescedHash)) { String[] YesNo = { "Yes",
-	 * "No" }; int keepInstalling = JOptionPane .showOptionDialog( null,
-	 * "There is no backup of your original Coalesced yet.\nThe hash of the Coalesced in the directory you specified does not match the known hash for Patch 3's Coalesced.bin.\nYour Coalesced.bin's hash: "
-	 * + coalDirHash + "\nPatch 3 Coalesced.bin's hash: " + patch3CoalescedHash
-	 * +
-	 * "\nYou can continue, but you might lose access to your original Coalesced.\nYou can find a copy of Patch 3's Coalesced on http://me3tweaks.com/tools/modmanager/faq if you need to restore your original.\nContinue installing this mod? "
-	 * , "Coalesced Backup Error", JOptionPane.YES_NO_OPTION,
-	 * JOptionPane.WARNING_MESSAGE, null, YesNo, YesNo[1]); if (keepInstalling
-	 * == 0) return true; return false; } else { // Make a backup of it String
-	 * destFile = ModManager.getDataDir() + "Coalesced.original"; String
-	 * sourceFile = ModManager.appendSlash(origDir) + "Coalesced.bin"; String[]
-	 * command = { "cmd.exe", "/c", "copy", "/Y", sourceFile, destFile }; try {
-	 * Process p = Runtime.getRuntime().exec(command);
-	 * 
-	 * // The InputStream we get from the Process reads from // the standard
-	 * output // of the process (and also the standard error, by // virtue of
-	 * the line // copyFiles.redirectErrorStream(true) ). BufferedReader reader
-	 * = new BufferedReader(new InputStreamReader(p.getInputStream())); String
-	 * line; do { line = reader.readLine(); if (line != null) {
-	 * ModManager.debugLogger.writeMessage(line); } } while (line != null);
-	 * reader.close();
-	 * 
-	 * p.waitFor(); } catch (IOException e) { ModManager.debugLogger
-	 * .writeMessage(
-	 * "Error backing up the original Coalesced. Hash matched but we had an I/O exception. Aborting install."
-	 * ); ModManager.debugLogger.writeMessage(e.getMessage()); return false; }
-	 * catch (InterruptedException e) { ModManager.debugLogger.writeMessage(
-	 * "Backup of the original Coalesced was interupted. Aborting install.");
-	 * ModManager.debugLogger.writeMessage(e.getMessage()); return false; }
-	 * return true; } } catch (Exception e) {
-	 * ModManager.debugLogger.writeMessage (
-	 * "Error occured while attempting to backup or hash the original Coalesced."
-	 * ); ModManager.debugLogger.writeMessage(e.getMessage()); return false; } }
-	 * // Backup exists return true; }
-	 */
-
 	/**
 	 * Export a resource embedded into a Jar file to the local file path.
 	 *
@@ -704,25 +653,7 @@ public class ModManager {
 		OutputStream resStreamOut = null;
 		String jarFolder;
 		try {
-			stream = ModManager.class.getResourceAsStream(resourceName);// note
-																		// that
-																		// each
-																		// / is
-																		// a
-																		// directory
-																		// down
-																		// in
-																		// the
-																		// "jar
-																		// tree"
-																		// been
-																		// the
-																		// jar
-																		// the
-																		// root
-																		// of
-																		// the
-																		// tree
+			stream = ModManager.class.getResourceAsStream(resourceName);
 			if (stream == null) {
 				throw new Exception("Cannot get resource \"" + resourceName + "\" from Jar file.");
 			}
@@ -818,6 +749,8 @@ public class ModManager {
 			ModManager.ExportResource("/binkw23.dll", bink32_orig.toString());
 			if (asi) {
 				ModManager.ExportResource("/binkw32_asi.dll", bink32.toString());
+				File zlib = new File(gamedir.toString() + "\\Binaries\\Win32\\zlib1.dll");
+				ModManager.ExportResource("/zlib1.dll", zlib.toString());
 			} else {
 				ModManager.ExportResource("/binkw32.dll", bink32.toString());
 			}
@@ -1286,7 +1219,13 @@ public class ModManager {
 			sourceDestination.getParentFile().mkdirs();
 
 			// run ME3EXPLORER --decompress-pcc
+			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching "+sourceDestination.getName());
 			ProcessResult pr = ModManager.decompressPCC(sourceSource, sourceDestination);
+			if (pr.getReturnCode() == 0) {
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Cached "+sourceDestination.getName());
+			} else {
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching failed for file "+sourceDestination.getName());
+			}
 			ModManager.debugLogger.writeMessage("File decompressed to location, and ready? : " + sourceDestination.exists());
 			return sourceDestination.getAbsolutePath();
 			// END OF
@@ -1340,6 +1279,8 @@ public class ModManager {
 			// patchProcessBuilder.redirectErrorStream(true);
 			// patchProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
 			Process extractionProcess;
+			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching "+sourceDestination.getName());
+			
 			try {
 				extractionProcess = extractionProcessBuilder.start();
 				BufferedReader reader = new BufferedReader(new InputStreamReader(extractionProcess.getInputStream()));
@@ -1348,6 +1289,11 @@ public class ModManager {
 					System.out.println(line);
 				int result = extractionProcess.waitFor();
 				ModManager.debugLogger.writeMessage("ME3Explorer process finished, return code: " + result);
+				if (result == 0) {
+					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Cached "+sourceDestination.getName());
+				} else {
+					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching failed for file "+sourceDestination.getName());
+				}
 				return sourceDestination.getAbsolutePath();
 			} catch (IOException e) {
 				ModManager.debugLogger.writeException(e);
@@ -1621,8 +1567,10 @@ public class ModManager {
 	 *         false otherwise
 	 */
 	public static boolean checkIfASIBinkBypassIsInstalled(String biogameDir) {
+		ModManager.debugLogger.writeMessage("Checking for ASI Binkw32 ASI with biogame location: "+biogameDir);
 		File bgdir = new File(biogameDir);
 		if (!bgdir.exists()) {
+			ModManager.debugLogger.writeMessage("Biogame dir does not exist: "+biogameDir);
 			return false;
 		}
 		File gamedir = bgdir.getParentFile();
@@ -1634,11 +1582,14 @@ public class ModManager {
 			ArrayList<String> asihashlist = new ArrayList<>(Arrays.asList(asiBinkHashes));
 			String binkhash = MD5Checksum.getMD5Checksum(bink32.toString());
 			if (asihashlist.contains(binkhash) && bink23.exists()) {
+				ModManager.debugLogger.writeMessage("Binkw32 ASI is installed");
 				return true;
 			}
 		} catch (Exception e) {
 			ModManager.debugLogger.writeErrorWithException("Exception while attempting to find DLC bypass (Binkw32).", e);
 		}
+		ModManager.debugLogger.writeMessage("Binkw32 ASI is not installed");
+
 		return false;
 	}
 
@@ -2168,5 +2119,14 @@ public class ModManager {
 
 	public static File getASIManifestFile() {
 		return new File(getASICache() + "manifest.xml");
+	}
+	
+	public static boolean checkIfCMMPatchIsTooLong() {
+		return System.getProperty("user.dir").length() > 120;
+	}
+
+	public static boolean areBalanceChangesInstalled(String bioGameDir) {
+		File bcf = new File((new File(bioGameDir).getParent()) + "/Binaries/win32/asi/ServerCoalesced.bin");
+		return bcf.exists();
 	}
 }

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -72,9 +72,9 @@ import com.sun.jna.platform.win32.WinReg;
 
 public class ModManager {
 
-	public static final String VERSION = "4.3.1";
+	public static final String VERSION = "4.3.1 SoakTest";
 	public static long BUILD_NUMBER = 60L;
-	public static final String BUILD_DATE = "8/7/2016";
+	public static final String BUILD_DATE = "8/31/2016";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
@@ -310,26 +310,27 @@ public class ModManager {
 					}
 				}
 				{
-				// AutoTOC game files after install
-				String autotocPostInstallStr = settingsini.get("Settings", "runautotocpostinstall");
-				int autotocPostInstallInt = 0;
-				if (autotocPostInstallStr != null && !autotocPostInstallStr.equals("")) {
-					try {
-						autotocPostInstallInt = Integer.parseInt(autotocPostInstallStr);
-						if (autotocPostInstallInt > 0) {
-							// logging is on
-							debugLogger.writeMessage("AutoTOC post install is enabled");
-							POST_INSTALL_AUTOTOC_INSTEAD = true;
-						} else {
-							debugLogger.writeMessage("AutoTOC post install is disabled");
+					// AutoTOC game files after install
+					String autotocPostInstallStr = settingsini.get("Settings", "runautotocpostinstall");
+					int autotocPostInstallInt = 0;
+					if (autotocPostInstallStr != null && !autotocPostInstallStr.equals("")) {
+						try {
+							autotocPostInstallInt = Integer.parseInt(autotocPostInstallStr);
+							if (autotocPostInstallInt > 0) {
+								// logging is on
+								debugLogger.writeMessage("AutoTOC post install is enabled");
+								POST_INSTALL_AUTOTOC_INSTEAD = true;
+							} else {
+								debugLogger.writeMessage("AutoTOC post install is disabled");
+								POST_INSTALL_AUTOTOC_INSTEAD = false;
+							}
+						} catch (NumberFormatException e) {
+							debugLogger.writeError("Number format exception reading the autotoc post install flag - defaulting to disabled");
 							POST_INSTALL_AUTOTOC_INSTEAD = false;
 						}
-					} catch (NumberFormatException e) {
-						debugLogger.writeError("Number format exception reading the autotoc post install flag - defaulting to disabled");
-						POST_INSTALL_AUTOTOC_INSTEAD = false;
 					}
-				}}
-				
+				}
+
 				// AutoTOC game files after install
 				String controllerModUserStr = settingsini.get("Settings", "controllermoduser");
 				int controllerModUserInt = 0;
@@ -346,7 +347,7 @@ public class ModManager {
 						}
 					} catch (NumberFormatException e) {
 						debugLogger.writeError("Number format exception reading the controller mod user flag - defaulting to disabled");
-						MODMAKER_CONTROLLER_MOD_ADDINS  = false;
+						MODMAKER_CONTROLLER_MOD_ADDINS = false;
 					}
 				}
 
@@ -418,11 +419,13 @@ public class ModManager {
 				new NetFrameworkMissingWindow(
 						"Mod Manager was unable to detect a usable .NET Framework. Mod Manager requires Microsoft .NET Framework 4.5 or higher in order to function properly. ");
 			}
-			
+
 			if (checkIfCMMPatchIsTooLong()) {
-				JOptionPane.showMessageDialog(null, "Mod Manager has detected that it running from a location with a long filepath.\nMod Manager caches files using their relative game directory path.\nYou may consider moving Mod Manager higher up this file system's hierarchy\nto avoid issues with Windows path limitations.", "Windows Path Limitation Warning", JOptionPane.WARNING_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"Mod Manager has detected that it running from a location with a long filepath.\nMod Manager caches files using their relative game directory path.\nYou may consider moving Mod Manager higher up this file system's hierarchy\nto avoid issues with Windows path limitations.",
+						"Windows Path Limitation Warning", JOptionPane.WARNING_MESSAGE);
 			}
-			
+
 			ModManager.debugLogger.writeMessage("========End of startup=========");
 		} catch (Throwable e) {
 			Wini ini;
@@ -1219,12 +1222,12 @@ public class ModManager {
 			sourceDestination.getParentFile().mkdirs();
 
 			// run ME3EXPLORER --decompress-pcc
-			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching "+sourceDestination.getName());
+			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching " + sourceDestination.getName());
 			ProcessResult pr = ModManager.decompressPCC(sourceSource, sourceDestination);
 			if (pr.getReturnCode() == 0) {
-				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Cached "+sourceDestination.getName());
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Cached " + sourceDestination.getName());
 			} else {
-				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching failed for file "+sourceDestination.getName());
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching failed for file " + sourceDestination.getName());
 			}
 			ModManager.debugLogger.writeMessage("File decompressed to location, and ready? : " + sourceDestination.exists());
 			return sourceDestination.getAbsolutePath();
@@ -1279,8 +1282,8 @@ public class ModManager {
 			// patchProcessBuilder.redirectErrorStream(true);
 			// patchProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
 			Process extractionProcess;
-			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching "+sourceDestination.getName());
-			
+			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching " + sourceDestination.getName());
+
 			try {
 				extractionProcess = extractionProcessBuilder.start();
 				BufferedReader reader = new BufferedReader(new InputStreamReader(extractionProcess.getInputStream()));
@@ -1290,9 +1293,9 @@ public class ModManager {
 				int result = extractionProcess.waitFor();
 				ModManager.debugLogger.writeMessage("ME3Explorer process finished, return code: " + result);
 				if (result == 0) {
-					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Cached "+sourceDestination.getName());
+					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Cached " + sourceDestination.getName());
 				} else {
-					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching failed for file "+sourceDestination.getName());
+					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Caching failed for file " + sourceDestination.getName());
 				}
 				return sourceDestination.getAbsolutePath();
 			} catch (IOException e) {
@@ -1567,10 +1570,10 @@ public class ModManager {
 	 *         false otherwise
 	 */
 	public static boolean checkIfASIBinkBypassIsInstalled(String biogameDir) {
-		ModManager.debugLogger.writeMessage("Checking for ASI Binkw32 ASI with biogame location: "+biogameDir);
+		ModManager.debugLogger.writeMessage("Checking for ASI Binkw32 ASI with biogame location: " + biogameDir);
 		File bgdir = new File(biogameDir);
 		if (!bgdir.exists()) {
-			ModManager.debugLogger.writeMessage("Biogame dir does not exist: "+biogameDir);
+			ModManager.debugLogger.writeMessage("Biogame dir does not exist: " + biogameDir);
 			return false;
 		}
 		File gamedir = bgdir.getParentFile();
@@ -1583,6 +1586,12 @@ public class ModManager {
 			String binkhash = MD5Checksum.getMD5Checksum(bink32.toString());
 			if (asihashlist.contains(binkhash) && bink23.exists()) {
 				ModManager.debugLogger.writeMessage("Binkw32 ASI is installed");
+				//Add zlib if not present to bring old installs up to date
+				File zlib = new File(gamedir.toString() + "\\Binaries\\Win32\\zlib1.dll");
+				if (!zlib.exists()) {
+					ModManager.debugLogger.writeMessage("Installing zlib.dll to bring old ASI bypass installation up to date");
+					ModManager.ExportResource("/zlib1.dll", zlib.toString());
+				}
 				return true;
 			}
 		} catch (Exception e) {
@@ -2120,7 +2129,7 @@ public class ModManager {
 	public static File getASIManifestFile() {
 		return new File(getASICache() + "manifest.xml");
 	}
-	
+
 	public static boolean checkIfCMMPatchIsTooLong() {
 		return System.getProperty("user.dir").length() > 120;
 	}

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -72,9 +72,9 @@ import com.sun.jna.platform.win32.WinReg;
 
 public class ModManager {
 
-	public static final String VERSION = "4.3.1 SoakTest";
+	public static final String VERSION = "4.3.1";
 	public static long BUILD_NUMBER = 60L;
-	public static final String BUILD_DATE = "8/31/2016";
+	public static final String BUILD_DATE = "9/2/2016";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1587,7 +1587,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				updateApplyButton();
 				if (ModManager.checkIfASIBinkBypassIsInstalled(fieldBiogameDir.getText()) == false) {
 					JOptionPane.showMessageDialog(null,
-							"ASI loader not installed.\nASI mods won't load without using the ASI version of binkw32.\nYou can install this from the tools menu.",
+							"ASI loader not installed.\nASI mods won't load without using the ASI version of binkw32.\nYou can install this from the tools menu or the ASI Mod Management window.",
 							"ASI loader not installed", JOptionPane.WARNING_MESSAGE);
 				}
 

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -190,6 +190,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		} else {
 			ModManager.debugLogger.writeMessage("Mod Manager GUI: Now setting visible.");
 			try {
+				boolean asiinstalled = ASIModWindow.IsASIModGroupInstalled(5);
+				System.out.println("UG5 installed: " + asiinstalled);
 				this.setVisible(true);
 			} catch (Exception e) {
 				ModManager.debugLogger.writeErrorWithException("Uncaught runtime exception:", e);
@@ -423,7 +425,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					publish(new ThreadCommand("UPDATE_HELP_MENU"));
 					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading ASI list from ME3Tweaks"));
 					ASIModWindow.getOnlineASIManifest();
-					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Updated ASI mod list"));
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Downloading latest MixIns"));
+					String updateStr = PatchLibraryWindow.getLatestMixIns();
+					publish(new ThreadCommand("SET_STATUSBAR_TEXT", updateStr));
 					if (modModel.getSize() > 0) {
 						publish(new ThreadCommand("SET_STATUSBAR_TEXT", "Checking for updates to mods"));
 						checkAllModsForUpdates(false);
@@ -822,76 +826,83 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		new FileDrop(contentPanel, new FileDrop.Listener() {
 			public void filesDropped(java.io.File[] files) {
 				// only works with first file
-				if (files.length > 0 && files[0].exists()) {
-					ModManager.debugLogger.writeMessage("File was dropped onto Mod Manager Window: " + files[0]);
+				if (validateBIOGameDir()) {
+					if (files.length > 0 && files[0].exists()) {
+						ModManager.debugLogger.writeMessage("File was dropped onto Mod Manager Window: " + files[0]);
 
-					if (files[0].isDirectory()) {
-						// prompt
-						new FolderBatchWindow(ModManagerWindow.this, files[0]);
-					}
-					if (files[0].isFile()) {
-						String extension = FilenameUtils.getExtension(files[0].toString()).toLowerCase();
-						switch (extension) {
-						case "7z":
-						case "zip":
-						case "rar":
-							new ModImportArchiveWindow(ModManagerWindow.this, files[0].toString());
-							break;
-						case "pcc":
-						case "asi":
-							int exebuild = ModManager.checkforME3105(fieldBiogameDir.getText());
-							if (exebuild != 5) {
-								labelStatus.setText("ASI mods don't work with Mass Effect 3 1.0" + exebuild);
-								break;
-							}
-							if (!ModManager.checkIfASIBinkBypassIsInstalled(fieldBiogameDir.getText())) {
-								labelStatus.setText("Binkw32 ASI loader not installed");
-								break;
-							}
-						case "xml":
+						if (files[0].isDirectory()) {
+							// prompt
 							new FolderBatchWindow(ModManagerWindow.this, files[0]);
-							break;
-						case "dlc":
-							new MountFileEditorWindow(files[0].toString());
-							break;
-						case "tlk":
-							TLKTool.decompileTLK(files[0]);
-							break;
-
-						case "bin":
-							// read magic at beginning to find out what type of
-							// file this is
-							try {
-								byte[] buffer = new byte[4];
-								InputStream is = new FileInputStream(files[0]);
-								if (is.read(buffer) != buffer.length) {
-									// do something
-								}
-								int magic = ResourceUtils.byteArrayToInt(buffer);
-								switch (magic) {
-								case ModManager.COALESCED_MAGIC_NUMBER:
-									new CoalescedWindow(files[0], false);
+						}
+						if (files[0].isFile()) {
+							String extension = FilenameUtils.getExtension(files[0].toString()).toLowerCase();
+							switch (extension) {
+							case "7z":
+							case "zip":
+							case "rar":
+								new ModImportArchiveWindow(ModManagerWindow.this, files[0].toString());
+								break;
+							case "pcc":
+							case "asi":
+								int exebuild = ModManager.checkforME3105(fieldBiogameDir.getText());
+								if (exebuild != 5) {
+									labelStatus.setText("ASI mods don't work with Mass Effect 3 1.0" + exebuild);
 									break;
 								}
+								if (!ModManager.checkIfASIBinkBypassIsInstalled(fieldBiogameDir.getText())) {
+									labelStatus.setText("Binkw32 ASI loader not installed");
+									break;
+								}
+							case "xml":
+								new FolderBatchWindow(ModManagerWindow.this, files[0]);
+								break;
+							case "dlc":
+								new MountFileEditorWindow(files[0].toString());
+								break;
+							case "tlk":
+								TLKTool.decompileTLK(files[0]);
+								break;
 
-								is.close();
+							case "bin":
+								// read magic at beginning to find out what type of
+								// file this is
+								try {
+									byte[] buffer = new byte[4];
+									InputStream is = new FileInputStream(files[0]);
+									if (is.read(buffer) != buffer.length) {
+										// do something
+									}
+									int magic = ResourceUtils.byteArrayToInt(buffer);
+									switch (magic) {
+									case ModManager.COALESCED_MAGIC_NUMBER:
+										new CoalescedWindow(files[0], false);
+										break;
+									}
 
-								/*
-								 * switch (magic) { default:
-								 * System.out.println("uh"); }
-								 */
-							} catch (IOException e) {
-								e.printStackTrace();
-								// this shouldn't be possible
-							} finally {
+									is.close();
 
+									/*
+									 * switch (magic) { default:
+									 * System.out.println("uh"); }
+									 */
+								} catch (IOException e) {
+									e.printStackTrace();
+									// this shouldn't be possible
+								} finally {
+
+								}
+								break;
+							default:
+								labelStatus.setText("Extension not supported for Drag and Drop: " + extension);
+								break;
 							}
-							break;
-						default:
-							labelStatus.setText("Extension not supported for Drag and Drop: " + extension);
-							break;
 						}
 					}
+				} else {
+					labelStatus.setText("Drag and Drop requires a valid BioGame directory");
+					labelStatus.setVisible(true);
+					JOptionPane.showMessageDialog(null, "The BIOGame directory is not valid.\nFix the BIOGame directory to use drag and drop features.",
+							"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		});
@@ -2128,7 +2139,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				if (ModManager.validateNETFrameworkIsInstalled()) {
 					ModManager.debugLogger.writeMessage("Opening patch library window.");
 					updateApplyButton();
-					new PatchLibraryWindow();
+					new PatchLibraryWindow(PatchLibraryWindow.MANUAL_MODE);
 				} else {
 					updateApplyButton();
 					labelStatus.setText(".NET Framework 4.5 or higher is missing");
@@ -2194,12 +2205,25 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 		} else if (e.getSource() == toolsInstallBinkw32asi) {
 			if (validateBIOGameDir()) {
-				int result = JOptionPane.showConfirmDialog(ModManagerWindow.this,
-						"<html><div style='width: 300px'>Installing the ASI version of binkw32.dll bypass will load .asi files and run 3rd party code. Any .asi file in the same folder as MassEffect3.exe and within a subfolder named asi will be loaded at game startup. The code in these asi files will then be run like any program on your computer.<br><br>Ensure you trust the developer you download and install ASI mods from.<br><br>If you have no idea what this means, you should use the default non-asi binkw32.dll bypass option.<br><br>Install the ASI version of binkw32 bypass?</div></html>",
-						"Potential security risk", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-				if (result == JOptionPane.YES_OPTION) {
-					ModManager.debugLogger.writeMessage("Installing manual Binkw32 (ASI) bypass.");
-					installBinkw32Bypass(true);
+				if (validateVC2012()) {
+					int result = JOptionPane.showConfirmDialog(ModManagerWindow.this,
+							"<html><div style='width: 300px'>Installing the ASI version of binkw32.dll bypass will load .asi files and run 3rd party code. Any .asi file in the same folder as MassEffect3.exe and within a subfolder named asi will be loaded at game startup. The code in these asi files will then be run like any program on your computer.<br><br>Ensure you trust the developer you download and install ASI mods from.<br><br>If you have no idea what this means, you should use the default non-asi binkw32.dll bypass option.<br><br>Install the ASI version of binkw32 bypass?</div></html>",
+							"Potential security risk", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+					if (result == JOptionPane.YES_OPTION) {
+						ModManager.debugLogger.writeMessage("Installing manual Binkw32 (ASI) bypass.");
+						installBinkw32Bypass(true);
+					}
+				} else {
+					labelStatus.setText("Binkw32 ASI Bypass requires Visual C++ 2012 x86");
+					labelStatus.setVisible(true);
+					JOptionPane.showMessageDialog(null,
+							"The Binkw32 ASI Bypass requires Visual C++ 2012 x86 redistributable.\nIf you are sure you have this installed, turn off the .NET version check in Mod Manager options.",
+							"ASI loader requires VC2012 x86", JOptionPane.ERROR_MESSAGE);
+					try {
+						ModManager.openWebpage(new URL("https://www.microsoft.com/en-us/download/details.aspx?id=30679"));
+					} catch (MalformedURLException e1) {
+						ModManager.debugLogger.writeErrorWithException("Unable to open VC++ download page:", e1);
+					}
 				}
 			} else {
 				labelStatus.setText("Installing DLC bypass requires valid BIOGame directory");
@@ -2229,6 +2253,29 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 						JOptionPane.ERROR_MESSAGE);
 			}
 		}
+	}
+
+	private boolean validateVC2012() {
+		if (!ModManager.PERFORM_DOT_NET_CHECK) {
+			return true;
+		}
+		try {
+			String x86VC2012 = "SOFTWARE\\Classes\\Installer\\Dependencies\\{33d1fd90-4274-48a1-9bc1-97e33d9c2d6f}";
+			String installDir = null;
+			ModManager.debugLogger.writeMessage("Scanning registry for Visual C++ 2012 x86");
+			installDir = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, x86VC2012, "Version");
+
+			if (installDir == null) {
+				return false;
+			}
+
+			if (installDir.equals("11.0.61030.0")) {
+				return true;
+			}
+		} catch (Throwable e) {
+			ModManager.debugLogger.writeErrorWithException("Error occured while attempting to get VC2012 installation status! Could be the JNA crash.", e);
+		}
+		return false;
 	}
 
 	private void checkAllModsForUpdates(boolean isManualCheck) {

--- a/src/com/me3tweaks/modmanager/OptionsWindow.java
+++ b/src/com/me3tweaks/modmanager/OptionsWindow.java
@@ -34,6 +34,7 @@ public class OptionsWindow extends JDialog {
 	private JCheckBox autoTocPostInstall;
 	private AbstractButton logModInit;
 	private JCheckBox logPatchInit;
+	private JCheckBox autoFixControllerModMaker;
 
 	public OptionsWindow(JFrame callingWindow) {
 		setupWindow();
@@ -137,6 +138,33 @@ public class OptionsWindow extends JDialog {
 						ini.put("Settings", "autoinjectkeybinds", "0");
 					}
 					ModManager.AUTO_INJECT_KEYBINDS = autoInjectKeybindsModMaker.isSelected();
+					ini.store();
+				} catch (InvalidFileFormatException error) {
+					error.printStackTrace();
+				} catch (IOException error) {
+					ModManager.debugLogger.writeMessage("Settings file encountered an I/O error while attempting to write it. Settings not saved.");
+				}
+			}
+		});
+		
+		autoFixControllerModMaker = new JCheckBox("Auto-inject controller mod fixes into ModMaker mods");
+		autoFixControllerModMaker
+				.setToolTipText("<html>A few mixins will cause a file conflict with the controller mods if two mods are installed over each other.<br>Turn this option on if you are a controller mod user and it will apply the camera turning mixins to any ModMaker mod that modifies SFXGame.</html>");
+		autoFixControllerModMaker.setSelected(ModManager.MODMAKER_CONTROLLER_MOD_ADDINS);
+		autoFixControllerModMaker.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				Wini ini;
+				try {
+					File settings = new File(ModManager.SETTINGS_FILENAME);
+					if (!settings.exists())
+						settings.createNewFile();
+					ini = new Wini(settings);
+					if (autoFixControllerModMaker.isSelected()) {
+						ini.put("Settings", "controllermoduser", "1");
+					} else {
+						ini.put("Settings", "controllermoduser", "0");
+					}
+					ModManager.MODMAKER_CONTROLLER_MOD_ADDINS = autoFixControllerModMaker.isSelected();
 					ini.store();
 				} catch (InvalidFileFormatException error) {
 					error.printStackTrace();
@@ -359,6 +387,8 @@ public class OptionsWindow extends JDialog {
 		
 		optionsPanel.add(autoApplyMixins);
 		optionsPanel.add(autoInjectKeybindsModMaker);
+		optionsPanel.add(autoFixControllerModMaker);
+		optionsPanel.add(new JSeparator(JSeparator.HORIZONTAL));
 		optionsPanel.add(autoTocPostInstall);
 		optionsPanel.add(new JSeparator(JSeparator.HORIZONTAL));
 		optionsPanel.add(autoUpdateModManager);

--- a/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
@@ -144,6 +144,9 @@ public class PatchApplicationWindow extends JDialog {
 						failedPatches.add(patch);
 						publish(new ThreadCommand("PATCH_FAILED", Integer.toString(applyResult), new PatchModBundle(patch, mod)));
 					}
+					if (patch.isDynamic()) {
+						FileUtils.deleteQuietly(new File(patch.getPatchPath()));
+					}
 					numcompleted++;
 				}
 			}

--- a/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
+++ b/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
@@ -153,6 +153,7 @@ public class RestoreFilesWindow extends JDialog {
 					return processDeleteUnpackedFiles(customTaskHeader);
 				case RestoreMode.ALL:
 					numjobs = ModType.getHeaderNameArray().length + 3;
+					wipeBalanceChanges();
 					publish("Deleting custom DLC, restoring basegame/unpacked files,SFARs, unpacked content");
 					return removeCustomDLC() && processRestoreBasegame(false, false) && restoreSFARsUsingHeaders(ModType.getDLCHeaderNameArray())
 							&& processDeleteUnpackedFiles(ModType.getDLCHeaderNameArray());
@@ -171,10 +172,12 @@ public class RestoreFilesWindow extends JDialog {
 				case RestoreMode.UNPACKEDBASEGAME:
 					numjobs = 1;
 					publish("Restoring basegame and unpacked DLC files");
+					wipeBalanceChanges();
 					return processRestoreBasegame(false, false);
 				case RestoreMode.VANILLIFYDLC:
 					numjobs = 2 + ModType.getDLCHeaderNameArray().length;
 					publish("Attempting to return DLC to vanilla state");
+					wipeBalanceChanges();
 					return removeCustomDLC() && restoreSFARsUsingHeaders(ModType.getDLCHeaderNameArray())
 							&& processDeleteUnpackedFiles(ModType.getDLCHeaderNameArray());
 				case RestoreMode.ALLDLC:
@@ -188,10 +191,12 @@ public class RestoreFilesWindow extends JDialog {
 				case RestoreMode.MP:
 					numjobs = ModType.getMPHeaderNameArray().length;
 					publish("Restoring MP SFARs");
+					wipeBalanceChanges();
 					return restoreSFARsUsingHeaders(ModType.getMPHeaderNameArray());
 				case RestoreMode.MPBASE:
 					numjobs = ModType.getMPHeaderNameArray().length + 1;
 					publish("Restoring MP SFARs and basegame files");
+					wipeBalanceChanges();
 					return processRestoreBasegame(false, true) && restoreSFARsUsingHeaders(ModType.getMPHeaderNameArray());
 				case RestoreMode.SPBASE:
 					numjobs = ModType.getSPHeaderNameArray().length + 1;
@@ -201,6 +206,10 @@ public class RestoreFilesWindow extends JDialog {
 					//numjobs calculated in the procedure
 					publish("Deleting unpacked files");
 					return processDeleteUnpackedFiles(ModType.getDLCHeaderNameArray());
+				case RestoreMode.BALANCE_CHANGES:
+					publish("Deleting ServerCoalesced.bin");
+					wipeBalanceChanges();
+					return true;
 				default:
 					return false;
 				}
@@ -338,6 +347,19 @@ public class RestoreFilesWindow extends JDialog {
 				return true;
 			} else {
 				return false;
+			}
+		}
+		
+		/**
+		 * Deletes ServerCoalesced.bin from ME3/Binaries/win32/ServerCoalesced.bin
+		 */
+		private void wipeBalanceChanges() {
+			File bcf = new File((new File(BioGameDir).getParent()) + "/Binaries/win32/asi/ServerCoalesced.bin");
+			if (bcf.exists()) {
+				FileUtils.deleteQuietly(bcf);
+				ModManager.debugLogger.writeMessage("Deleted ServerCoalesced.bin");
+			} else {
+				ModManager.debugLogger.writeMessage("No ServerCoalesced.bin. Nothing to delete");
 			}
 		}
 
@@ -781,6 +803,9 @@ public class RestoreFilesWindow extends JDialog {
 			case RestoreMode.VANILLIFYDLC:
 				status = "Vanillified DLC";
 				break;
+			case RestoreMode.BALANCE_CHANGES:
+				status = "Uninstalled balance changes override file";
+				break;
 			}
 			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(status);
 			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setVisible(true);
@@ -816,5 +841,4 @@ public class RestoreFilesWindow extends JDialog {
 		// Log.i(Launch.APPTAG, "DebugView\n"+this.toString());
 		consoleArea.setText(getConsoleString());
 	}
-
 }

--- a/src/com/me3tweaks/modmanager/UpdateAvailableWindow.java
+++ b/src/com/me3tweaks/modmanager/UpdateAvailableWindow.java
@@ -401,6 +401,7 @@ public class UpdateAvailableWindow extends JDialog implements ActionListener, Pr
 			ProcessBuilder pb = new ProcessBuilder(command);
 			pb.start();
 			ModManager.debugLogger.writeMessage("Upgrading to build "+build+", shutting down.");
+			ModManager.MOD_MANAGER_UPDATE_READY = true; //do not delete temp
 			System.exit(0);
 		} catch (IOException e) {
 			ModManager.debugLogger.writeErrorWithException("FAILED TO RUN AUTO UPDATER:",e);
@@ -414,7 +415,7 @@ public class UpdateAvailableWindow extends JDialog implements ActionListener, Pr
 	 */
 	private boolean buildUpdateScript(){
 		StringBuilder sb = new StringBuilder();
-		sb.append("::Update script for Mod Manager 4.1 (Build "+build+")");
+		sb.append("::Update script for Mod Manager "+ModManager.VERSION+" (Build "+build+")");
 		sb.append("\r\n");
 		sb.append("\r\n");
 		sb.append("@echo off");

--- a/src/com/me3tweaks/modmanager/modmaker/DynamicPatch.java
+++ b/src/com/me3tweaks/modmanager/modmaker/DynamicPatch.java
@@ -54,12 +54,17 @@ public class DynamicPatch {
 		finalPatch.setPatchCMMVer(ModManager.MODDESC_VERSION_SUPPORT);
 		finalPatch.setPatchAuthor("ME3Tweaks ModMaker Dynamic MixIn");
 		finalPatch.setMe3tweaksid(0);
+		finalPatch.setIsDynamic(true);
 	}
 
 	public File getOutputfile() {
 		return outputfile;
 	}
 
+	/**
+	 * Returns a mixin defined from a dynamic mixin from me3tweaks modmaker
+	 * @return standard mixin object
+	 */
 	public Patch getFinalPatch() {
 		return finalPatch;
 	}

--- a/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
@@ -186,6 +186,8 @@ public class ME3TweaksUtils {
 			return "CITADEL";
 		case "Default_DLC_EXP_Pack003_Base.bin":
 			return "CITADEL_BASE";
+		case "ServerCoalesced.bin":
+			return "BALANCE_CHANGES";
 		default:
 			ModManager.debugLogger.writeMessage("ME3TWEAKSUTILS ERROR: HEADER => INTERNAL " + coalName);
 			return null;
@@ -230,6 +232,8 @@ public class ME3TweaksUtils {
 			return "CITADEL";
 		case "Default_DLC_EXP_Pack003_Base.bin":
 			return "CITADEL_BASE";
+		case "ServerCoalesced.bin":
+			return "BALANCE_CHANGES";
 		default:
 			ModManager.debugLogger.writeMessage("ME3TWEAKSUTILS ERROR: FILENAME => HEADER " + coalName);
 			return null;
@@ -383,6 +387,8 @@ public class ME3TweaksUtils {
 			return "Default_DLC_EXP_Pack003.bin";
 		case "CITADEL_BASE":
 			return "Default_DLC_EXP_Pack003_Base.bin";
+		case "BALANCE_CHANGES":
+			return "ServerCoalesced.bin";
 		default:
 			ModManager.debugLogger.writeMessage("ME3TWEAKSUTILS ERROR: HEADER => FILENAME " + header);
 			return null;
@@ -436,6 +442,8 @@ public class ME3TweaksUtils {
 			return "Default_DLC_EXP_Pack003.bin";
 		case "CITADEL_BASE":
 			return "Default_DLC_EXP_Pack003_Base.bin";
+		case "BALANCE_CHANGES":
+			return "ServerCoalesced.bin";
 		default:
 			ModManager.debugLogger.writeMessage("ME3TWEAKSUTILS ERROR: NO MATCH INTERNAL => FILENAME: " + internal);
 			return null;
@@ -486,6 +494,8 @@ public class ME3TweaksUtils {
 			return "CITADEL";
 		case "CITADEL_BASE":
 			return "CITADEL_BASE";
+		case "BALANCE_CHANGES":
+			return "BALANCE_CHANGES";
 		default:
 			ModManager.debugLogger.writeMessage("ME3TWEAKSUTILS ERROR: INTERNAL => HEADER " + internal);
 			return null;
@@ -595,7 +605,6 @@ public class ME3TweaksUtils {
 			return "/BIOGame/DLC/DLC_EXP_Pack003/PCConsoleTOC.bin";
 		case "Default_DLC_EXP_Pack003_Base.bin":
 			return "/BIOGame/DLC/DLC_EXP_Pack003_Base/PCConsoleTOC.bin";
-
 		default:
 			ModManager.debugLogger.writeMessage("[coalFileNameToDLCTOCDIR] UNRECOGNIZED COAL FILE: " + coalName);
 			return null;

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -53,6 +53,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import com.me3tweaks.modmanager.ASIModWindow;
 import com.me3tweaks.modmanager.AutoTocWindow;
 import com.me3tweaks.modmanager.KeybindsInjectionWindow;
 import com.me3tweaks.modmanager.ModManager;
@@ -61,6 +62,8 @@ import com.me3tweaks.modmanager.ModManagerWindow;
 import com.me3tweaks.modmanager.PatchLibraryWindow;
 import com.me3tweaks.modmanager.objects.Mod;
 import com.me3tweaks.modmanager.objects.ModDelta;
+import com.me3tweaks.modmanager.objects.ModJob;
+import com.me3tweaks.modmanager.objects.ModType;
 import com.me3tweaks.modmanager.objects.ThreadCommand;
 import com.me3tweaks.modmanager.utilities.ResourceUtils;
 import com.me3tweaks.modmanager.valueparsers.biodifficulty.Category;
@@ -1865,6 +1868,19 @@ public class ModMakerCompilerWindow extends JDialog {
 		dispose();
 		if (mod == null) {
 			//updater supresses this window
+			for (ModJob job : newMod.jobs) {
+				if (job.getJobName().equals(ModType.BINI)){
+					if (ModManager.checkIfASIBinkBypassIsInstalled(ModManagerWindow.ACTIVE_WINDOW.fieldBiogameDir.getText())) {
+						if (!ASIModWindow.IsASIModGroupInstalled(5)) {
+							//loader installed, no balance changes replacer
+							JOptionPane.showMessageDialog(this, "<html><div style=\"width: 400px\">"+modName + " contains changes to the Balance Changes file.<br>For the mod to fully work you need to install the Balance Changes Replacer ASI from\nthe ASI Mod Management window, located at Mod Management > Manage ASI Code Injection Mods.</div></html>", "Balance Changer Replacer ASI required", JOptionPane.WARNING_MESSAGE);
+						}
+					} else {
+						JOptionPane.showMessageDialog(this, "<html><div style=\"width: 400px\">"+modName + " contains changes to the Balance Changes file.<br>For the mod to fully work you need to install the ASI loader as well as the Balance Changes Replacer ASI from the ASI Mod Management window, located at Mod Management > Manage ASI Code Injection Mods.</div></html>", "ASI Loader + Balance Changer Replacer ASI required", JOptionPane.WARNING_MESSAGE);
+					}
+					break;
+				}
+			}
 			JOptionPane.showMessageDialog(this, modName + " was successfully created!", "Mod Created", JOptionPane.INFORMATION_MESSAGE);
 			new ModManagerWindow(false);
 		}

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -193,8 +193,8 @@ public class ModMakerCompilerWindow extends JDialog {
 				String modDelta = null;
 				if (mmcode > 0) {
 					try {
-						String downloadedfile = ModManager.getTempDir()+code+".xml";
-						File lzmafile = new File(downloadedfile+".lzma");
+						String downloadedfile = ModManager.getTempDir() + code + ".xml";
+						File lzmafile = new File(downloadedfile + ".lzma");
 						publish(new ThreadCommand("UPDATE_INFO", "<html>Downloading mod delta from ME3Tweaks</html>"));
 						FileUtils.copyURLToFile(new URL(lzmalink), lzmafile);
 						publish(new ThreadCommand("UPDATE_INFO", "<html>Decompressing mod delta</html>"));
@@ -209,8 +209,8 @@ public class ModMakerCompilerWindow extends JDialog {
 							throw new IOException("Failed to decompress LZMA file, falling back...");
 						}
 					} catch (IOException e) {
-						FileUtils.deleteQuietly(new File(ModManager.getTempDir()+code+".xml"));
-						FileUtils.deleteQuietly(new File(ModManager.getTempDir()+code+".xml.lzma"));
+						FileUtils.deleteQuietly(new File(ModManager.getTempDir() + code + ".xml"));
+						FileUtils.deleteQuietly(new File(ModManager.getTempDir() + code + ".xml.lzma"));
 						try {
 							ModManager.debugLogger.writeMessage("I/O Exception using LZMA link, falling back to decompressed link...");
 							publish(new ThreadCommand("UPDATE_INFO", "<html>Downloading mod delta from ME3Tweaks</html>"));
@@ -516,6 +516,8 @@ public class ModMakerCompilerWindow extends JDialog {
 			return "/BIOGame/DLC/DLC_EXP_Pack003/CookedPCConsole/Default_DLC_EXP_Pack003.bin";
 		case "Default_DLC_EXP_Pack003_Base.bin":
 			return "/BIOGame/DLC/DLC_EXP_Pack003_Base/CookedPCConsole/Default_DLC_EXP_Pack003_Base.bin";
+		case "ServerCoalesced.bin":
+			return "\\Binaries\\win32\\asi\\ServerCoalesced.bin";
 		default:
 			ModManager.debugLogger.writeMessage("ERROR: UNRECOGNIZED COAL FILE: " + coalName);
 			return null;
@@ -739,18 +741,19 @@ public class ModMakerCompilerWindow extends JDialog {
 		protected Void doInBackground() throws Exception {
 			int coalsCompeted = 0;
 			for (String coal : coalsToDownload) {
-				try {
-					if (!ModManager.hasPristineCoalesced(coal, ME3TweaksUtils.FILENAME)) {
-						ME3TweaksUtils.downloadPristineCoalesced(coal, ME3TweaksUtils.FILENAME);
-					}
-					FileUtils.copyFile(new File(ModManager.getPristineCoalesced(coal, ME3TweaksUtils.FILENAME)), new File(ModManager.getCompilingDir() + "coalesceds/" + coal));
-					ModManager.debugLogger.writeMessage("Copied pristine coalesced of " + coal + " to: " + (new File("coalesceds/" + coal)).getAbsolutePath());
-					coalsCompeted++;
-					this.publish(coalsCompeted);
-				} catch (IOException e) {
-					ModManager.debugLogger.writeMessage("Failed to download coalesced file due to IO Exception.");
-					ModManager.debugLogger.writeException(e);
+				//try {
+				if (!ModManager.hasPristineCoalesced(coal, ME3TweaksUtils.FILENAME)) {
+					ME3TweaksUtils.downloadPristineCoalesced(coal, ME3TweaksUtils.FILENAME);
 				}
+				FileUtils.copyFile(new File(ModManager.getPristineCoalesced(coal, ME3TweaksUtils.FILENAME)), new File(ModManager.getCompilingDir() + "coalesceds/" + coal));
+				ModManager.debugLogger.writeMessage("Copied pristine coalesced of " + coal + " to: " + (new File("coalesceds/" + coal)).getAbsolutePath());
+				coalsCompeted++;
+				this.publish(coalsCompeted);
+				//} catch (IOException e) {
+				//	ModManager.debugLogger.writeMessage("Failed to download coalesced file due to IO Exception.");
+				//	ModManager.debugLogger.writeException(e);
+				//	error = true;
+				//}
 			}
 			return null;
 		}
@@ -772,16 +775,20 @@ public class ModMakerCompilerWindow extends JDialog {
 			} catch (ExecutionException e) {
 				ModManager.debugLogger.writeMessage("Error occured in CoalDownloadWorker():");
 				ModManager.debugLogger.writeException(e);
-				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this, "An error occured while trying to download pristine Coalesced files from ME3Tweaks:\n" + e.getMessage()
-						+ "\n\nYou should report this to FemShep via the Forums link in the help menu.", "Compiling Error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
+						"An error occured while trying to download pristine Coalesced files from ME3Tweaks:\n" + e.getMessage()
+								+ "\n\nYou should report this to FemShep via the Forums link in the help menu.\nInclude a Mod Manager log from this session.",
+						"Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block
-				e.printStackTrace();
+				error = true;
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("ModMaker mod failed to compile");
 				return;
 			}
 			if (error) {
 				dispose();
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("ModMaker mod failed to compile");
 				return;
 			}
 			ModManager.debugLogger.writeMessage("Required coalesceds downloaded");
@@ -796,9 +803,11 @@ public class ModMakerCompilerWindow extends JDialog {
 	 * merges the contents of the downloaded mod into all of the decompiled json
 	 * files.
 	 */
-	class MergeWorker extends SwingWorker<Void, Integer> {
+	class MergeWorker extends SwingWorker<Void, ThreadCommand> {
 		boolean error = false;
 		JProgressBar progress;
+		int coalsMerged = 0;
+		int numCoalSections = 1;
 
 		public MergeWorker(JProgressBar progress) {
 			ModManager.debugLogger.writeMessage("=============MERGEWORKER=============");
@@ -819,6 +828,14 @@ public class ModMakerCompilerWindow extends JDialog {
 			 */
 
 			NodeList coalNodeList = dataElement.getChildNodes();
+			for (int i = 0; i < coalNodeList.getLength(); i++) {
+				//coalNode is a node containing the coalesced module, such as <MP1> or <BASEGAME>
+				Node coalNode = coalNodeList.item(i);
+				if (coalNode.getNodeType() == Node.ELEMENT_NODE) {
+					numCoalSections++;
+				}
+			}
+
 			//Iterate over the coalesceds.
 			for (int i = 0; i < coalNodeList.getLength(); i++) {
 				//coalNode is a node containing the coalesced module, such as <MP1> or <BASEGAME>
@@ -833,6 +850,8 @@ public class ModMakerCompilerWindow extends JDialog {
 					for (int j = 0; j < filesNodeList.getLength(); j++) {
 						Node fileNode = filesNodeList.item(j);
 						if (fileNode.getNodeType() == Node.ELEMENT_NODE) {
+							publish(new ThreadCommand("MERGING_FILE",coalNode.getNodeName()+" "+fileNode.getNodeName()));
+
 							//we now have a file ID such as biogame.
 							//We need to load that XML file now.
 							String iniFileName = fileNode.getNodeName() + ".xml";
@@ -960,6 +979,14 @@ public class ModMakerCompilerWindow extends JDialog {
 
 									//first tokenize the path...
 									String path = property.getAttribute("path");
+									if (path.equals("")) {
+										//will never find.
+										dispose();
+										JOptionPane.showMessageDialog(null, "<html>Unable to compile mod.<br>Path for property is empty: " + newPropName + ".<br>Module: "
+												+ intCoalName + "<br>File: " + iniFileName + "</html>", "Compiling Error", JOptionPane.ERROR_MESSAGE);
+										error = true;
+										return null;
+									}
 									StringTokenizer drillTokenizer = new StringTokenizer(path, "&"); // - splits this in the event we need to drill down. Spaces are valid it seems in the path.
 									Element drilled = null;
 									NodeList drilledList = SectionList;
@@ -987,9 +1014,8 @@ public class ModMakerCompilerWindow extends JDialog {
 										}
 										if (!pathfound) {
 											dispose();
-											JOptionPane.showMessageDialog(null,
-													"<html>Could not find the path " + path + " to property.<br>Module: " + intCoalName + "<br>File: " + iniFileName + "</html>",
-													"Compiling Error", JOptionPane.ERROR_MESSAGE);
+											JOptionPane.showMessageDialog(null, "<html>Could not find the path " + path + " for property " + newPropName + ".<br>Module: "
+													+ intCoalName + "<br>File: " + iniFileName + "</html>", "Compiling Error", JOptionPane.ERROR_MESSAGE);
 											error = true;
 											return null;
 										}
@@ -998,9 +1024,8 @@ public class ModMakerCompilerWindow extends JDialog {
 										//we didn't find what we wanted...
 										dispose();
 										error = true;
-										JOptionPane.showMessageDialog(null,
-												"<html>Could not find the path " + path + " to property.<br>Module: " + intCoalName + "<br>File: " + iniFileName + "</html>",
-												"Compiling Error", JOptionPane.ERROR_MESSAGE);
+										JOptionPane.showMessageDialog(null, "<html>Could not find the path " + path + " for property " + newPropName + ".<br>Module: " + intCoalName
+												+ "<br>File: " + iniFileName + "</html>", "Compiling Error", JOptionPane.ERROR_MESSAGE);
 										return null;
 									}
 									if (operation.equals("addition")) {
@@ -1242,7 +1267,7 @@ public class ModMakerCompilerWindow extends JDialog {
 											sb.append("</html>");
 
 											JOptionPane.showMessageDialog(null, sb.toString(), "Compiling Error", JOptionPane.ERROR_MESSAGE);
-											ModManager.debugLogger.writeMessage(sb.toString());
+											ModManager.debugLogger.writeError(sb.toString());
 										}
 									}
 								}
@@ -1259,10 +1284,33 @@ public class ModMakerCompilerWindow extends JDialog {
 							transformer.transform(input, output);
 						}
 					}
+					coalsMerged++;
+					System.err.println((coalsMerged / (numCoalSections * 1.0)) * 100);
+					publish(new ThreadCommand("MERGE_TASK_COMPLETED"));
 				}
 			}
 
 			return null;
+		}
+
+		@Override
+		protected void process(List<ThreadCommand> commands) {
+			for (ThreadCommand tc : commands) {
+				switch (tc.getCommand()) {
+				case "MERGE_TASK_COMPLETED":
+					if (coalsMerged != 0) {
+						System.err.println((coalsMerged / (float) numCoalSections) * 100);
+						progress.setValue((int) Math.ceil(((coalsMerged / (numCoalSections * 1.0)) * 100)));
+					} else {
+						progress.setValue(0);
+					}
+					break;
+				case "MERGING_FILE":
+					String currentoperation = tc.getMessage();
+					currentOperationLabel.setText("Merging "+currentoperation);
+					break;
+				}
+			}
 		}
 
 		protected void done() {
@@ -1277,10 +1325,13 @@ public class ModMakerCompilerWindow extends JDialog {
 				error = true;
 			} catch (InterruptedException e) {
 				// TODO Auto-generated catch block
-				e.printStackTrace();
+				dispose();
+				error = true;
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("ModMaker mod failed to compile");
 				return;
 			}
 			if (error) {
+				ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("ModMaker mod failed to compile");
 				dispose();
 				return;
 			}
@@ -1555,7 +1606,7 @@ public class ModMakerCompilerWindow extends JDialog {
 			}
 			ModManager.debugLogger.writeMessage("Creating in-memory moddesc.ini");
 			ini = new Wini(moddesc);
-			ini.put("ModManager", "cmmver", 4.1);
+			ini.put("ModManager", "cmmver", 4.3);
 			ini.put("ModInfo", "modname", modName);
 			ini.put("ModInfo", "moddev", modDev);
 			ini.put("ModInfo", "moddesc", modDescription + "<br>Created with ME3Tweaks ModMaker.");
@@ -1582,14 +1633,18 @@ public class ModMakerCompilerWindow extends JDialog {
 					ModManager.debugLogger.writeError("ERROR! Didn't move " + reqcoal + " to the proper mod element directory. Could already exist.");
 				}
 				//copy pcconsoletoc
-				File tocFile = new File(ModManager.getCompilingDir() + "toc\\" + ME3TweaksUtils.coalFilenameToInternalName(reqcoal) + "\\PCConsoleTOC.bin");
-				File destToc = new File(compCoalDir + "\\PCConsoleTOC.bin");
-				destToc.delete();
-				ModManager.debugLogger.writeMessage("Moving TOC file: " + tocFile.getAbsolutePath() + " to " + destToc.getAbsolutePath());
-				if (tocFile.renameTo(destToc)) {
-					ModManager.debugLogger.writeMessage("Moved " + reqcoal + " TOC to proper mod element directory");
+				if (!reqcoal.equals("ServerCoalesced.bin")) {
+					File tocFile = new File(ModManager.getCompilingDir() + "toc\\" + ME3TweaksUtils.coalFilenameToInternalName(reqcoal) + "\\PCConsoleTOC.bin");
+					File destToc = new File(compCoalDir + "\\PCConsoleTOC.bin");
+					destToc.delete();
+					ModManager.debugLogger.writeMessage("Moving TOC file: " + tocFile.getAbsolutePath() + " to " + destToc.getAbsolutePath());
+					if (tocFile.renameTo(destToc)) {
+						ModManager.debugLogger.writeMessage("Moved " + reqcoal + " TOC to proper mod element directory");
+					} else {
+						ModManager.debugLogger.writeError("ERROR! Didn't move " + reqcoal + " TOC to the proper mod element directory. Could already exist.");
+					}
 				} else {
-					ModManager.debugLogger.writeError("ERROR! Didn't move " + reqcoal + " TOC to the proper mod element directory. Could already exist.");
+					ModManager.debugLogger.writeMessage("Skipping BALANCE_CHANGES PCConsoleTOC.bin");
 				}
 
 				//copy tlk
@@ -1614,6 +1669,7 @@ public class ModMakerCompilerWindow extends JDialog {
 				}
 
 				boolean basegame = reqcoal.equals("Coalesced.bin");
+				boolean balance = reqcoal.equals("ServerCoalesced.bin");
 				ini.put(ME3TweaksUtils.coalFilenameToHeaderName(reqcoal), "moddir", ME3TweaksUtils.coalFilenameToInternalName(reqcoal));
 
 				//build descriptors
@@ -1649,6 +1705,9 @@ public class ModMakerCompilerWindow extends JDialog {
 					replacesb.append(ME3TweaksUtils.coalFileNameToDLCTOCDir(reqcoal));
 					ini.put(ME3TweaksUtils.coalFilenameToHeaderName(reqcoal), "newfiles", newsb.toString());
 					ini.put(ME3TweaksUtils.coalFilenameToHeaderName(reqcoal), "replacefiles", replacesb.toString());
+				} else if (balance) {
+					ini.put(ME3TweaksUtils.coalFilenameToHeaderName(reqcoal), "newfiles", reqcoal + "");
+					ini.put(ME3TweaksUtils.coalFilenameToHeaderName(reqcoal), "replacefiles", coalFileNameToDLCDir(reqcoal));
 				} else {
 					ini.put(ME3TweaksUtils.coalFilenameToHeaderName(reqcoal), "newfiles", reqcoal + ";PCConsoleTOC.bin");
 					ini.put(ME3TweaksUtils.coalFilenameToHeaderName(reqcoal), "replacefiles",
@@ -1748,7 +1807,7 @@ public class ModMakerCompilerWindow extends JDialog {
 			ModManager.debugLogger.writeMessage("Mod failed validation. Setting error flag to true.");
 			error = true;
 			JOptionPane.showMessageDialog(this,
-					modName + " was not successfully created.\nCheck the debugging file me3cmm_last_run_log.txt,\nand make sure debugging is enabled in Help>About.\nContact FemShep if you need help via the forums.",
+					modName + " was not successfully created.\nCheck the debugging file me3cmm_last_run_log.txt,\nand make sure mod startup logging is enabled in the options menu.\nContact FemShep if you need help via the forums.",
 					"Mod Not Created", JOptionPane.ERROR_MESSAGE);
 		}
 		/*
@@ -1778,7 +1837,7 @@ public class ModMakerCompilerWindow extends JDialog {
 			if (requiredMixinIds.size() > 0 || dynamicMixins.size() > 0) {
 				currentOperationLabel.setText("Preparing MixIns");
 				ModManager.debugLogger.writeMessage("Mod delta recommends MixIns, running PatchLibraryWindow()");
-				PatchLibraryWindow plw = new PatchLibraryWindow(this,requiredMixinIds, dynamicMixins, newMod);
+				PatchLibraryWindow plw = new PatchLibraryWindow(this, requiredMixinIds, dynamicMixins, newMod);
 				for (DynamicPatch dp : dynamicMixins) {
 					FileUtils.deleteQuietly(dp.getOutputfile());
 				}
@@ -1828,6 +1887,7 @@ public class ModMakerCompilerWindow extends JDialog {
 			if (languages.size() > 0 && !this.tocsToDownload.contains("Coalesced.bin")) {
 				this.tocsToDownload.add("Coalesced.bin");
 			}
+			this.tocsToDownload.remove("ServerCoalesced.bin");
 			this.numtoc = this.tocsToDownload.size();
 			this.progress = progress;
 			if (numtoc > 0) {

--- a/src/com/me3tweaks/modmanager/objects/InstalledASIMod.java
+++ b/src/com/me3tweaks/modmanager/objects/InstalledASIMod.java
@@ -12,6 +12,10 @@ public class InstalledASIMod {
 		return filename;
 	}
 
+	public String toLogString() {
+		return "InstalledASIMod [installedPath=" + installedPath + ", filename=" + filename + ", hash=" + hash + "]";
+	}
+
 	private String installedPath, filename, hash;
 
 	public String getInstalledPath() {

--- a/src/com/me3tweaks/modmanager/objects/ModJob.java
+++ b/src/com/me3tweaks/modmanager/objects/ModJob.java
@@ -20,6 +20,7 @@ public class ModJob {
 	public static final int BASEGAME = 1;
 	public static final int DLC = 0;
 	public static final int CUSTOMDLC = 2;
+	public static final int BALANCE_CHANGES = 3;
 	@Override
 	public String toString() {
 		return "ModJob [jobName=" + jobName + "]";

--- a/src/com/me3tweaks/modmanager/objects/ModType.java
+++ b/src/com/me3tweaks/modmanager/objects/ModType.java
@@ -27,7 +27,7 @@ public class ModType {
 	public static final String GUN01 = "FIREFIGHT";
 	public static final String GUN02 = "GROUNDSIDE";
 	public static final String CUSTOMDLC = "CUSTOMDLC";
-	public static final String BINI = "LIVEBALANCE";
+	public static final String BINI = "BALANCE_CHANGES";
 	public static final String DH1 = "GENESIS2";
 	public static final String COLLECTORSEDITION = "COLLECTORS_EDITION";
 	public static final String TESTPATCH_16_HASH = "9f7811a54c7f3bc21f5de7600a1ce721";
@@ -39,6 +39,10 @@ public class ModType {
 				GUN02, DH1, COLLECTORSEDITION };
 	}
 
+	public static String[] getLoadingHeaderNameArray() {
+		return new String[] { BASEGAME, MP1, MP2, MP3, MP4, MP5, PATCH1, PATCH2, TESTPATCH, HEN_PR, END, EXP1, EXP2, EXP3, EXP3B, APP01, GUN01,
+				GUN02, DH1, COLLECTORSEDITION, BINI };
+	}
 	/**
 	 * Gets the list of standard folders in the DLC folder. Includes the __metadata directory.
 	 * @return Arraylist of strings of things like DLC_CON_MP1 etc. Does not include DLC_TESTPATCH.
@@ -109,6 +113,8 @@ public class ModType {
 		switch (modType) {
 		case BASEGAME:
 			return "CookedPCConsole";
+		case BINI: 
+			return "..\\Binaries\\win32\\asi";
 		case MP1:
 			return "DLC\\DLC_CON_MP1\\CookedPCConsole"; //Resurgence
 		case MP2:

--- a/src/com/me3tweaks/modmanager/objects/Patch.java
+++ b/src/com/me3tweaks/modmanager/objects/Patch.java
@@ -39,6 +39,7 @@ public class Patch implements Comparable<Patch> {
 	double patchVersion, patchCMMVer;
 	private String patchAuthor;
 	private int me3tweaksid;
+	private boolean isDynamic = false;
 
 	public Patch(String descriptorPath, String patchPath) {
 		ModManager.debugLogger.writeMessage("Loading patch: " + descriptorPath);
@@ -580,5 +581,13 @@ public class Patch implements Comparable<Patch> {
 
 	public void setPatchPath(String patchPath) {
 		this.patchPath = patchPath;
+	}
+
+	public void setIsDynamic(boolean b) {
+		this.isDynamic = b;
+	}
+	
+	public boolean isDynamic() {
+		return this.isDynamic;
 	}
 }

--- a/src/com/me3tweaks/modmanager/objects/RestoreMode.java
+++ b/src/com/me3tweaks/modmanager/objects/RestoreMode.java
@@ -17,7 +17,8 @@ public class RestoreMode {
 	public static final int REMOVECUSTOMDLC = 8;
 	public static final int ALLDLC = 9;
 	public static final int REMOVEUNPACKEDITEMS = 10;
-	
+	public static final int BALANCE_CHANGES = 11;
+
 	public static final int MP1SFAR = 11;
 	public static final int MP2SFAR = 12;
 	public static final int MP3SFAR = 13;

--- a/src/com/me3tweaks/modmanager/ui/SwingLink.java
+++ b/src/com/me3tweaks/modmanager/ui/SwingLink.java
@@ -1,0 +1,107 @@
+package com.me3tweaks.modmanager.ui;
+
+import java.awt.Cursor;
+import java.awt.Desktop;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.net.URI;
+
+import javax.swing.Action;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+
+public class SwingLink extends JLabel {
+	  private static final long serialVersionUID = 8273875024682878518L;
+	  private String text;
+	  private URI uri;
+	  private Action action;
+
+	  public SwingLink(String text, URI uri){
+	    super();
+	    setup(text,uri);
+	    setCursor(new Cursor(Cursor.HAND_CURSOR));
+	  }
+	  
+	  public SwingLink(String text, String tooltip, Action action) {
+		  super();
+		  setup(text,tooltip, action);
+		  setCursor(new Cursor(Cursor.HAND_CURSOR));
+	  }
+
+	  public SwingLink(String text, String uri){
+	    super();
+	    setup(text,URI.create(uri));
+	    setCursor(new Cursor(Cursor.HAND_CURSOR));
+	  }
+
+	  public void setup(String t, URI u){
+	    text = t;
+	    uri = u;
+	    setText(text);
+	    setToolTipText(uri.toString());
+	    addMouseListener(new MouseAdapter() {
+	      public void mouseClicked(MouseEvent e) {
+	        open(uri);
+	      }
+	      public void mouseEntered(MouseEvent e) {
+	        setText(text,false);
+	      }
+	      public void mouseExited(MouseEvent e) {
+	        setText(text,true);
+	      }
+	    });
+	  }
+	  
+	  public void setup(String t, String tooltip, Action u){
+		    text = t;
+		    action = u;
+		    setText(text);
+		    setToolTipText(tooltip);
+		    addMouseListener(new MouseAdapter() {
+		      public void mouseClicked(MouseEvent e) {
+		        u.actionPerformed(new ActionEvent(this,ActionEvent.ACTION_PERFORMED,null));
+		      }
+		      public void mouseEntered(MouseEvent e) {
+		        setText(text,false);
+		      }
+		      public void mouseExited(MouseEvent e) {
+		        setText(text,true);
+		      }
+		    });
+		  }
+
+	  @Override
+	  public void setText(String text){
+	    setText(text,true);
+	  }
+
+	  public void setText(String text, boolean ul){
+	    String link = ul ? "<u>"+text+"</u>" : text;
+	    super.setText("<html><span style=\"color: #000099;\">"+
+	    link+"</span></html>");
+	    this.text = text;
+	  }
+
+	  public String getRawText(){
+	    return text;
+	  }
+
+	  private static void open(URI uri) {
+	    if (Desktop.isDesktopSupported()) {
+	      Desktop desktop = Desktop.getDesktop();
+	      try {
+	        desktop.browse(uri);
+	      } catch (IOException e) {
+	        JOptionPane.showMessageDialog(null,
+	            "Failed to launch the link, your computer is likely misconfigured.",
+	            "Cannot Launch Link",JOptionPane.WARNING_MESSAGE);
+	      }
+	    } else {
+	      JOptionPane.showMessageDialog(null,
+	          "Java is not able to launch links on your computer.",
+	          "Cannot Launch Link", JOptionPane.WARNING_MESSAGE);
+	    }
+	  }
+	}

--- a/src/com/me3tweaks/modmanager/utilities/DebugLogger.java
+++ b/src/com/me3tweaks/modmanager/utilities/DebugLogger.java
@@ -59,6 +59,16 @@ public class DebugLogger {
 			Runtime.getRuntime().addShutdownHook(new Thread() {
 				public void run() {
 					try {
+						writeMessage("Mod Manager is closing");
+						//Cleanup temp dir
+						if (!ModManager.MOD_MANAGER_UPDATE_READY) {
+							File tempFolder = new File(ModManager.getTempDir());
+							if(tempFolder.isDirectory() && tempFolder.list().length > 0){
+								FileUtils.cleanDirectory(tempFolder);
+								ModManager.debugLogger.writeMessage("Temp folder is not empty, cleaning up...");
+							}
+						}
+						
 						DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
 						Date date = new Date();
 						writeMessage("Logger shutting down. Time: " + dateFormat.format(date));


### PR DESCRIPTION
# ME3Tweaks Mod Manager 4.3.1
### Fixes since 4.3.1 soaktest
- On ModMaker mod compiling, if balance changes were part of the mod but the asi loader or balance changer replacer asi is not installed, the dialog indicating that wouldn't show. Now it does. It will not show if done through a mod update.
- On mod install,  if balance changes were part of the mod but the asi loader or balance changer replacer asi is not installed, the dialog indicating that wouldn't show. Now it does.
- ASI Mod Manager window would not update to indicate new binkw32 asi installation status, this has been fixed
## New Features
- New ModDesc.ini header: BALANCE_CHANGES. This used to be named LIVEBALANCE but support was never fully implemented in the past.
- ModMaker 2.2 support: Can now compile BALANCE_CHANGES tasks. Requires balance changes replacer ASI. ModMaker will prompt about this if the ASI is not installed at end of compile time
- ModMaker can now automatically apply controller mod fixes if you turn on the controller mod fixes option in the options window. This will auto-apply mixins if specific files are modified for the compiling mod and will integrate controller mod changes to them. You still need to install controller mod first, and then the modmaker mod or you will lose other changes to these files (such as damage resistance values)
-  Mod security update: You can no longer include .. in replace or delete tasks. This was supposed to be included in the previous build but somehow didn't make it.
- Mod Manager will throw a warning if it detects it is nested too deep in the file system. Some users nest it very deep and some command line programs that are called do not work with very long pathnames for some reason
- MixIns are now automatically updated if automatic mod updates are enabled
- Items in the temp directory are now deleted at shutdown as long as an update is not being applied to mod manager. Dynamic mixins were supposed to be deleted after compiling but weren't, so this folder could be filled with thousands of 1KB files
- The presence of the Talon keybinding sections in the keybinds override file will cause the keybinds injector to remove BioInput from the Reckoning DLC. This will automatic talon keybind fixing.
## Feature Updates/Changed Behavior
- ModMaker compiler now shows what it is doing wihle merging coalesced files
- Mod Manager's status bar will show the current operation during mixin install. This will help show users a file is being cached (which is why first time installs take a while)
- ASI Manager was renamed to ASI Mod Management
- ASI Mod Management window was slightly re-organized
- ASI Mod Management now shows update group ID (for me3tweaks), text and more info in the asi action dialog
- Logging autotoc now lists what job is being performed to make it easier to read multi-threaded tasks
- Restoring anything related to MP will now delete binaries/win32/asi/ServerCoalesced.bin
- Installing binkw32 ASI loader will now install zlib.dll as required by some ASIs. If already installed, when checking for binkw32 asi, if found, zlib will be installed if it already isn't, to make older installs consistent with new ones.
- Filedropping requires a valid biogame directory now. Not all operations require this, but some do, and coding the check would add a lot of uglyness to it. This may be changed someday.
- ModMaker mods now compile against ModDesc 4.3 (previously it used 4.1)
- A few dialogs text were outdated, and have been updated to show new location of items
## BugFixes
- Binkw32 ASI installer now checks for VC2012x86. If this is not installed the game would throw a licensing error. Now when you install it, it will require this first.
- Some error messages were being written as simply messages. They have been changed to error messages for easier debugging.
- Keybinds Injector may have previous been unable to inject keybinds on certain mods that didn't have a basegame job (and a few other conditions). This has been fixed.
