### PR TITLE
Mass Effect 3 Mod Manager 4.5 - Build 68

### DIFF
--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -70,7 +70,7 @@ public class ModInstallWindow extends JDialog {
 		this.setPreferredSize(new Dimension(320, 220));
 		consoleQueue = new String[levelCount];
 
-		setupWindow();
+		setupWindow(mod);
 
 		this.setIconImages(ModManager.ICONS);
 		this.pack();
@@ -157,10 +157,10 @@ public class ModInstallWindow extends JDialog {
 		return result == JOptionPane.YES_OPTION;
 	}
 
-	private void setupWindow() {
+	private void setupWindow(Mod mod) {
 		JPanel rootPanel = new JPanel(new BorderLayout());
 		JPanel northPanel = new JPanel(new BorderLayout());
-		infoLabel = new JLabel("<html>Applying mod to Mass Effect 3...<br>This may take a few minutes.</html>");
+		infoLabel = new JLabel("<html>Applying "+mod.getModName()+" to Mass Effect 3...</html>");
 		northPanel.add(infoLabel, BorderLayout.NORTH);
 		progressBar = new JProgressBar(0, 100);
 		progressBar.setStringPainted(true);
@@ -203,8 +203,9 @@ public class ModInstallWindow extends JDialog {
 		protected InjectionCommander(Mod mod) {
 			this.mod = new Mod(mod); //clone before applying alternates and optional addins
 			ModManager.debugLogger.writeMessage("========Installing " + this.mod.getModName() + "========");
-			ModManager.debugLogger.writeMessage("Applying automatic alt's before parsing jobs");
+			ModManager.debugLogger.writeMessage("Applying alternate files before parsing jobs");
 			alternatesApplied = this.mod.applyAutomaticAlternates(bioGameDir);
+			alternatesApplied |= this.mod.applyManualAlternates(bioGameDir); //Must be separate or it might short circuit in compilation!
 			if (alternatesApplied) {
 				ModManager.debugLogger.writeMessage("At least one alternate file was applied, install now requires pre-toc.");
 			}

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -80,16 +80,16 @@ import com.sun.jna.win32.W32APIOptions;
 
 public class ModManager {
 
-	public static final String VERSION = "4.4.5";
-	public static long BUILD_NUMBER = 67L;
-	public static final String BUILD_DATE = "2/23/2017";
+	public static final String VERSION = "4.5";
+	public static long BUILD_NUMBER = 68L;
+	public static final String BUILD_DATE = "3/6/2017";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static boolean logging = false;
 	public static final double MODMAKER_VERSION_SUPPORT = 2.2; // max modmaker
 																// version
-	public static final double MODDESC_VERSION_SUPPORT = 4.4; // max supported
+	public static final double MODDESC_VERSION_SUPPORT = 4.5; // max supported
 																// cmmver in
 																// moddesc
 	public static boolean MOD_MANAGER_UPDATE_READY = false; //if true, don't delete temp

--- a/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchApplicationWindow.java
@@ -97,7 +97,6 @@ public class PatchApplicationWindow extends JDialog {
 		this.setResizable(false);
 		this.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
 		this.setIconImages(ModManager.ICONS);
-		this.pack();
 		if (callingDialog == null && callingDialog == null) {
 			this.setLocationRelativeTo(null);
 		} else {
@@ -121,7 +120,7 @@ public class PatchApplicationWindow extends JDialog {
 				}
 			}
 		});
-
+		pack();
 	}
 
 	class PatchApplicationTask extends SwingWorker<Void, Object> {

--- a/src/com/me3tweaks/modmanager/UnpackWindow.java
+++ b/src/com/me3tweaks/modmanager/UnpackWindow.java
@@ -72,7 +72,7 @@ public class UnpackWindow extends JDialog {
 	private void setupWindow() {
 		JPanel rootPanel = new JPanel(new BorderLayout());
 		JPanel northPanel = new JPanel(new BorderLayout());
-		infoLabel = new JLabel("<html>Select DLCs to unpack.<br>Unpacking DLCs can take a really long time.</html>");
+		infoLabel = new JLabel("<html>Select DLCs to unpack.<br>Unpacking DLCs can take a really long time.<br>Do not use this if you are going to install ALOT.</html>");
 		northPanel.add(infoLabel, BorderLayout.NORTH);
 
 		progressBar = new JProgressBar(0, 100);

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerEntryWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerEntryWindow.java
@@ -1,13 +1,15 @@
 package com.me3tweaks.modmanager.modmaker;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dialog;
 import java.awt.Dimension;
-import java.awt.Toolkit;
+import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -16,9 +18,11 @@ import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
@@ -39,10 +43,9 @@ import javax.swing.text.DocumentFilter;
 import org.ini4j.InvalidFileFormatException;
 import org.ini4j.Wini;
 
-import com.me3tweaks.modmanager.CoalescedWindow;
 import com.me3tweaks.modmanager.ModManager;
 import com.me3tweaks.modmanager.ModManagerWindow;
-import com.me3tweaks.modmanager.utilities.MD5Checksum;
+import com.me3tweaks.modmanager.utilities.ResourceUtils;
 
 @SuppressWarnings("serial")
 public class ModMakerEntryWindow extends JDialog implements ActionListener {
@@ -90,18 +93,31 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 		modMakerPanel.setLayout(new BoxLayout(modMakerPanel, BoxLayout.Y_AXIS));
 		JPanel infoPane = new JPanel();
 		infoPane.setLayout(new BoxLayout(infoPane, BoxLayout.LINE_AXIS));
+		BufferedImage modmakerLogo;
+		JLabel modmakerLogoLabel = null;
+		try {
+			modmakerLogo = ImageIO.read(ModMakerEntryWindow.class.getResourceAsStream("/resource/modmaker.png"));
+			modmakerLogo = ResourceUtils.getScaledInstance(
+					modmakerLogo, 290, 109, RenderingHints.VALUE_INTERPOLATION_BILINEAR, true);
+			modmakerLogoLabel = new JLabel(new ImageIcon(modmakerLogo));
+			modmakerLogoLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+		} catch (Exception e1) {
+			ModManager.debugLogger.writeErrorWithException("Unable to load ModMaker logo image from jar:", e1);
+		}
 		infoLabel = new JLabel(
-				"<html>ME3Tweaks ModMaker allows you to easily create Mass Effect 3 mods in a simple to use interface.<br>Enter a download code to download and compile a mod.<br>Please note that you should have a vanilla game when applying MixIns as some files may be pulled from the game's folders during application.</html>");
+				"<html>ME3Tweaks ModMaker is an online mod creation tool that works with Mod Manager.<br>Enter a mod code below to download and compile a mod.</html>");
 		infoPane.add(Box.createHorizontalGlue());
 		infoPane.add(infoLabel);
 		infoPane.add(Box.createHorizontalGlue());
+		if (modmakerLogoLabel != null) {
+			modMakerPanel.add(modmakerLogoLabel);
+		}
 		modMakerPanel.add(infoPane);
 
 		JPanel languageChoicesPanel = new JPanel();
 		languageChoicesPanel.setLayout(new BoxLayout(languageChoicesPanel, BoxLayout.LINE_AXIS));
 		languageChoicesPanel.setMaximumSize(new Dimension(550, 30));
-		TitledBorder languageBorder = BorderFactory
-				.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Languages to compile");
+		TitledBorder languageBorder = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED), "Languages to compile");
 		languageChoicesPanel.setBorder(languageBorder);
 		languageChoices = new JComboBox<String>(languages);
 		languageChoices.setToolTipText("Languages to compile. Choose your game's language to speed up compiling significantly.");
@@ -167,22 +183,22 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 		getCodePane.add(Box.createRigidArea(new Dimension(10, 5)));
 		getCodePane.add(sideloadButton);
 		getCodePane.add(Box.createHorizontalGlue());
+		modMakerPanel.add(Box.createRigidArea(new Dimension(10,5)));
 		modMakerPanel.add(getCodePane);
 		modMakerPanel.add(Box.createVerticalGlue());
 		if (!hasDLCBypass) {
 			JPanel launcherWVPanel = new JPanel();
 			launcherWVPanel.setLayout(new BoxLayout(launcherWVPanel, BoxLayout.LINE_AXIS));
 			launcherWVPanel.add(Box.createHorizontalGlue());
-			launcherWVPanel
-					.add(new JLabel(
+			launcherWVPanel.add(
+					new JLabel(
 							"<html>The Launcher_WV.exe DLC bypass will be installed so your mod will work.<br>To use mods you will need to use Start Game from Mod Manager.<br>Tab and ` will open the console in game.<br>Your game will not be modified by this file.</html>"),
-							BorderLayout.CENTER);
+					BorderLayout.CENTER);
 			launcherWVPanel.add(Box.createHorizontalGlue());
 			modMakerPanel.add(launcherWVPanel);
-			setPreferredSize(new Dimension(DIALOG_WIDTH, DIALOG_HEIGHT + 90));
+			//setPreferredSize(new Dimension(DIALOG_WIDTH, DIALOG_HEIGHT + 90));
 		} else {
-			setPreferredSize(new Dimension(DIALOG_WIDTH, DIALOG_HEIGHT));
-
+			//setPreferredSize(new Dimension(DIALOG_WIDTH, DIALOG_HEIGHT));
 		}
 		codeField.addActionListener(this);
 		downloadButton.addActionListener(this);
@@ -215,8 +231,7 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 			ModManager.debugLogger.writeMessage("Invalid INI! Did the user modify it by hand?");
 			e.printStackTrace();
 		} catch (IOException e) {
-			ModManager.debugLogger
-					.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting is stored to disk.");
+			ModManager.debugLogger.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting is stored to disk.");
 		}
 	}
 
@@ -233,11 +248,9 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 			File tankMasterCompiler = new File(ModManager.getTankMasterCompilerDir() + "MassEffect3.Coalesce.exe");
 			if (!tankMasterCompiler.exists()) {
 				dispose();
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"<html>You need TankMaster's Coalesced Compiler in order to use ModMaker.<br><br>It should have been bundled with Mod Manager 3 in the TankMaster Compiler folder.</html>",
-								"Prerequesites Error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"<html>You need TankMaster's Coalesced Compiler in order to use ModMaker.<br><br>It should have been bundled with Mod Manager 3 in the TankMaster Compiler folder.</html>",
+						"Prerequesites Error", JOptionPane.ERROR_MESSAGE);
 
 				ModManager.debugLogger.writeMessage("Tankmaster's compiler not detected. Abort. Searched at: " + tankMasterCompiler.toString());
 				return false;
@@ -247,19 +260,16 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 			String me3explorerdir = ModManager.getME3ExplorerEXEDirectory(false);
 			if (me3explorerdir == null) {
 				dispose();
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"<html>You need ME3Explorer in order to use ModMaker.<br><br>It should have been bundled with Mod Manager 4 in the data/ME3Explorer folder.</html>",
-								"Prerequesites Error", JOptionPane.ERROR_MESSAGE);
+				JOptionPane.showMessageDialog(null,
+						"<html>You need ME3Explorer in order to use ModMaker.<br><br>It should have been bundled with Mod Manager 4 in the data/ME3Explorer folder.</html>",
+						"Prerequesites Error", JOptionPane.ERROR_MESSAGE);
 
 				ModManager.debugLogger.writeMessage("ME3Explorer not detected. Abort.");
 				return false;
 			}
 		} catch (Exception e) {
 			JOptionPane.showMessageDialog(null, "<html>An error occured while attempting to check prerequesites for ModMaker:<br>" + e.getMessage()
-					+ "<br>Please report this to FemShep with the Mod Manager log at femshep@me3tweaks.com.</html>", "Prerequesites Error",
-					JOptionPane.ERROR_MESSAGE);
+					+ "<br>Please report this to FemShep with the Mod Manager log at femshep@me3tweaks.com.</html>", "Prerequesites Error", JOptionPane.ERROR_MESSAGE);
 			return false;
 		}
 		//All prereqs met.
@@ -343,8 +353,7 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 				} catch (InvalidFileFormatException e) {
 					e.printStackTrace();
 				} catch (IOException e) {
-					ModManager.debugLogger.writeErrorWithException(
-							"Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
+					ModManager.debugLogger.writeErrorWithException("Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
 				}
 				this.setModalityType(Dialog.ModalityType.MODELESS);
 				dispose();
@@ -411,8 +420,7 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 			ModManager.debugLogger.writeMessage("Invalid INI! Did the user modify it by hand?");
 			e.printStackTrace();
 		} catch (IOException e) {
-			ModManager.debugLogger
-					.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting is stored to disk.");
+			ModManager.debugLogger.writeMessage("I/O Error reading settings file. It may not exist yet. It will be created when a setting is stored to disk.");
 		}
 		return getLanguages(defaultLang);
 	}
