### PR TITLE
Mod Manager 4.4.5 Build 67

### DIFF
--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -80,9 +80,9 @@ import com.sun.jna.win32.W32APIOptions;
 
 public class ModManager {
 
-	public static final String VERSION = "4.4.4";
-	public static long BUILD_NUMBER = 66L;
-	public static final String BUILD_DATE = "2/22/2017";
+	public static final String VERSION = "4.4.5";
+	public static long BUILD_NUMBER = 67L;
+	public static final String BUILD_DATE = "2/23/2017";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";

--- a/src/com/me3tweaks/modmanager/objects/ModJob.java
+++ b/src/com/me3tweaks/modmanager/objects/ModJob.java
@@ -42,6 +42,8 @@ public class ModJob {
 	 * 
 	 * @param DLCFilePath
 	 *            Path to the DLC Sfar file.
+	 * @param jobName Name of the job. Use 
+	 * @param requirementText Text to show if the DLC is not installed that this job targets
 	 */
 	public ModJob(String DLCFilePath, String jobName, String requirementText) {
 		setJobType(DLC);


### PR DESCRIPTION
# Mod Manager 4.4.5 Build 67
This is a bugfix release that fixes bugs in the Keybinds Injector.

## Bugfixes
 - Keybinds injection had a lot of bugs, from missing files, to not working at all if you didn't have a basegame or reckoning job in the mod you are injecting into. These have been fixed, along with AutoTOCing the mod after injection. It also adds proper error messages and logging.