### PR TITLE
Mass Effect 3 Mod Manager 4.5.1 MR1 Build 69

### DIFF
--- a/src/com/me3tweaks/modmanager/AutoTocWindow.java
+++ b/src/com/me3tweaks/modmanager/AutoTocWindow.java
@@ -221,7 +221,7 @@ public class AutoTocWindow extends JDialog {
 				boolean hasTOC = false;
 				if (mode == LOCALMOD_MODE) {
 					//see if has toc file
-					for (String file : job.newFiles) {
+					for (String file : job.filesToReplace) {
 						String filename = FilenameUtils.getName(file);
 						if (filename.equals("PCConsoleTOC.bin")) {
 							hasTOC = true;
@@ -250,8 +250,8 @@ public class AutoTocWindow extends JDialog {
 					//batchJobs.add(tbd);
 
 					//break into batches
-					ModManager.debugLogger.writeMessage("["+job.getJobName()+"]Number of files in this job: "+(job.newFiles.size() + job.addFiles.size()-1));
-					for (String newFile : job.newFiles) {
+					ModManager.debugLogger.writeMessage("["+job.getJobName()+"]Number of files in this job: "+(job.filesToReplace.size() + job.addFiles.size()-1));
+					for (String newFile : job.filesToReplace) {
 						String filename = FilenameUtils.getName(newFile);
 						if (filename.equals("PCConsoleTOC.bin")) {
 							continue; //this doesn't need updated.
@@ -353,7 +353,7 @@ public class AutoTocWindow extends JDialog {
 				boolean hasTOC = false;
 				if (mode == LOCALMOD_MODE) {
 					//find out if it has a toc file
-					for (String file : job.newFiles) {
+					for (String file : job.filesToReplace) {
 						String filename = FilenameUtils.getName(file);
 						if (filename.equals("PCConsoleTOC.bin")) {
 							hasTOC = true;
@@ -365,7 +365,7 @@ public class AutoTocWindow extends JDialog {
 				}
 
 				if (hasTOC) { //calc files
-					for (String file : job.newFiles) {
+					for (String file : job.filesToReplace) {
 						String filename = FilenameUtils.getName(file);
 						if (filename.equalsIgnoreCase("PCConsoleTOC.bin") || filename.equalsIgnoreCase("Mount.dlc")) {
 							continue;

--- a/src/com/me3tweaks/modmanager/ImportEntryWindow.java
+++ b/src/com/me3tweaks/modmanager/ImportEntryWindow.java
@@ -428,7 +428,7 @@ public class ImportEntryWindow extends JDialog {
 	 * @return
 	 */
 	public boolean inputValidate() {
-		if (modNameField.getText() == "") {
+		if (modNameField.getText().equals("")) {
 			JOptionPane.showMessageDialog(this, "You must set a Mod Name.", "Mod Name Required", JOptionPane.ERROR_MESSAGE);
 			return false;
 		}

--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -630,8 +630,8 @@ public class ModInstallWindow extends JDialog {
 			String me3dir = ModManager.appendSlash(bgdir.getParent());
 
 			//Check for files to replace not being present
-			for (int i = 0; i < job.filesToReplace.size(); i++) {
-				String fileToReplace = job.filesToReplace.get(i);
+			for (int i = 0; i < job.filesToReplaceTargets.size(); i++) {
+				String fileToReplace = job.filesToReplaceTargets.get(i);
 				File unpackeddlcfile = new File(me3dir + fileToReplace);
 				if (!unpackeddlcfile.exists()) {
 					ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Game DB: unpacked DLC file not present. DLC job will use SFAR method: " + job.getJobName());

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -80,9 +80,9 @@ import com.sun.jna.win32.W32APIOptions;
 
 public class ModManager {
 
-	public static final String VERSION = "4.5.1";
+	public static final String VERSION = "4.5.1 MR1";
 	public static long BUILD_NUMBER = 69L;
-	public static final String BUILD_DATE = "3/9/2017";
+	public static final String BUILD_DATE = "3/10/2017";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1315,9 +1315,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modutilsRestoreMod.addActionListener(this);
 		modutilsRestoreMod.setVisible(false);
 
-		modutilsDeleteMod = new JMenuItem("Delete mod");
+		modutilsDeleteMod = new JMenuItem("Delete mod from library");
 		modutilsDeleteMod.addActionListener(this);
-		modutilsDeleteMod.setToolTipText("Delete this mod from Mod Manager");
+		modutilsDeleteMod.setToolTipText("<html>Delete this mod from Mod Manager.<br>This does not remove this mod if it is installed</html>");
 
 		modMenu.add(modutilsHeader);
 		modMenu.add(modutilsCheckforupdate);
@@ -2204,7 +2204,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 		} else if (e.getSource() == modutilsDeleteMod) {
 			ModManager.debugLogger.writeMessage("User clicked Delete Mod on " + modModel.get(modList.getSelectedIndex()).getModName());
-			int result = JOptionPane.showConfirmDialog(this, "Deleting this mod will remove it from your filesystem.\nThis operation cannot be reversed.\nDelete "
+			int result = JOptionPane.showConfirmDialog(this, "Deleting this mod will remove it from Mod Manager's library.\nThis does not remove the mod if it is installed.\nThis operation cannot be reversed.\nDelete "
 					+ modModel.get(modList.getSelectedIndex()).getModName() + "?", "Confirm Mod Deletion", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
 			if (result == JOptionPane.OK_OPTION) {
 				ModManager.debugLogger.writeMessage("Deleting mod: " + modModel.get(modList.getSelectedIndex()).getModPath());

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -2013,7 +2013,7 @@ public class Mod implements Comparable<Mod> {
 			if (job.getJobName() == ModType.COAL) {
 				return true;
 			}
-			for (String file : job.filesToReplace) {
+			for (String file : job.filesToReplaceTargets) {
 				file = file.replaceAll("\\\\", "/"); //make sure all are the same (since the yall work)
 				if (file.toLowerCase().equals("/BIOGame/CookedPCConsole/Coalesced.bin".toLowerCase())) {
 					return true;
@@ -2062,14 +2062,14 @@ public class Mod implements Comparable<Mod> {
 			if (!job.getJobName().equals(header)) {
 				continue;
 			}
-			for (int i = 0; i < job.filesToReplace.size(); i++) {
-				String file = job.filesToReplace.get(i);
+			for (int i = 0; i < job.filesToReplaceTargets.size(); i++) {
+				String file = job.filesToReplaceTargets.get(i);
 				file = file.replaceAll("\\\\", "/"); //make sure all are the same (since the yall work)
 				if (!file.startsWith("/")) {
 					file = "/" + file;
 				}
 				if (file.toLowerCase().equals(modulePath.toLowerCase())) {
-					return job.newFiles.get(i);
+					return job.filesToReplace.get(i);
 				}
 			}
 		}
@@ -2529,13 +2529,20 @@ public class Mod implements Comparable<Mod> {
 			break;
 		case AlternateFile.OPERATION_NOINSTALL:
 			ModManager.debugLogger.writeMessage("Condition match, will no longer modify " + af.getModFile());
-			String fileToRemove = ResourceUtils.normalizeFilePath(getModPath() + af.getAltFile(), true);
+			String fileToRemovePath = af.getModFile();
+			if (fileToRemovePath.charAt(0) == '/' || fileToRemovePath.charAt(0) == '\\') {
+				fileToRemovePath = fileToRemovePath.substring(1);
+			}
+			String fileToRemove = ResourceUtils.normalizeFilePath(getModPath() + fileToRemovePath, false);
 			String fileToRemoveTarget = ResourceUtils.normalizeFilePath(af.getModFile(), false);
+			/*if (job.getJobType() == ModJob.CUSTOMDLC) {
+				fileToRemove = fileToRemoveTarget;
+			}*/
 			boolean ftr = job.getFilesToReplace().remove(fileToRemove);
 			boolean ftrt = job.getFilesToReplaceTargets().remove(fileToRemoveTarget);
 			if (ftr ^ ftrt) {
 				ModManager.debugLogger.writeError(
-						"Application of NO_INSTALL has caused mod to become invalid as one of the replace lists didn't contain the correct values, but the other one did.");
+						"Application of NO_INSTALL has caused mod to become invalid as one of the replace files lists didn't contain the correct values to remove, but the other one did.");
 			}
 			break;
 		case AlternateFile.OPERATION_SUBSTITUTE:

--- a/src/com/me3tweaks/modmanager/objects/ModJob.java
+++ b/src/com/me3tweaks/modmanager/objects/ModJob.java
@@ -33,7 +33,7 @@ public class ModJob {
 	private String jobName, requirementText;
 	private ArrayList<String> sourceFolders; //CUSTOMDLC (used only for writing desc file)
 	private ArrayList<String> destFolders; //CUSTOMDLC (used only for writing desc file)
-	public ArrayList<String> newFiles, filesToReplace, addFiles, addFilesTargets, removeFilesTargets;
+	public ArrayList<String> filesToReplace, filesToReplaceTargets, addFiles, addFilesTargets, removeFilesTargets;
 	private String sourceDir;
 	private ArrayList<String> addFilesReadOnlyTargets;
 	private ArrayList<AlternateFile> altfiles;
@@ -54,8 +54,8 @@ public class ModJob {
 		this.setJobName(jobName);
 		this.DLCFilePath = DLCFilePath;
 		this.requirementText = requirementText;
-		newFiles = new ArrayList<String>();
 		filesToReplace = new ArrayList<String>();
+		filesToReplaceTargets = new ArrayList<String>();
 		addFiles = new ArrayList<String>();
 		addFilesTargets = new ArrayList<String>();
 		removeFilesTargets = new ArrayList<String>();
@@ -107,8 +107,8 @@ public class ModJob {
 	public ModJob() {
 		setJobType(BASEGAME);
 		setJobName(ModType.BASEGAME);
-		newFiles = new ArrayList<String>();
 		filesToReplace = new ArrayList<String>();
+		filesToReplaceTargets = new ArrayList<String>();
 		addFiles = new ArrayList<String>();
 		addFilesTargets = new ArrayList<String>();
 		removeFilesTargets = new ArrayList<String>();
@@ -141,8 +141,8 @@ public class ModJob {
 				destFolders.add(str);
 			}
 		}
-		newFiles = new ArrayList<String>();
 		filesToReplace = new ArrayList<String>();
+		filesToReplaceTargets = new ArrayList<String>();
 		addFiles = new ArrayList<String>();
 		addFilesTargets = new ArrayList<String>();
 		removeFilesTargets = new ArrayList<String>();
@@ -152,11 +152,11 @@ public class ModJob {
 		for (AlternateFile f : job.altfiles) {
 			altfiles.add(new AlternateFile(f));
 		}
-		for (String str : job.newFiles) {
-			newFiles.add(str);
-		}
 		for (String str : job.filesToReplace) {
 			filesToReplace.add(str);
+		}
+		for (String str : job.filesToReplaceTargets) {
+			filesToReplaceTargets.add(str);
 		}
 		for (String str : job.addFiles) {
 			addFiles.add(str);
@@ -192,7 +192,7 @@ public class ModJob {
 	 * @return
 	 */
 	public ArrayList<String> getFilesToReplace() {
-		return newFiles;
+		return filesToReplace;
 	}
 
 	/**
@@ -233,13 +233,13 @@ public class ModJob {
 			}
 		}
 
-		if (newFiles.contains(newFile) || filesToReplace.contains(fileToReplace)) {
+		if (filesToReplace.contains(newFile) || filesToReplaceTargets.contains(fileToReplace)) {
 			ModManager.debugLogger.writeError("Adding duplicate source or target file for replacement: " + newFile + " or " + fileToReplace);
 			return false;
 		}
 
-		newFiles.add(newFile);
-		filesToReplace.add(fileToReplace);
+		filesToReplace.add(newFile);
+		filesToReplaceTargets.add(fileToReplace);
 		return true;
 	}
 
@@ -249,7 +249,7 @@ public class ModJob {
 	 * @return
 	 */
 	public ArrayList<String> getFilesToReplaceTargets() {
-		return filesToReplace;
+		return filesToReplaceTargets;
 	}
 
 	/*
@@ -291,7 +291,7 @@ public class ModJob {
 	 * @return
 	 */
 	public boolean hasTOC() {
-		for (String newFile : newFiles) {
+		for (String newFile : filesToReplace) {
 			if (FilenameUtils.getName(newFile).equals("PCConsoleTOC.bin")) {
 				return true;
 			}


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 4.5.1 MR1 Build 69
This is a maintenance build that fixes a few bugs.

The changelog for the main 4.5.1 version is at #38 

## Bug Fixes
 - Custom DLC Mod Importer works again. Somehow this broke in the final stages of testing 4.5.1. Turns out having a backslash at the end to denote a folder is not always best.
 - Delete Mod now indicates that it deletes it from the library, not from the game
 - Automatic alternates (SP Controller Mod, Expanded Galaxy Mod) should now properly parse OP_NOINSTALL for CustomDLC. Previously it didn't, but the mod somehow still installed.
 - A progress bar has been added to the Custom DLC importer so you can see that things are happening.