@@ -441,8 +449,7 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 			} catch (InvalidFileFormatException e) {
 				e.printStackTrace();
 			} catch (IOException e) {
-				ModManager.debugLogger.writeErrorWithException(
-						"Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
+				ModManager.debugLogger.writeErrorWithException("Settings file encountered an I/O error while attempting to write it. Settings not saved.", e);
 			}
 			callingWindow.startModMaker(codeField.getText().toString(), languages);
 		}

--- a/src/com/me3tweaks/modmanager/objects/AlternateCustomDLC.java
+++ b/src/com/me3tweaks/modmanager/objects/AlternateCustomDLC.java
@@ -19,12 +19,14 @@ public class AlternateCustomDLC {
 	public static final String CONDITION_ANY_DLC_NOT_PRESENT = "COND_ANY_DLC_NOT_PRESENT"; //multiple DLC, any of which are missing
 	public static final String CONDITION_ALL_DLC_PRESENT = "COND_ALL_DLC_PRESENT";
 
+	private boolean isValid = true;
 	private String altDLC;
 	private String destDLC;
 	private String conditionalDLC;
 	private String condition;
 	private String description;
 	private String operation;
+	private String jobHeader;
 	private ArrayList<String> conditionalDLCs = new ArrayList<String>();
 	private String friendlyName;
 	private boolean hasBeenChosen;
@@ -33,7 +35,12 @@ public class AlternateCustomDLC {
 		this.hasBeenChosen = hasBeenChosen;
 	}
 
+	/**
+	 * Constructs a Alternate Custom DLC object. This is the original constructor introduced in Mod Manager 4.4, and only works with Custom DLC.
+	 * @param altfileText String to parse
+	 */
 	public AlternateCustomDLC(String altfileText) {
+		jobHeader = ModType.CUSTOMDLC;
 		condition = ValueParserLib.getStringProperty(altfileText, "Condition", false);
 		if (!condition.equals(CONDITION_MANUAL)) {
 			conditionalDLC = ValueParserLib.getStringProperty(altfileText, "ConditionalDLC", false);
@@ -47,6 +54,36 @@ public class AlternateCustomDLC {
 		destDLC = ValueParserLib.getStringProperty(altfileText,"ModDestDLC", false);
 		friendlyName = ValueParserLib.getStringProperty(altfileText, "FriendlyName", true);
 	}
+	
+/*	/**
+	 * Constructs a alternate installation option for non-Custom DLC things.
+	 * @param altfileText Text to parse
+	 * @param jobHeader Job that this object targets
+	 *//*
+	public AlternateCustomDLC(String altfileText, String jobHeader) {
+		condition = ValueParserLib.getStringProperty(altfileText, "Condition", false);
+		if (!condition.equals(CONDITION_MANUAL)) {
+			isValid = false; //Alternate Custom DLC targetting official DLC or basegame must be manually chosen.
+			return;
+		}
+		operation = ValueParserLib.getStringProperty(altfileText, "ModOperation", false);
+		if (!operation.equals(arg0))
+		
+		altDLC = ValueParserLib.getStringProperty(altfileText, "ModAltDLC", false);
+		description = ValueParserLib.getStringProperty(altfileText, "Description", true);
+		destDLC = ValueParserLib.getStringProperty(altfileText,"ModDestDLC", false);
+		friendlyName = ValueParserLib.getStringProperty(altfileText, "FriendlyName", true);
+	}*/
+	
+	/**
+	 * Returns if this is a valid Alternate Custom DLC object. This value is only set when using non-custom dlc options (targetting official file replacements)
+	 * @return true if valid, false if not valid
+	 */
+	public boolean isValid() {
+		return isValid;
+	}
+	
+	
 
 	private void parseConditionalDLC() {
 		String str = conditionalDLC.replaceAll("\\(", "");

--- a/src/com/me3tweaks/modmanager/objects/AlternateFile.java
+++ b/src/com/me3tweaks/modmanager/objects/AlternateFile.java
@@ -21,12 +21,14 @@ public class AlternateFile {
 	private String condition;
 	private String description;
 	private String operation;
+	private String substitutefile;
 	private String friendlyName;
+	private boolean enabled = false;
 
 	public AlternateFile(String altfileText) {
 		conditionalDLC = ValueParserLib.getStringProperty(altfileText, "ConditionalDLC", false);
 		modFile = ValueParserLib.getStringProperty(altfileText, "ModFile", false);
-		if (modFile.charAt(0) != '/') {
+		if (modFile.charAt(0) != '/' && modFile.charAt(0) != '\\') {
 			modFile = "/" + modFile;
 		}
 		altFile = ValueParserLib.getStringProperty(altfileText, "ModAltFile", false);
@@ -34,6 +36,7 @@ public class AlternateFile {
 		description = ValueParserLib.getStringProperty(altfileText, "Description", true);
 		operation = ValueParserLib.getStringProperty(altfileText, "ModOperation", false);
 		friendlyName = ValueParserLib.getStringProperty(altfileText, "FriendlyName", true);
+		substitutefile = ValueParserLib.getStringProperty(altfileText, "SubstituteFile", false);
 	}
 
 	public String getFriendlyName() {
@@ -57,6 +60,8 @@ public class AlternateFile {
 		condition = alt.condition;
 		description = alt.description;
 		operation = alt.operation;
+		enabled = alt.enabled;
+		substitutefile = alt.substitutefile;
 	}
 
 	public String getDescription() {
@@ -121,17 +126,19 @@ public class AlternateFile {
 				ModManager.debugLogger.writeError("Operation is not one of the allowed values: " + operation);
 				return false;
 			}
-			ArrayList<String> officialHeaders = new ArrayList<String>(Arrays.asList(ModType.getDLCHeaderNameArray()));
-			if (!officialHeaders.contains(conditionalDLC)) {
-				File f = new File(modPath + conditionalDLC);
-				if (f.exists() && f.isDirectory()) {
-					ModManager.debugLogger.writeError("ConditionalDLC is listed as part of the custom dlc this mod will install: " + conditionalDLC
-							+ ". On mod's first install this will have no effect, and on subsequent will change what is being installed.");
-					return false;
-				} else {
-					if (!conditionalDLC.startsWith("DLC_")) {
-						ModManager.debugLogger.writeError("ConditionalDLC is not an official header and does not start with DLC_: " + conditionalDLC + ".");
+			if (condition.equals(CONDITION_DLC_NOT_PRESENT) || condition.equals(CONDITION_DLC_PRESENT)) {
+				ArrayList<String> officialHeaders = new ArrayList<String>(Arrays.asList(ModType.getDLCHeaderNameArray()));
+				if (!officialHeaders.contains(conditionalDLC)) {
+					File f = new File(modPath + conditionalDLC);
+					if (f.exists() && f.isDirectory()) {
+						ModManager.debugLogger.writeError("ConditionalDLC is listed as part of the custom dlc this mod will install: " + conditionalDLC
+								+ ". On mod's first install this will have no effect, and on subsequent will change what is being installed.");
 						return false;
+					} else {
+						if (!conditionalDLC.startsWith("DLC_")) {
+							ModManager.debugLogger.writeError("ConditionalDLC is not an official header and does not start with DLC_: " + conditionalDLC + ".");
+							return false;
+						}
 					}
 				}
 			}
@@ -160,6 +167,22 @@ public class AlternateFile {
 
 	public void setOperation(String operation) {
 		this.operation = operation;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setHasBeenChosen(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getSubtituteFile() {
+		return substitutefile;
+	}
+
+	public void setSubstituteFile(String substitutefile) {
+		this.substitutefile = substitutefile;
 	}
 
 }

--- a/src/com/me3tweaks/modmanager/objects/ModJob.java
+++ b/src/com/me3tweaks/modmanager/objects/ModJob.java
@@ -21,6 +21,7 @@ public class ModJob {
 	public static final int DLC = 0;
 	public static final int CUSTOMDLC = 2;
 	public static final int BALANCE_CHANGES = 3;
+
 	@Override
 	public String toString() {
 		return "ModJob [jobName=" + jobName + "]";
@@ -35,6 +36,7 @@ public class ModJob {
 	public ArrayList<String> newFiles, filesToReplace, addFiles, addFilesTargets, removeFilesTargets;
 	private String sourceDir;
 	private ArrayList<String> addFilesReadOnlyTargets;
+	private ArrayList<AlternateFile> altfiles;
 
 	/**
 	 * Holds many parameters that are required to inject files into a DLC Sfar
@@ -42,8 +44,10 @@ public class ModJob {
 	 * 
 	 * @param DLCFilePath
 	 *            Path to the DLC Sfar file.
-	 * @param jobName Name of the job. Use 
-	 * @param requirementText Text to show if the DLC is not installed that this job targets
+	 * @param jobName
+	 *            Name of the job. Use
+	 * @param requirementText
+	 *            Text to show if the DLC is not installed that this job targets
 	 */
 	public ModJob(String DLCFilePath, String jobName, String requirementText) {
 		setJobType(DLC);
@@ -56,6 +60,7 @@ public class ModJob {
 		addFilesTargets = new ArrayList<String>();
 		removeFilesTargets = new ArrayList<String>();
 		setAddFilesReadOnlyTargets(new ArrayList<String>());
+		altfiles = new ArrayList<AlternateFile>();
 	}
 
 	public ArrayList<String> getFilesToAdd() {
@@ -81,6 +86,14 @@ public class ModJob {
 	public void setRemoveFilesTargets(ArrayList<String> removeFilesTargets) {
 		this.removeFilesTargets = removeFilesTargets;
 	}
+	
+	public ArrayList<AlternateFile> getAlternateFiles() {
+		return altfiles;
+	}
+
+	public void setAlternateFiles(ArrayList<AlternateFile> altfiles) {
+		this.altfiles = altfiles;
+	}
 
 	/**
 	 * Creates a basegame modjob. It doesn't need a path since it can be derived
@@ -100,6 +113,7 @@ public class ModJob {
 		addFilesTargets = new ArrayList<String>();
 		removeFilesTargets = new ArrayList<String>();
 		setAddFilesReadOnlyTargets(new ArrayList<String>());
+		altfiles = new ArrayList<AlternateFile>();
 	}
 
 	/**
@@ -133,7 +147,11 @@ public class ModJob {
 		addFilesTargets = new ArrayList<String>();
 		removeFilesTargets = new ArrayList<String>();
 		setAddFilesReadOnlyTargets(new ArrayList<String>());
+		altfiles = new ArrayList<AlternateFile>();
 
+		for (AlternateFile f : job.altfiles) {
+			altfiles.add(new AlternateFile(f));
+		}
 		for (String str : job.newFiles) {
 			newFiles.add(str);
 		}
@@ -184,7 +202,9 @@ public class ModJob {
 	 *            Source file that will be injected (full file path)
 	 * @param fileToReplace
 	 *            File path in DLC or basegame that will be updated
-	 * @param ignoreExistenceErrors Ignores errors if a source file doesn't exist. Typically means the file is compressed.
+	 * @param ignoreExistenceErrors
+	 *            Ignores errors if a source file doesn't exist. Typically means
+	 *            the file is compressed.
 	 * @return True if task was added OK, false if the source file does not
 	 *         exist or duplicate files were added
 	 */
@@ -311,7 +331,9 @@ public class ModJob {
 	 *            new file to add
 	 * @param targetPath
 	 *            path to place in DLC
-	 * @param ignoreExistenceErrors Ignores errors if a source file doesn't exist. Typically a sign the mod is compressed and has no files on disk yet.
+	 * @param ignoreExistenceErrors
+	 *            Ignores errors if a source file doesn't exist. Typically a
+	 *            sign the mod is compressed and has no files on disk yet.
 	 * @return true if added, false otherwise
 	 */
 	public boolean addNewFileTask(String sourceFile, String targetPath, boolean ignoreExistenceErrors) {

--- a/src/com/me3tweaks/modmanager/utilities/ResourceUtils.java
+++ b/src/com/me3tweaks/modmanager/utilities/ResourceUtils.java
@@ -2,6 +2,10 @@ package com.me3tweaks.modmanager.utilities;
 
 import java.awt.Color;
 import java.awt.Desktop;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -351,12 +355,76 @@ public class ResourceUtils {
 		return (buffer[0] << 24) & 0xff000000 | (buffer[1] << 16) & 0x00ff0000 | (buffer[2] << 8) & 0x0000ff00 | (buffer[3] << 0) & 0x000000ff;
 	}
 
+	/**
+	 * Converts backslashes to forwardslashes, or vice versa
+	 * @param absolutePath Path to convert
+	 * @param backslash Set to true to make backwards slash, false to make forwardslashes
+	 * @return
+	 */
 	public static String normalizeFilePath(String absolutePath, boolean backslash) {
 		if (!backslash) {
 			return absolutePath.replaceAll("\\\\", "/");
 		}
 		return absolutePath.replaceAll("/", "\\\\");
 	}
+
+    public static BufferedImage getScaledInstance(
+            BufferedImage img, int targetWidth,
+            int targetHeight, Object hint, 
+            boolean higherQuality)
+        {
+            int type =
+                (img.getTransparency() == Transparency.OPAQUE)
+                ? BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
+            BufferedImage ret = (BufferedImage) img;
+            int w, h;
+            if (higherQuality)
+            {
+                // Use multi-step technique: start with original size, then
+                // scale down in multiple passes with drawImage()
+                // until the target size is reached
+                w = img.getWidth();
+                h = img.getHeight();
+            }
+            else
+            {
+                // Use one-step technique: scale directly from original
+                // size to target size with a single drawImage() call
+                w = targetWidth;
+                h = targetHeight;
+            }
+
+            do
+            {
+                if (higherQuality && w > targetWidth)
+                {
+                    w /= 2;
+                    if (w < targetWidth)
+                    {
+                        w = targetWidth;
+                    }
+                }
+
+                if (higherQuality && h > targetHeight)
+                {
+                    h /= 2;
+                    if (h < targetHeight)
+                    {
+                        h = targetHeight;
+                    }
+                }
+
+                BufferedImage tmp = new BufferedImage(w, h, type);
+                Graphics2D g2 = tmp.createGraphics();
+                g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
+                g2.drawImage(ret, 0, 0, w, h, null);
+                g2.dispose();
+
+                ret = tmp;
+            } while (w != targetWidth || h != targetHeight);
+
+            return ret;
+        }
 
 	/*
 	 * public static void main(final String[] args) throws IOException { try


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 4.5 - Build 68
This build adds support for ModDesc 4.5 and fixes a few bugs while updating the UI in a few places.

This build needs testing.

## New Features
- ModDesc 4.5 allows you to specify manual alternate files (user chosen) for OP_NOINSTALL and OP_SUBSTITUTE. An example of this is an upcoming SP Controller Support mod update that will allow users to substitute a mod file that will remove the branding text, but keeping this configuration as one of my supported ones so users don't go editing my mods and then asking me to help them.

## Changed Features
- Mod Merging tool has been deprecated. It isn't tested and isn't really necessary these days with autotoc. It's an old relic and adds a lot of merging code that's complex.
- Installing LauncherWV is deprecated. It's old and not as reliable. Mod Manager hasn't used LauncherWV as the default bypass for a while.
- ME3Tweaks ModMaker entry screen has been updated.
- ME3Logger and Custom DLC Conflicts are now part of logs by default.
- Applying Mod screen now shows the name of mod
- Unpack DLC now indicates you should not use that if you're going to be using the ALOT mod by creeperlava

## Bugfixes
- Some of the altfiles specifications could cause a mod to not load, this has been fixed. 
- Generating a log should be more reliable. Hopefully.
- Fixed alternate installation options tooltip indicating theres only 1 config when there's actually more
- Fixed bug where altfiles spec would add a / instead of replacing a \ with / when normalizing a file path
- Fixed some small other bugs 