### PR TITLE
Mod Manager 4.4.1 Build 63

### DIFF
--- a/src/com/me3tweaks/modmanager/LogOptionsWindow.java
+++ b/src/com/me3tweaks/modmanager/LogOptionsWindow.java
@@ -535,7 +535,7 @@ public class LogOptionsWindow extends JDialog {
 					//Execute and get the response.
 					HttpResponse response = httpclient.execute(httppost);
 					HttpEntity entity = response.getEntity();
-					//new File(outputFile).delete();
+					new File(outputFile).delete();
 					if (entity != null) {
 						InputStream instream = entity.getContent();
 						try {

--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -202,17 +201,19 @@ public class ModInstallWindow extends JDialog {
 		private ArrayList<String> outdatedinstalledfolders;
 
 		protected InjectionCommander(Mod mod) {
-			ModManager.debugLogger.writeMessage("===============Start of INJECTION COMMANDER==============");
+			this.mod = new Mod(mod); //clone before applying alternates and optional addins
+			ModManager.debugLogger.writeMessage("========Installing " + this.mod.getModName() + "========");
 			ModManager.debugLogger.writeMessage("Applying automatic alt's before parsing jobs");
-			this.mod = new Mod(mod); //clone before applying alternates
 			alternatesApplied = this.mod.applyAutomaticAlternates(bioGameDir);
 			if (alternatesApplied) {
 				ModManager.debugLogger.writeMessage("At least one alternate file was applied, install now requires pre-toc.");
 			}
+			ModManager.debugLogger.writeMessage("Finshing applying alternate files. Now checking for manually selected addins...");
+			this.mod.applyManualCustomDLCs();
+			ModManager.debugLogger.writeMessage("Finished applying addins. Preparing to start the injection thread.");
 			this.jobs = this.mod.getJobs();
 			numjobs = jobs.length;
 			failedJobs = new ArrayList<String>();
-			ModManager.debugLogger.writeMessage("========Installing " + this.mod.getModName() + "========");
 			ModManager.debugLogger.writeMessage("Starting the InjectionCommander thread. Number of jobs to do: " + numjobs);
 		}
 
@@ -222,12 +223,14 @@ public class ModInstallWindow extends JDialog {
 			ModManager.debugLogger.writeMessage("Checking for DLC Bypass.");
 			if (!ModManager.hasKnownDLCBypass(bioGameDir)) {
 				ModManager.debugLogger.writeMessage("No DLC bypass detected, installing binkw32 bypass...");
-				if (!ModManager.installBinkw32Bypass(bioGameDir,false)) {
+				if (!ModManager.installBinkw32Bypass(bioGameDir, false)) {
 					ModManager.debugLogger.writeError("Binkw32 bypass failed to install");
 				}
 			} else {
 				ModManager.debugLogger.writeMessage("A DLC bypass is installed");
 			}
+			
+			
 
 			boolean checkedDB = false;
 			for (ModJob job : jobs) {
@@ -390,7 +393,9 @@ public class ModInstallWindow extends JDialog {
 					int numFilesToReplace = filesToReplace.size();
 					for (int i = 0; i < numFilesToReplace; i++) {
 						String fileToReplace = filesToReplace.get(i);
-
+						if (FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
+							continue; //skip PCConsoleTOC as they'll be updated outside of mod installs. Especially the basegame one.
+						}
 						File basegamefile = new File(me3dir + fileToReplace);
 
 						String relative = ResourceUtils.getRelativePath(basegamefile.getAbsolutePath(), me3dir, File.separator);
@@ -443,6 +448,9 @@ public class ModInstallWindow extends JDialog {
 					//DLC appears unpacked					
 					for (int i = 0; i < numFilesToReplace; i++) {
 						String fileToReplace = filesToReplace.get(i);
+						if (FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
+							continue; //skip PCConsoleTOC as they'll be updated outside of mod installs. Especially the basegame one.
+						}
 						File unpackeddlcfile = new File(me3dir + fileToReplace);
 
 						//check if in GDB
@@ -815,42 +823,21 @@ public class ModInstallWindow extends JDialog {
 				backupfile.getParentFile().mkdirs();
 
 				String relative = ResourceUtils.getRelativePath(unpacked.getAbsolutePath(), me3dir, File.separator);
-				RepairFileInfo rfi = bghDB.getFileInfo(relative);
-				// validate file to backup.
-				boolean justInstall = false;
 				boolean installAndUpdate = false;
-				if (rfi == null) {
-					int reply = JOptionPane.showOptionDialog(null,
-							"<html><div style=\"width: 400px\">The file:<br>" + relative + "<br>is not in the repair database. "
-									+ "Installing/Removing this file may overwrite your default setup if you restore and have custom mods like texture swaps installed.</div></html>",
-							"Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-							new String[] { "Add to DB and install", "Install file", "Cancel mod installation" }, "default");
-					switch (reply) {
-					case JOptionPane.CANCEL_OPTION:
-						installCancelled = true;
-						return false;
-					case JOptionPane.NO_OPTION:
-						justInstall = true;
-						break;
-					case JOptionPane.YES_OPTION:
-						installAndUpdate = true;
-						break;
-					}
-				}
 
-				// Check filesize
-				if (!justInstall && !installAndUpdate) {
-					if (unpacked.length() != rfi.filesize) {
-						// MISMATCH!
+				if (!FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
+					RepairFileInfo rfi = bghDB.getFileInfo(relative);
+					// validate file to backup.
+					boolean justInstall = false;
+					if (rfi == null) {
 						int reply = JOptionPane.showOptionDialog(null,
-								"<html>The filesize of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>" + unpacked.length()
-										+ " bytes (installed) vs " + rfi.filesize + " bytes (database)<br><br>"
-										+ "This file could be corrupted or modified since the database was created.<br>"
-										+ "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when you restore.<br></html>",
+								"<html><div style=\"width: 400px\">The file:<br>" + relative + "<br>is not in the repair database. "
+										+ "Installing/Removing this file may overwrite your default setup if you restore and have custom mods like texture swaps installed.</div></html>",
 								"Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-								new String[] { "Backup and update DB", "Backup this file", "Cancel mod installation" }, "default");
+								new String[] { "Add to DB and install", "Install file", "Cancel mod installation" }, "default");
 						switch (reply) {
 						case JOptionPane.CANCEL_OPTION:
+							installCancelled = true;
 							return false;
 						case JOptionPane.NO_OPTION:
 							justInstall = true;
@@ -860,19 +847,16 @@ public class ModInstallWindow extends JDialog {
 							break;
 						}
 					}
-				}
 
-				// Check hash
-				if (!justInstall && !installAndUpdate) {
-					// this is outside of the previous if statement as the
-					// previous one could set the restoreAnyways variable
-					// again.
-					try {
-						if (!MD5Checksum.getMD5Checksum(unpacked.getAbsolutePath()).equals(rfi.md5)) {
+					// Check filesize
+					if (!justInstall && !installAndUpdate) {
+						if (unpacked.length() != rfi.filesize) {
+							// MISMATCH!
 							int reply = JOptionPane.showOptionDialog(null,
-									"<html>The hash of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>"
-											+ "This file has changed since the database was created.<br>"
-											+ "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when restoring.<br></html>",
+									"<html>The filesize of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>" + unpacked.length()
+											+ " bytes (installed) vs " + rfi.filesize + " bytes (database)<br><br>"
+											+ "This file could be corrupted or modified since the database was created.<br>"
+											+ "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when you restore.<br></html>",
 									"Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
 									new String[] { "Backup and update DB", "Backup this file", "Cancel mod installation" }, "default");
 							switch (reply) {
@@ -886,11 +870,37 @@ public class ModInstallWindow extends JDialog {
 								break;
 							}
 						}
-					} catch (Exception e) {
-						ModManager.debugLogger.writeException(e);
+					}
+
+					// Check hash
+					if (!justInstall && !installAndUpdate) {
+						// this is outside of the previous if statement as the
+						// previous one could set the restoreAnyways variable
+						// again.
+						try {
+							if (!MD5Checksum.getMD5Checksum(unpacked.getAbsolutePath()).equals(rfi.md5)) {
+								int reply = JOptionPane.showOptionDialog(null,
+										"<html>The hash of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>"
+												+ "This file has changed since the database was created.<br>"
+												+ "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when restoring.<br></html>",
+										"Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+										new String[] { "Backup and update DB", "Backup this file", "Cancel mod installation" }, "default");
+								switch (reply) {
+								case JOptionPane.CANCEL_OPTION:
+									return false;
+								case JOptionPane.NO_OPTION:
+									justInstall = true;
+									break;
+								case JOptionPane.YES_OPTION:
+									installAndUpdate = true;
+									break;
+								}
+							}
+						} catch (Exception e) {
+							ModManager.debugLogger.writeException(e);
+						}
 					}
 				}
-
 				try {
 					// backup and then copy file
 					Files.copy(originalpath, backuppath);

--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -368,8 +368,8 @@ public class ModInstallWindow extends JDialog {
 				if (bghDB == null) {
 					//cannot continue
 					failedLoadingDB = true;
-					JOptionPane.showMessageDialog(null, "<html>The game repair database failed to load.<br>" + "Only one connection to the local database is allowed at a time.<br>"
-							+ "Please make sure you only have one instance of Mod Manager running.</html>", "Database Failure", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null, "<html>The game repair database failed to load.<br>" + "Only one connection to the local repair database is allowed at a time.<br>"
+							+ "Please make sure you only have one instance of Mod Manager running.<br>Mod Manager appears as Java (TM) Platform Binary (or javaw.exe on Windows Vista/7) in Task Manager.<br><br>If the issue persists and you are sure only one instance is running, close Mod Manager and<br>delete the the data\\databases folder.<br>You will need to re-create the game repair database afterwards.<br><br>If this *STILL* does not fix your issue, please send a log to FemShep through the help menu.</html>", "Database Failure", JOptionPane.ERROR_MESSAGE);
 					return true;
 				}
 
@@ -1264,10 +1264,9 @@ public class ModInstallWindow extends JDialog {
 						}
 						if (bghDB == null) {
 							//cannot continue
-							JOptionPane.showMessageDialog(null,
-									"<html>The game repair database failed to load.<br>" + "Only one connection to the local database is allowed at a time.<br>"
-											+ "Please make sure you only have one instance of Mod Manager running.</html>",
-									"Database Failure", JOptionPane.ERROR_MESSAGE);
+							JOptionPane.showMessageDialog(null, "<html>The game repair database failed to load.<br>" + "Only one connection to the local repair database is allowed at a time.<br>"
+									+ "Please make sure you only have one instance of Mod Manager running.<br>Mod Manager appears as Java (TM) Platform Binary (or javaw.exe on Windows Vista/7) in Task Manager.<br><br>If the issue persists and you are sure only one instance is running, close Mod Manager and<br>delete the the data\\databases folder.<br>You will need to re-create the game repair database afterwards.<br><br>If this *STILL* does not fix your issue, please send a log to FemShep through the help menu.</html>", "Database Failure", JOptionPane.ERROR_MESSAGE);
+
 						}
 					}
 				} else {

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -80,9 +80,9 @@ import com.sun.jna.win32.W32APIOptions;
 
 public class ModManager {
 
-	public static final String VERSION = "4.4 MR3";
-	public static long BUILD_NUMBER = 62L;
-	public static final String BUILD_DATE = "10/1/2016";
+	public static final String VERSION = "4.4.1";
+	public static long BUILD_NUMBER = 63L;
+	public static final String BUILD_DATE = "10/10/2016";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";

--- a/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
@@ -20,7 +20,6 @@ import javax.swing.SwingWorker;
 import org.apache.commons.io.FileUtils;
 
 import com.me3tweaks.modmanager.ModManager.Lock;
-import com.me3tweaks.modmanager.modmaker.ModMakerCompilerWindow;
 import com.me3tweaks.modmanager.objects.Mod;
 import com.me3tweaks.modmanager.objects.Patch;
 import com.me3tweaks.modmanager.objects.PatchModBundle;

--- a/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
+++ b/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.SimpleTimeZone;
 
 import javax.swing.JDialog;
 import javax.swing.JLabel;
@@ -29,11 +28,9 @@ import javax.swing.border.EmptyBorder;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 
-import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
 import com.me3tweaks.modmanager.objects.ModType;
 import com.me3tweaks.modmanager.objects.RestoreMode;
 import com.me3tweaks.modmanager.repairdb.BasegameHashDB;
@@ -56,7 +53,8 @@ public class RestoreFilesWindow extends JDialog {
 
 	public RestoreFilesWindow(String BioGameDir, int restoreMode) {
 		if (ModManager.isMassEffect3Running()) {
-			JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can restore game files.","MassEffect3.exe is running", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can restore game files.", "MassEffect3.exe is running",
+					JOptionPane.ERROR_MESSAGE);
 			return;
 		}
 		this.BioGameDir = BioGameDir;
@@ -81,7 +79,8 @@ public class RestoreFilesWindow extends JDialog {
 	 */
 	public RestoreFilesWindow(String BioGameDir, String header, int operationType) {
 		if (ModManager.isMassEffect3Running()) {
-			JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can restore files.","MassEffect3.exe is running", JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can restore files.", "MassEffect3.exe is running",
+					JOptionPane.ERROR_MESSAGE);
 			return;
 		}
 		this.BioGameDir = BioGameDir;
@@ -186,8 +185,7 @@ public class RestoreFilesWindow extends JDialog {
 					numjobs = 2 + ModType.getDLCHeaderNameArray().length;
 					publish("Attempting to return DLC to vanilla state");
 					wipeBalanceChanges();
-					return removeCustomDLC() && restoreSFARsUsingHeaders(ModType.getDLCHeaderNameArray())
-							&& processDeleteUnpackedFiles(ModType.getDLCHeaderNameArray());
+					return removeCustomDLC() && restoreSFARsUsingHeaders(ModType.getDLCHeaderNameArray()) && processDeleteUnpackedFiles(ModType.getDLCHeaderNameArray());
 				case RestoreMode.ALLDLC:
 					numjobs = ModType.getHeaderNameArray().length;
 					publish("Restoring all DLC SFARs");
@@ -236,8 +234,7 @@ public class RestoreFilesWindow extends JDialog {
 			ArrayList<String> filepaths = new ArrayList<String>();
 
 			for (String header : dlcHeaders) {
-				String dlcFolderPath = ModManager.appendSlash(RestoreFilesWindow.this.BioGameDir)
-						+ ModManager.appendSlash(ModType.getDLCPath(header));
+				String dlcFolderPath = ModManager.appendSlash(RestoreFilesWindow.this.BioGameDir) + ModManager.appendSlash(ModType.getDLCPath(header));
 				File dlcDirectory = new File(dlcFolderPath);
 				if (dlcDirectory.exists()) {
 					File files[] = dlcDirectory.listFiles();
@@ -315,8 +312,7 @@ public class RestoreFilesWindow extends JDialog {
 		private boolean restoreSFARsUsingHeaders(String[] dlcHeaders) {
 			int restoresCompleted = 0;
 			for (String header : dlcHeaders) {
-				if (processRestoreJob(
-						ModManager.appendSlash(RestoreFilesWindow.this.BioGameDir) + ModManager.appendSlash(ModType.getDLCPath(header)), header)) {
+				if (processRestoreJob(ModManager.appendSlash(RestoreFilesWindow.this.BioGameDir) + ModManager.appendSlash(ModType.getDLCPath(header)), header)) {
 					ModManager.debugLogger.writeMessage("Processed Restore SFAR Job (SUCCESS): " + header);
 					completed++; //for progress bar
 					restoresCompleted++; //for local checking
@@ -357,9 +353,10 @@ public class RestoreFilesWindow extends JDialog {
 				return false;
 			}
 		}
-		
+
 		/**
-		 * Deletes ServerCoalesced.bin from ME3/Binaries/win32/ServerCoalesced.bin
+		 * Deletes ServerCoalesced.bin from
+		 * ME3/Binaries/win32/ServerCoalesced.bin
 		 */
 		private void wipeBalanceChanges() {
 			File bcf = new File((new File(BioGameDir).getParent()) + "/Binaries/win32/asi/ServerCoalesced.bin");
@@ -394,11 +391,8 @@ public class RestoreFilesWindow extends JDialog {
 			}
 			if (bghDB == null) {
 				//cannot continue
-				JOptionPane
-						.showMessageDialog(null, "<html>The game repair database failed to load.<br>"
-								+ "Only one connection to the local database is allowed at a time.<br>"
-								+ "Please make sure you only have one instance of Mod Manager running.</html>", "Database Failure",
-								JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "<html>The game repair database failed to load.<br>" + "Only one connection to the local database is allowed at a time.<br>"
+						+ "Please make sure you only have one instance of Mod Manager running.</html>", "Database Failure", JOptionPane.ERROR_MESSAGE);
 				return false;
 			}
 			HashMap<String, String> dlcFolderMap = ModType.getHeaderFolderMap();
@@ -414,42 +408,15 @@ public class RestoreFilesWindow extends JDialog {
 						String taskTitle = backup.getAbsolutePath().startsWith(dlcbackupfolder) ? "UNPACKED DLC" : "BASEGAME";
 						//verify it.
 						String relative = ResourceUtils.getRelativePath(backup.getAbsolutePath(), backupfolder, File.separator);
-						RepairFileInfo rfi = bghDB.getFileInfo(relative);
-						boolean restoreAnyways = false;
-						if (rfi == null) {
-							int reply = JOptionPane.showOptionDialog(null, "<html>The file:<br>" + relative + "<br>is not in the repair database. "
-									+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
-									"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, new String[] {
-											"Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
-							switch (reply) {
-							case JOptionPane.CANCEL_OPTION:
-								return false;
-							case JOptionPane.NO_OPTION:
-								continue;
-							case JOptionPane.YES_OPTION:
-								restoreAnyways = true;
-								break;
-							}
-						}
-						if (!restoreAnyways) {
-							//verify the file
-							if (backup.length() != rfi.filesize) {
-								//MISMATCH!
-								int reply = JOptionPane
-										.showOptionDialog(
-												null,
-												"<html>The filesize of the file:<br>"
-														+ relative
-														+ "<br>does not match the one stored in the repair game database.<br>"
-														+ backup.length()
-														+ " bytes (backup) vs "
-														+ rfi.filesize
-														+ " bytes (database)<br><br>"
-														+ "This file could be corrupted or modified since the database was created.<br>"
-														+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
-												"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-												new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" },
-												"default");
+						if (!backup.getName().equalsIgnoreCase("PCConsoleTOC.bin")) {
+							RepairFileInfo rfi = bghDB.getFileInfo(relative);
+							boolean restoreAnyways = false;
+							if (rfi == null) {
+								int reply = JOptionPane.showOptionDialog(null,
+										"<html>The file:<br>" + relative + "<br>is not in the repair database. "
+												+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
+										"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+										new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
 								switch (reply) {
 								case JOptionPane.CANCEL_OPTION:
 									return false;
@@ -460,25 +427,17 @@ public class RestoreFilesWindow extends JDialog {
 									break;
 								}
 							}
-						}
-
-						if (!restoreAnyways) {
-							//this is outside of the previous if statement as the previous one could set the restoreAnyways variable again.
-							try {
-								String hash = MD5Checksum.getMD5Checksum(backup.getAbsolutePath());
-								if (!hash.equals(rfi.md5)) {
-									ModManager.debugLogger.writeError("Hash of backup failed: DB Lists: " + rfi.md5 + ", Backup file has: " + hash);
-									int reply = JOptionPane
-											.showOptionDialog(
-													null,
-													"<html>The hash of the file:<br>"
-															+ relative
-															+ "<br>does not match the one stored in the repair game database.<br>"
-															+ "The backup file has changed since the database was created.<br>"
-															+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
-													"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-													new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" },
-													"default");
+							if (!restoreAnyways) {
+								//verify the file
+								if (backup.length() != rfi.filesize) {
+									//MISMATCH!
+									int reply = JOptionPane.showOptionDialog(null,
+											"<html>The filesize of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>"
+													+ backup.length() + " bytes (backup) vs " + rfi.filesize + " bytes (database)<br><br>"
+													+ "This file could be corrupted or modified since the database was created.<br>"
+													+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
+											"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+											new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
 									switch (reply) {
 									case JOptionPane.CANCEL_OPTION:
 										return false;
@@ -489,9 +448,34 @@ public class RestoreFilesWindow extends JDialog {
 										break;
 									}
 								}
-							} catch (Exception e) {
-								// TODO Auto-generated catch block
-								ModManager.debugLogger.writeException(e);
+							}
+
+							if (!restoreAnyways) {
+								//this is outside of the previous if statement as the previous one could set the restoreAnyways variable again.
+								try {
+									String hash = MD5Checksum.getMD5Checksum(backup.getAbsolutePath());
+									if (!hash.equals(rfi.md5)) {
+										ModManager.debugLogger.writeError("Hash of backup failed: DB Lists: " + rfi.md5 + ", Backup file has: " + hash);
+										int reply = JOptionPane.showOptionDialog(null,
+												"<html>The hash of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>"
+														+ "The backup file has changed since the database was created.<br>"
+														+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
+												"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+												new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
+										switch (reply) {
+										case JOptionPane.CANCEL_OPTION:
+											return false;
+										case JOptionPane.NO_OPTION:
+											continue;
+										case JOptionPane.YES_OPTION:
+											restoreAnyways = true;
+											break;
+										}
+									}
+								} catch (Exception e) {
+									// TODO Auto-generated catch block
+									ModManager.debugLogger.writeException(e);
+								}
 							}
 						}
 
@@ -500,8 +484,7 @@ public class RestoreFilesWindow extends JDialog {
 						ModManager.debugLogger.writeMessage("Restoring " + relative);
 						try {
 							publish(taskTitle + ": Restoring " + backup.getName());
-							Files.copy(Paths.get(backup.toString()), Paths.get(ModManager.appendSlash(me3dir) + relative),
-									StandardCopyOption.REPLACE_EXISTING);
+							Files.copy(Paths.get(backup.toString()), Paths.get(ModManager.appendSlash(me3dir) + relative), StandardCopyOption.REPLACE_EXISTING);
 						} catch (IOException e) {
 							return false;
 						}
@@ -532,11 +515,8 @@ public class RestoreFilesWindow extends JDialog {
 			}
 			if (bghDB == null) {
 				//cannot continue
-				JOptionPane
-						.showMessageDialog(null, "<html>The game repair database failed to load.<br>"
-								+ "Only one connection to the local database is allowed at a time.<br>"
-								+ "Please make sure you only have one instance of Mod Manager running.</html>", "Database Failure",
-								JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null, "<html>The game repair database failed to load.<br>" + "Only one connection to the local database is allowed at a time.<br>"
+						+ "Please make sure you only have one instance of Mod Manager running.</html>", "Database Failure", JOptionPane.ERROR_MESSAGE);
 				return false;
 			}
 			String me3dir = (new File(RestoreFilesWindow.this.BioGameDir)).getParent();
@@ -559,34 +539,16 @@ public class RestoreFilesWindow extends JDialog {
 					String taskTitle = backup.getAbsolutePath().startsWith(dlcbackupfolder) ? "UNPACKED DLC" : "BASEGAME";
 					//verify it.
 					String relative = ResourceUtils.getRelativePath(backup.getAbsolutePath(), backupfolder, File.separator);
-					RepairFileInfo rfi = bghDB.getFileInfo(relative);
-					boolean restoreAnyways = false;
-					if (rfi == null) {
-						int reply = JOptionPane.showOptionDialog(null, "<html>The file:<br>" + relative + "<br>is not in the repair database. "
-								+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
-								"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, new String[] {
-										"Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
-						switch (reply) {
-						case JOptionPane.CANCEL_OPTION:
-							return false;
-						case JOptionPane.NO_OPTION:
-							continue;
-						case JOptionPane.YES_OPTION:
-							restoreAnyways = true;
-							break;
-						}
-					}
-					if (!restoreAnyways) {
-						//verify the file
-						if (backup.length() != rfi.filesize) {
-							//MISMATCH!
-							int reply = JOptionPane.showOptionDialog(null, "<html>The filesize of the file:<br>" + relative
-									+ "<br>does not match the one stored in the repair game database.<br>" + backup.length() + " bytes (backup) vs "
-									+ rfi.filesize + " bytes (database)<br><br>"
-									+ "This file could be corrupted or modified since the database was created.<br>"
-									+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
-									"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, new String[] {
-											"Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
+					if (!backup.getName().equalsIgnoreCase("PCConsoleTOC.bin")) {
+
+						RepairFileInfo rfi = bghDB.getFileInfo(relative);
+						boolean restoreAnyways = false;
+						if (rfi == null) {
+							int reply = JOptionPane.showOptionDialog(null,
+									"<html>The file:<br>" + relative + "<br>is not in the repair database. "
+											+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
+									"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+									new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
 							switch (reply) {
 							case JOptionPane.CANCEL_OPTION:
 								return false;
@@ -597,25 +559,17 @@ public class RestoreFilesWindow extends JDialog {
 								break;
 							}
 						}
-					}
-
-					if (!restoreAnyways) {
-						//this is outside of the previous if statement as the previous one could set the restoreAnyways variable again.
-						try {
-							String hash = MD5Checksum.getMD5Checksum(backup.getAbsolutePath());
-							if (!hash.equals(rfi.md5)) {
-								ModManager.debugLogger.writeError("Hash of backup failed: DB Lists: " + rfi.md5 + ", Backup file has: " + hash);
-								int reply = JOptionPane
-										.showOptionDialog(
-												null,
-												"<html>The hash of the file:<br>"
-														+ relative
-														+ "<br>does not match the one stored in the repair game database.<br>"
-														+ "This file has changed since the database was created.<br>"
-														+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
-												"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-												new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" },
-												"default");
+						if (!restoreAnyways) {
+							//verify the file
+							if (backup.length() != rfi.filesize) {
+								//MISMATCH!
+								int reply = JOptionPane.showOptionDialog(null,
+										"<html>The filesize of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>" + backup.length()
+												+ " bytes (backup) vs " + rfi.filesize + " bytes (database)<br><br>"
+												+ "This file could be corrupted or modified since the database was created.<br>"
+												+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
+										"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+										new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
 								switch (reply) {
 								case JOptionPane.CANCEL_OPTION:
 									return false;
@@ -626,19 +580,42 @@ public class RestoreFilesWindow extends JDialog {
 									break;
 								}
 							}
-						} catch (Exception e) {
-							// TODO Auto-generated catch block
-							ModManager.debugLogger.writeException(e);
+						}
+
+						if (!restoreAnyways) {
+							//this is outside of the previous if statement as the previous one could set the restoreAnyways variable again.
+							try {
+								String hash = MD5Checksum.getMD5Checksum(backup.getAbsolutePath());
+								if (!hash.equals(rfi.md5)) {
+									ModManager.debugLogger.writeError("Hash of backup failed: DB Lists: " + rfi.md5 + ", Backup file has: " + hash);
+									int reply = JOptionPane.showOptionDialog(null,
+											"<html>The hash of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>"
+													+ "This file has changed since the database was created.<br>"
+													+ "Restoring this file may overwrite your default setup if you use custom mods like texture swaps.<br></html>",
+											"Restoring Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+											new String[] { "Restore this file", "Skip restoring this file", "Cancel basegame restore" }, "default");
+									switch (reply) {
+									case JOptionPane.CANCEL_OPTION:
+										return false;
+									case JOptionPane.NO_OPTION:
+										continue;
+									case JOptionPane.YES_OPTION:
+										restoreAnyways = true;
+										break;
+									}
+								}
+							} catch (Exception e) {
+								// TODO Auto-generated catch block
+								ModManager.debugLogger.writeException(e);
+							}
 						}
 					}
-
 					//restore it					
 					//String relative = new File(backupfolder).toURI().relativize(backup.toURI()).getPath();
 					ModManager.debugLogger.writeMessage("Restoring " + relative);
 					try {
 						publish(taskTitle + ": Restoring " + backup.getName());
-						Files.copy(Paths.get(backup.toString()), Paths.get(ModManager.appendSlash(me3dir) + relative),
-								StandardCopyOption.REPLACE_EXISTING);
+						Files.copy(Paths.get(backup.toString()), Paths.get(ModManager.appendSlash(me3dir) + relative), StandardCopyOption.REPLACE_EXISTING);
 					} catch (IOException e) {
 						return false;
 					}
@@ -722,13 +699,10 @@ public class RestoreFilesWindow extends JDialog {
 			if (backupSfar == null) {
 				//no backup!
 				publish(jobName + ": No backup exists, cannot restore.");
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"<html>No backup for "
-										+ jobName
-										+ " exists, you'll have to restore through Origin's Repair Game.<br>Select Tools>Backup DLC to avoid this issue after the game is restored.</html>",
-								"Error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"<html>No backup for " + jobName
+								+ " exists, you'll have to restore through Origin's Repair Game.<br>Select Tools>Backup DLC to avoid this issue after the game is restored.</html>",
+						"Error", JOptionPane.ERROR_MESSAGE);
 				return false;
 			}
 

--- a/src/com/me3tweaks/modmanager/StarterKitWindow.java
+++ b/src/com/me3tweaks/modmanager/StarterKitWindow.java
@@ -44,11 +44,13 @@ import org.apache.commons.validator.routines.UrlValidator;
 
 import com.me3tweaks.modmanager.FolderBatchWindow.BatchWorker;
 import com.me3tweaks.modmanager.ModManager.Lock;
+import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
 import com.me3tweaks.modmanager.objects.Mod;
 import com.me3tweaks.modmanager.objects.ModJob;
 import com.me3tweaks.modmanager.objects.ModType;
 import com.me3tweaks.modmanager.objects.MountFile;
 import com.me3tweaks.modmanager.objects.MountFlag;
+import com.me3tweaks.modmanager.objects.ThirdPartyModInfo;
 import com.me3tweaks.modmanager.objects.ThreadCommand;
 import com.me3tweaks.modmanager.ui.HintTextAreaUI;
 import com.me3tweaks.modmanager.ui.HintTextFieldUI;
@@ -138,8 +140,8 @@ public class StarterKitWindow extends JDialog {
 
 		mountFlagsCombobox.setModel(flagModel);
 		mountFlagsCombobox.setRenderer(new MountFlagCellRenderer());
-		mountFlagsCombobox
-				.setToolTipText("<html>Mount flags determine when this DLC is loaded and if it is required by save files.<br>Having a DLC load in MP will require all players to have the DLC installed or connections will be refused.</html>");
+		mountFlagsCombobox.setToolTipText(
+				"<html>Mount flags determine when this DLC is loaded and if it is required by save files.<br>Having a DLC load in MP will require all players to have the DLC installed or connections will be refused.</html>");
 
 		modName.setUI(new HintTextFieldUI("A Most Excellent Mod", true));
 		modDeveloper.setUI(new HintTextFieldUI("GatorZ", true));
@@ -148,21 +150,19 @@ public class StarterKitWindow extends JDialog {
 		internalDisplayName.setUI(new HintTextFieldUI("Excellent DLC Module", true));
 		internalTLKId.setUI(new HintTextFieldUI("13370000", true));
 		mountPriority.setUI(new HintTextFieldUI("4500", true));
-		modDescription
-				.setUI(new HintTextAreaUI(
-						"Mod description goes here.\nThis is what will appear in Mod Manager when the user selects your mod.\nThis is the moddesc attribute in moddesc.ini under [ModInfo].\nNewlines will be replaced with <br>."));
+		modDescription.setUI(new HintTextAreaUI(
+				"Mod description goes here.\nThis is what will appear in Mod Manager when the user selects your mod.\nThis is the moddesc attribute in moddesc.ini under [ModInfo].\nNewlines will be replaced with <br>."));
 		modName.setToolTipText("<html>Name of this mod that Mod Manager will display.<br>This is the moddesc modname value under [ModInfo]</html>");
-		modDeveloper
-				.setToolTipText("<html>Developer of this mod. Likely your modding scene alias.<br>This is the moddesc moddev value under [ModInfo]</html>");
-		modSite.setToolTipText("<html>Optional website that will show up in Mod Manager the user can click to get help, more info, etc about the mod.<br>This is the moddesc modsite value under [ModInfo]</html>");
-		internalDLCName
-				.setToolTipText("<html>The internal name for the DLC, after the standard DLC_MOD.<br>The hint for this textbox would mean the DLC folder is named DLC_MOD_ExcellentMod.</html>");
-		internalDisplayName
-				.setToolTipText("<html>Internal name for this DLC. If a DLC fails to load, the user may see this name at the main menu.</html>");
-		internalTLKId
-				.setToolTipText("<html>TLK ID to use for your generated TLK file.<br>A TLK file will be created for the main 6 languages<br>and the internal DLC name will be set on this one.<br>The mount file will point to this value.</html>");
-		mountPriority
-				.setToolTipText("<html>Mount priority of your mod. Official DLC ends around 3300.<br>Mods that have pcc files with the same name will only load the higher mount priority version.</html>");
+		modDeveloper.setToolTipText("<html>Developer of this mod. Likely your modding scene alias.<br>This is the moddesc moddev value under [ModInfo]</html>");
+		modSite.setToolTipText(
+				"<html>Optional website that will show up in Mod Manager the user can click to get help, more info, etc about the mod.<br>This is the moddesc modsite value under [ModInfo]</html>");
+		internalDLCName.setToolTipText(
+				"<html>The internal name for the DLC, after the standard DLC_MOD.<br>The hint for this textbox would mean the DLC folder is named DLC_MOD_ExcellentMod.</html>");
+		internalDisplayName.setToolTipText("<html>Internal name for this DLC. If a DLC fails to load, the user may see this name at the main menu.</html>");
+		internalTLKId.setToolTipText(
+				"<html>TLK ID to use for your generated TLK file.<br>A TLK file will be created for the main 6 languages<br>and the internal DLC name will be set on this one.<br>The mount file will point to this value.</html>");
+		mountPriority.setToolTipText(
+				"<html>Mount priority of your mod. Official DLC ends around 3300.<br>Mods that have pcc files with the same name will only load the higher mount priority version.</html>");
 
 		c.gridy = 0;
 		c.gridx = fieldColumn;
@@ -200,8 +200,8 @@ public class StarterKitWindow extends JDialog {
 					String modpath = ModManager.getModsDir() + modName.getText();
 					File modpathfile = new File(modpath);
 					if (modpathfile.exists() && modpathfile.isDirectory()) {
-						int result = JOptionPane.showConfirmDialog(StarterKitWindow.this, "A mod named " + modName.getText()
-								+ " already exists.\nDelete this mod and create the starter kit in its place?", "Mod already exists",
+						int result = JOptionPane.showConfirmDialog(StarterKitWindow.this,
+								"A mod named " + modName.getText() + " already exists.\nDelete this mod and create the starter kit in its place?", "Mod already exists",
 								JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
 						if (result == JOptionPane.NO_OPTION) {
 							return;
@@ -285,7 +285,8 @@ public class StarterKitWindow extends JDialog {
 			String[] schemes = { "http", "https" }; // DEFAULT schemes = "http", "https", "ftp"
 			UrlValidator urlValidator = new UrlValidator(schemes);
 			if (!urlValidator.isValid(modsite)) {
-				showErrorMessage("Invalid mod site. This is the clickable link at the bottom of Mod Manager mod descriptions in the right side pane.\nThe specified URL is not valid.");
+				showErrorMessage(
+						"Invalid mod site. This is the clickable link at the bottom of Mod Manager mod descriptions in the right side pane.\nThe specified URL is not valid.");
 				return false;
 			}
 		}
@@ -331,6 +332,17 @@ public class StarterKitWindow extends JDialog {
 		} catch (NumberFormatException e) {
 			showErrorMessage("Invalid Mount Priority. Value must be between 1 and " + Short.MAX_VALUE + ".");
 			return false;
+		}
+
+		ThirdPartyModInfo tpmi = ME3TweaksUtils.getThirdPartyModInfoByMountID(priorityString);
+		if (tpmi != null) {
+			int result = JOptionPane.showConfirmDialog(StarterKitWindow.this,
+					"<html><div style='width: 400px'>The mod you are creating has the same mount priority as " + tpmi.getModname()
+							+ ". You should change this priority to prevent conflicts.<br><br>When mount priorities conflict, the game behaves in an undefined manner.<br>Change mount priority?</div></html>",
+					"Conflicting Mount Priority", JOptionPane.YES_NO_OPTION, JOptionPane.ERROR_MESSAGE);
+			if (result == JOptionPane.YES_OPTION) {
+				return false;
+			}
 		}
 		return true;
 	}
@@ -503,12 +515,10 @@ public class StarterKitWindow extends JDialog {
 			publish(new ThreadCommand("SET_DIALOG_PROGRESS", null, 60));
 			publish(new ThreadCommand("SET_DIALOG_TEXT", "Moving Default_DLC_MOD_" + internaldlcname));
 			ModManager.debugLogger.writeMessage("Recompiling Default_DLC_MOD_" + internaldlcname + ".bin");
-			CoalescedWindow.compileCoalesced(cookedPath + "Default_DLC_MOD_" + internaldlcname + File.separator + "Default_DLC_MOD_"
-					+ internaldlcname + ".xml");
+			CoalescedWindow.compileCoalesced(cookedPath + "Default_DLC_MOD_" + internaldlcname + File.separator + "Default_DLC_MOD_" + internaldlcname + ".xml");
 			FileUtils.deleteQuietly(new File(coalpath));
 			ModManager.debugLogger.writeMessage("Moving Default_DLC_MOD_" + internaldlcname + ".bin to " + coalpath);
-			FileUtils.moveFile(new File(cookedPath + "Default_DLC_MOD_" + internaldlcname + File.separator + "Default_DLC_MOD_" + internaldlcname
-					+ ".bin"), new File(coalpath));
+			FileUtils.moveFile(new File(cookedPath + "Default_DLC_MOD_" + internaldlcname + File.separator + "Default_DLC_MOD_" + internaldlcname + ".bin"), new File(coalpath));
 
 			//update mount.dlc
 			publish(new ThreadCommand("SET_DIALOG_PROGRESS", null, 70));
@@ -532,8 +542,8 @@ public class StarterKitWindow extends JDialog {
 
 			//move coaleseced folder
 			ModManager.debugLogger.writeMessage("Moving Coalesced folder");
-			FileUtils.moveDirectory(new File(cookedPath + "Default_DLC_MOD_" + internaldlcname), new File(modpath + "WORKSPACE" + File.separator
-					+ "Default_DLC_MOD_" + internaldlcname));
+			FileUtils.moveDirectory(new File(cookedPath + "Default_DLC_MOD_" + internaldlcname),
+					new File(modpath + "WORKSPACE" + File.separator + "Default_DLC_MOD_" + internaldlcname));
 
 			//Create moddesc.ini
 			ModManager.debugLogger.writeMessage("Creating moddesc.ini for " + modname);
@@ -622,24 +632,17 @@ public class StarterKitWindow extends JDialog {
 			}
 			if (callingDialog instanceof StarterKitWindow) {
 				if (OK) {
-					JOptionPane
-							.showMessageDialog(
-									callingDialog,
-									modname
-											+ " has been created.\nPlace files into the mod's DLC_MOD_"
-											+ internaldlcname
-											+ " folder to add game files to the mod.\nReload Mod Manager before installing so it refreshes the list of files in the folder.\nBe sure to run AutoTOC on the mod before installation.",
-									modname + " created", JOptionPane.INFORMATION_MESSAGE);
+					JOptionPane.showMessageDialog(callingDialog,
+							modname + " has been created.\nPlace files into the mod's DLC_MOD_" + internaldlcname
+									+ " folder to add game files to the mod.\nReload Mod Manager before installing so it refreshes the list of files in the folder.\nBe sure to run AutoTOC on the mod before installation.",
+							modname + " created", JOptionPane.INFORMATION_MESSAGE);
 					callingDialog.dispose();
 					ResourceUtils.openDir(generatedMod.getModPath());
 					new ModManagerWindow(false);
 				} else {
-					JOptionPane
-							.showMessageDialog(
-									callingDialog,
-									modname
-											+ " was not successfully created.\nReview the Mod Manager log in the help menu for more detailed information.\nIf you continue to have issues contact FemShep with the log attached.",
-									modname + " not created", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(callingDialog,
+							modname + " was not successfully created.\nReview the Mod Manager log in the help menu for more detailed information.\nIf you continue to have issues contact FemShep with the log attached.",
+							modname + " not created", JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		}

--- a/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Iterator;
 
 import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONObject;
@@ -15,7 +16,6 @@ import com.me3tweaks.modmanager.ModManager;
 import com.me3tweaks.modmanager.objects.Mod;
 import com.me3tweaks.modmanager.objects.ModType;
 import com.me3tweaks.modmanager.objects.ThirdPartyModInfo;
-import com.me3tweaks.modmanager.utilities.MD5Checksum;
 
 public class ME3TweaksUtils {
 	public static final int FILENAME = 0;
@@ -666,5 +666,30 @@ public class ME3TweaksUtils {
 		}
 
 		return null;
+	}
+
+	public static ThirdPartyModInfo getThirdPartyModInfoByMountID(String priorityString) {
+		if (ModManager.THIRD_PARTY_MOD_JSON == null) {
+			return null;
+		}
+		ModManager.debugLogger.writeMessage("Looking up mod information by mount priority using the 3rd party mod id service: "+priorityString);
+		try {
+			JSONParser parser = new JSONParser();
+			JSONObject dbObj = (JSONObject) parser.parse(ModManager.THIRD_PARTY_MOD_JSON);
+			
+		    for (Object key : dbObj.keySet()) {
+		        //based on you key types
+		        String keyStr = (String)key;
+		        JSONObject modinfo = (JSONObject) dbObj.get(keyStr);
+		        String mountpriority = (String) modinfo.get("mountpriority");
+		        System.out.println(mountpriority);
+		        if (mountpriority.equalsIgnoreCase(priorityString)) {
+					return new ThirdPartyModInfo(keyStr,modinfo);
+		        }
+		    }
+		} catch (ParseException e) {
+			ModManager.debugLogger.writeErrorWithException("Failed to parse 3rd party mod information: ", e);
+		}
+	    return null;
 	}
 }

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -270,7 +270,7 @@ public class ModMakerCompilerWindow extends JDialog {
 				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
 						"An error occured while preparing to compile the mod:\n" + e.getMessage() + "\nCheck the Mod Manager log for more info (in the help menu).",
 						"Pre-compilation error", JOptionPane.ERROR_MESSAGE);
-
+				dispose();
 				new ModManagerWindow(false);
 			} catch (SAXException e) {
 				running = false;
@@ -278,6 +278,7 @@ public class ModMakerCompilerWindow extends JDialog {
 				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
 						"An error occured while preparing to compile the mod:\n" + e.getMessage() + "\nCheck the Mod Manager log for more info (in the help menu).",
 						"Pre-compilation error", JOptionPane.ERROR_MESSAGE);
+				dispose();
 				new ModManagerWindow(false);
 			} catch (Exception e) {
 				running = false;

--- a/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
@@ -303,9 +303,9 @@ public class AllModsUpdateWindow extends JDialog {
 			} else if (upackages.size() != completedUpdates.size()) {
 				//one error occured
 				JOptionPane.showMessageDialog(callingWindow, completedUpdates.size() + " mod(s) successfully updated.\n" + (upackages.size() - completedUpdates.size())
-						+ " failed to update.\nMod Manager will now reload mods.", "Some mods were updated", JOptionPane.WARNING_MESSAGE);
+						+ " failed to update.\nYou will need to apply updated mod(s) for them to take effect.\nMod Manager will now reload mods.", "Some mods were updated", JOptionPane.WARNING_MESSAGE);
 			} else {
-				JOptionPane.showMessageDialog(callingWindow, upackages.size() + " mod(s) have been successfully updated.\nMod Manager will now reload mods.", "Mods updated",
+				JOptionPane.showMessageDialog(callingWindow, upackages.size() + " mod(s) have been successfully updated.\nYou will need to apply updated mod(s) for them to take effect.\nMod Manager will now reload mods.", "Mods updated",
 						JOptionPane.INFORMATION_MESSAGE);
 			}
 

--- a/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
@@ -200,7 +200,11 @@ public class AllModsUpdateWindow extends JDialog {
 						ModManager.debugLogger.writeMessage("Parsing upackage " + upackage.getServerModName() + ", Preparing user prompt.");
 						updatetext += getVersionUpdateString(upackage);
 					}
-					updatetext += "Update these mods?";
+					if (upackages.size() > 1) {
+						updatetext += "Update these mods?";
+					} else {
+						updatetext += "Update this mod?";
+					}
 					int result = JOptionPane.showConfirmDialog(AllModsUpdateWindow.this, updatetext, "Mod updates available", JOptionPane.YES_NO_OPTION);
 					switch (result) {
 					case JOptionPane.YES_OPTION:

--- a/src/com/me3tweaks/modmanager/modupdater/ModUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModUpdateWindow.java
@@ -496,7 +496,7 @@ public class ModUpdateWindow extends JDialog implements PropertyChangeListener {
 		protected void done() {
 			dispose();
 			if (amuw == null && !error) {
-				JOptionPane.showMessageDialog(null, upackage.getMod().getModName() + " has been successfully updated.\nMod Manager will now reload mods.", "Update successful",
+				JOptionPane.showMessageDialog(null, upackage.getMod().getModName() + " has been successfully updated.\nYou will need to apply "+upackage.getMod().getModName()+" for the update to take effect.\nMod Manager will now reload mods.", "Update successful",
 						JOptionPane.INFORMATION_MESSAGE);
 			} else if (amuw == null) {
 				JOptionPane.showMessageDialog(null, upackage.getMod().getModName() + " failed to update. The Mod Manager log will have more information.", "Updated failed",

--- a/src/com/me3tweaks/modmanager/objects/AlternateCustomDLC.java
+++ b/src/com/me3tweaks/modmanager/objects/AlternateCustomDLC.java
@@ -26,17 +26,26 @@ public class AlternateCustomDLC {
 	private String description;
 	private String operation;
 	private ArrayList<String> conditionalDLCs = new ArrayList<String>();
+	private String friendlyName;
+	private boolean hasBeenChosen;
+
+	public void setHasBeenChosen(boolean hasBeenChosen) {
+		this.hasBeenChosen = hasBeenChosen;
+	}
 
 	public AlternateCustomDLC(String altfileText) {
-		conditionalDLC = ValueParserLib.getStringProperty(altfileText, "ConditionalDLC", false);
-		altDLC = ValueParserLib.getStringProperty(altfileText, "ModAltDLC", false);
 		condition = ValueParserLib.getStringProperty(altfileText, "Condition", false);
-		if (condition.equals(CONDITION_ANY_DLC_NOT_PRESENT)) {
-			parseConditionalDLC();
+		if (!condition.equals(CONDITION_MANUAL)) {
+			conditionalDLC = ValueParserLib.getStringProperty(altfileText, "ConditionalDLC", false);
+			if (condition.equals(CONDITION_ANY_DLC_NOT_PRESENT)) {
+				parseConditionalDLC();
+			}
 		}
+		altDLC = ValueParserLib.getStringProperty(altfileText, "ModAltDLC", false);
 		description = ValueParserLib.getStringProperty(altfileText, "Description", true);
 		operation = ValueParserLib.getStringProperty(altfileText, "ModOperation", false);
 		destDLC = ValueParserLib.getStringProperty(altfileText,"ModDestDLC", false);
+		friendlyName = ValueParserLib.getStringProperty(altfileText, "FriendlyName", true);
 	}
 
 	private void parseConditionalDLC() {
@@ -71,6 +80,8 @@ public class AlternateCustomDLC {
 		for (String str: alt.conditionalDLCs){
 			conditionalDLCs.add(str);
 		}
+		friendlyName = alt.friendlyName;
+		hasBeenChosen = alt.hasBeenChosen;
 	}
 
 	public String getDescription() {
@@ -159,11 +170,6 @@ public class AlternateCustomDLC {
 		this.operation = operation;
 	}
 
-	public boolean isApplicable() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
 	public ArrayList<String> getConditionalDLCList() {
 		return conditionalDLCs;
 	}
@@ -173,5 +179,13 @@ public class AlternateCustomDLC {
 
 	public void setDestDLC(String destDLC) {
 		this.destDLC = destDLC;
+	}
+
+	public String getFriendlyName() {
+		return friendlyName;
+	}
+
+	public boolean hasBeenChoosen() {
+		return hasBeenChosen;
 	}
 }

--- a/src/com/me3tweaks/modmanager/objects/AlternateFile.java
+++ b/src/com/me3tweaks/modmanager/objects/AlternateFile.java
@@ -21,6 +21,7 @@ public class AlternateFile {
 	private String condition;
 	private String description;
 	private String operation;
+	private String friendlyName;
 
 	public AlternateFile(String altfileText) {
 		conditionalDLC = ValueParserLib.getStringProperty(altfileText, "ConditionalDLC", false);
@@ -32,6 +33,15 @@ public class AlternateFile {
 		condition = ValueParserLib.getStringProperty(altfileText, "Condition", false);
 		description = ValueParserLib.getStringProperty(altfileText, "Description", true);
 		operation = ValueParserLib.getStringProperty(altfileText, "ModOperation", false);
+		friendlyName = ValueParserLib.getStringProperty(altfileText, "FriendlyName", true);
+	}
+
+	public String getFriendlyName() {
+		return friendlyName;
+	}
+
+	public void setFriendlyName(String friendlyName) {
+		this.friendlyName = friendlyName;
 	}
 
 	/**

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -1003,6 +1003,14 @@ public class Mod implements Comparable<Mod> {
 				modDisplayDescription += "\n";
 			}
 		}
+		
+		if (hasAutomaticConfiguration()) {
+			modDisplayDescription += "This mod has been automatically configured for your game's current configuration.\n"; 
+		}
+		
+		if (hasOptionalManualCustomDLC()) {
+			modDisplayDescription += "This mod contains alternate installation options. Access them through the mod utils menu.\n"; 
+		}
 
 		// Add modversion
 		if (modVersion != null) {
@@ -1022,6 +1030,7 @@ public class Mod implements Comparable<Mod> {
 		if (classicCode > 0 /* && ModManager.IS_DEBUG */) {
 			modDisplayDescription += "\nUpdate code: " + classicCode;
 		}
+		
 		if (getSideloadOnlyTargets().size() > 0) {
 			modDisplayDescription += "\nFuture updates may require sideloading an update package";
 		}
@@ -1039,6 +1048,38 @@ public class Mod implements Comparable<Mod> {
 
 		// Add modifier
 		modDisplayDescription += getModifyString();
+	}
+
+	private boolean hasAutomaticConfiguration() {
+		if (alternateCustomDLC.size() > 0) {
+			for (AlternateCustomDLC dlc : alternateCustomDLC) {
+				if (!dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL)) {
+					return true;
+				}
+			}
+		}
+		
+		if (alternateFiles.size() > 0) {
+			for (AlternateFile altfile : alternateFiles) {
+				if (!altfile.getCondition().equals(AlternateFile.CONDITION_MANUAL)) {
+					return true;
+				}
+			}
+		}
+		
+		return false;
+	}
+
+	private boolean hasOptionalManualCustomDLC() {
+		if (alternateCustomDLC.size() > 0) {
+			for (AlternateCustomDLC dlc : alternateCustomDLC) {
+				if (dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL)) {
+					return true;
+				}
+			}
+		}
+		
+		return false;
 	}
 
 	public String getModDisplayDescription() {

--- a/src/com/me3tweaks/modmanager/objects/ThirdPartyModInfo.java
+++ b/src/com/me3tweaks/modmanager/objects/ThirdPartyModInfo.java
@@ -4,14 +4,24 @@ import org.json.simple.JSONObject;
 
 public class ThirdPartyModInfo {
 	private String modname, modauthor, customDLCfolder, moddescription, modsite;
-
-	public ThirdPartyModInfo(String modname, String modauthor, String customDLCfolder, String moddescription, String modsite) {
+	private short mountpriority;
+	/**
+	 * Copy constructor
+	 * @param modname
+	 * @param modauthor
+	 * @param customDLCfolder
+	 * @param moddescription
+	 * @param modsite
+	 * @param mountpriority
+	 */
+	public ThirdPartyModInfo(String modname, String modauthor, String customDLCfolder, String moddescription, String modsite, short mountpriority) {
 		super();
 		this.modname = modname;
 		this.modauthor = modauthor;
 		this.customDLCfolder = customDLCfolder;
 		this.moddescription = moddescription;
 		this.modsite = modsite;
+		this.mountpriority = mountpriority;
 	}
 
 	public ThirdPartyModInfo(String customdlcfolder, JSONObject modinfo) {
@@ -20,6 +30,8 @@ public class ThirdPartyModInfo {
 		this.modauthor = (String) modinfo.get("moddev");
 		this.moddescription = (String) modinfo.get("moddesc");
 		this.modsite = (String) modinfo.get("modsite");
+		String priority = (String) modinfo.get("mountpriority");
+		this.mountpriority = Short.parseShort(priority);
 	}
 
 	public String getModname() {
@@ -60,5 +72,13 @@ public class ThirdPartyModInfo {
 
 	public void setModsite(String modsite) {
 		this.modsite = modsite;
+	}
+
+	public short getMountpriority() {
+		return mountpriority;
+	}
+
+	public void setMountpriority(short mountpriority) {
+		this.mountpriority = mountpriority;
 	}
 }

--- a/src/com/me3tweaks/modmanager/repairdb/BasegameHashDB.java
+++ b/src/com/me3tweaks/modmanager/repairdb/BasegameHashDB.java
@@ -219,6 +219,9 @@ public class BasegameHashDB extends JFrame implements ActionListener {
 						ModManager.debugLogger.writeError("Skipping cmmbackup file " + file);
 						continue; //skip backups folder
 					}
+					if (file.getName().equalsIgnoreCase("PCConsoleTOC.bin")){
+						continue; //skip PCConsoleTOC as they'll be updated outside of mod installs. Especially the basegame one.
+					}
 					filesToHash.add(file);
 				}
 			}

--- a/src/com/me3tweaks/modmanager/repairdb/BasegameHashDB.java
+++ b/src/com/me3tweaks/modmanager/repairdb/BasegameHashDB.java
@@ -363,8 +363,8 @@ public class BasegameHashDB extends JFrame implements ActionListener {
 			} else {
 				if (showGUI) {
 					infoLabel.setText("Database can't be loaded.");
-					JOptionPane.showMessageDialog(null, "Unable to connect to database.\nDo you have multiple Mod Manager windows open?", "Database error",
-							JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null, "<html>The game repair database failed to load.<br>" + "Only one connection to the local repair database is allowed at a time.<br>"
+							+ "Please make sure you only have one instance of Mod Manager running.<br>Mod Manager appears as Java (TM) Platform Binary (or javaw.exe on Windows Vista/7) in Task Manager.<br><br>If the issue persists and you are sure only one instance is running, close Mod Manager and delete the<br>data\\databases folder.<br>You will need to re-create the game repair database afterwards.<br><br>If this *STILL* does not fix your issue, please send a log to FemShep through the help menu.</html>", "Database Failure", JOptionPane.ERROR_MESSAGE);
 					dispose();
 				}
 			}

--- a/src/com/me3tweaks/modmanager/valueparsers/ValueParserLib.java
+++ b/src/com/me3tweaks/modmanager/valueparsers/ValueParserLib.java
@@ -77,7 +77,7 @@ public class ValueParserLib {
 
 	public static String getStringProperty(String inputString, String propertyName, boolean isQuoted) {
 		int charIndex = inputString.indexOf(propertyName);
-		System.out.println(inputString.charAt(charIndex - 1));
+		//System.out.println(inputString.charAt(charIndex - 1));
 		if (charIndex > 0
 				&& (inputString.charAt(charIndex - 1) == '(' || inputString.charAt(charIndex - 1) == ',' || inputString.charAt(charIndex - 1) == '"' || inputString
 						.charAt(charIndex - 1) == ' ')) {


### PR DESCRIPTION
## ME3Tweaks Mod Manager 4.4.1 Build 63

This build fixes a few bugs and introduces a few new features for mod deployment.

![image](https://cloud.githubusercontent.com/assets/2738836/19257936/ffe03f88-8f30-11e6-8a81-40f8da616063.png)WARNING! This update will wipe your MixIn library and delete your mixin cache to correct an issue with the bugfix mixins. Mod Manager will automatically redownload these, if you have any custom mixins back them up!![image](https://cloud.githubusercontent.com/assets/2738836/19257936/ffe03f88-8f30-11e6-8a81-40f8da616063.png)
### New Features
- altdlc descriptor structs now support the property **FriendlyName**. This property is used to display the operation in the new mod utils menu item **Alternate Installation Options**, to describe what the alternate option does. 
  ![image](https://cloud.githubusercontent.com/assets/2738836/19257787/ac6d8776-8f2f-11e6-93f6-abea69eb0ecb.png)
  Items that are greyed out are automatically selected and configured by the mod developer, selectable items can be chosen by the user. The pre-existing **Description** property now sets the tooltip of these items. These are key for users to understand how the mod is being configured.
- 2 new lines are added to mod descriptions for mods that have automatic alternate custom dlc options and automatic alternate file options.
  ![image](https://cloud.githubusercontent.com/assets/2738836/19257911/b813ae1a-8f30-11e6-81c4-82c48aae0ca2.png)
- Starter Kit now uses the [3rdpartymodservice ](http://me3tweaks.com/mods/known_dlc_mods)to identify potential mount priority conflicts.
### Feature Changes
- Information messages displayed when the game repair database now list steps to potentially fixing the problem. If you encounter errors with the game repair database, PLEASE SEND LOGS! The problem can't fix itself.
- The mod updater now tells users they need to apply the updated mod for it to take effect. It was semi-ambiguous what the mod updater was actually updating in the past (installed vs library).
### Bugfixes
- Sideloading a modmaker mod with the wrong file will now close the compiler window. It uses to just hang around.
- PCConsoleTOC files are no longer checked in the game repair database, as they will be automatically generated when you TOC the game. Previously PCConsoleTOC was a huge pain as you could install a custom DLC mod, TOC the game, and then mod manager would backup a modified TOC file (that was still valid). These files are now entirely ignored by the database.
### Updater info
- This build uses a long unused updating feature that will run a script inside the update package to fix the mixin cache while mod manager is closed. It will tag the fix as applied. Future updates will see this and skip the application of the fix (as this fix will now be in all future installers)
