### PR TITLE
Mass Effect 3 Mod Manager 4.5.2 Build 70

### DIFF
--- a/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
@@ -78,7 +78,7 @@ public class CustomDLCConflictWindow extends JDialog {
 	public String transplanterpath;
 	public HashMap<String, CustomDLC> secondPriorityUIConflictFiles;
 	public ArrayList<String> blacklistedGUIconflictfiles = new ArrayList<String>(
-			Arrays.asList(new String[] { "SFXWeapon_SniperRifle_Collector_LOC_INT.pcc", "SFXWeapon_AssaultRifle_Spitfire.pcc", "SFXWeapon_SMG_Collector_LOC_INT.pcc", "Startup_DLC_CON_MAPMOD_INT.pcc" }));
+			Arrays.asList(new String[] { "BioD_CitCas.pcc", "SFXWeapon_SniperRifle_Collector_LOC_INT.pcc", "SFXWeapon_AssaultRifle_Spitfire.pcc", "SFXWeapon_SMG_Collector_LOC_INT.pcc", "Startup_DLC_CON_MAPMOD_INT.pcc" }));
 
 	public CustomDLCConflictWindow() {
 		setupWindow();

--- a/src/com/me3tweaks/modmanager/CustomDLCWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCWindow.java
@@ -74,7 +74,12 @@ public class CustomDLCWindow extends JDialog {
 
 		int datasize = 0;
 		for (String dir : directories) {
-			if (ModType.isKnownDLCFolder(dir)) {
+			String displayDir = dir;
+			if (dir.toLowerCase().startsWith("xdlc_")) {
+				displayDir = dir.substring(1);
+			}
+			
+			if (ModType.isKnownDLCFolder(displayDir)) {
 				continue;
 			}
 			datasize++;
@@ -89,10 +94,7 @@ public class CustomDLCWindow extends JDialog {
 				}
 			} else {
 				//try to lookup via 3rd party service
-				String displayDir = dir;
-				if (dir.toLowerCase().startsWith("xdlc_")) {
-					displayDir = dir.substring(1);
-				}
+				
 				dlcName = ME3TweaksUtils.getThirdPartyModName(displayDir);
 			}
 
@@ -186,19 +188,19 @@ public class CustomDLCWindow extends JDialog {
 			}
 		};
 		table.setRowHeight(30);
-
+		table.setAutoResizeMode(JTable.AUTO_RESIZE_NEXT_COLUMN);
 		ButtonColumn buttonColumn = new ButtonColumn(table, delete, COL_ACTION);
 		CustomDLCManagerToggleButtonColumn buttonColumn2 = new CustomDLCManagerToggleButtonColumn(table, toggle, COL_TOGGLE);
 
 		DefaultTableCellRenderer centerRenderer = new DefaultTableCellRenderer();
 		centerRenderer.setHorizontalAlignment(JLabel.CENTER);
 		table.getColumnModel().getColumn(COL_MOUNT_PRIORITY).setCellRenderer(centerRenderer);
-
+		
 		JScrollPane scrollpane = new JScrollPane(table);
 		panel.add(scrollpane, BorderLayout.CENTER);
 
 		JLabel mpLabel = new JLabel(
-				"<html><div style=\"text-align: center;\">Custom DLC will never authorize unless you use a DLC bypass.<br>You can check for Custom DLC conflicts using the Custom DLC Conflict Detector tool in the Mod Management menu.<br>Custom DLCs that have MP in their Mount Flag will make all players require that DLC in order to join the lobby.</div></html>",
+				"<html><div style=\"text-align: center;\">Custom DLC will never authorize unless you use a DLC bypass.<br>You can check for Custom DLC conflicts using the Custom DLC Conflict Detector tool in the Mod Management menu.</div></html>",
 				SwingConstants.CENTER);
 		panel.add(mpLabel, BorderLayout.SOUTH);
 		panel.setBorder(new EmptyBorder(5, 5, 5, 5));

--- a/src/com/me3tweaks/modmanager/CustomDLCWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCWindow.java
@@ -1,6 +1,7 @@
 package com.me3tweaks.modmanager;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.io.File;
@@ -28,13 +29,14 @@ import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
 import com.me3tweaks.modmanager.objects.ModType;
 import com.me3tweaks.modmanager.objects.MountFile;
 import com.me3tweaks.modmanager.ui.ButtonColumn;
+import com.me3tweaks.modmanager.ui.CustomDLCManagerToggleButtonColumn;
 
 public class CustomDLCWindow extends JDialog {
 
 	protected static final int COL_FOLDER = 0;
 	protected static final int COL_NAME = 1;
-	protected static final int COL_MOUNT = 2;
-	public static final int COL_MOUNT_PRIORITY = 3;
+	public static final int COL_MOUNT_PRIORITY = 2;
+	protected static final int COL_TOGGLE = 3;
 	protected static final int COL_ACTION = 4;
 	private String bioGameDir;
 	private ArrayList<MountFile> mountList;
@@ -52,19 +54,21 @@ public class CustomDLCWindow extends JDialog {
 		setTitle("Custom DLC Manager");
 		setModal(true);
 		setPreferredSize(new Dimension(800, 600));
-		setMinimumSize(new Dimension(300, 200));
+		setMinimumSize(new Dimension(700, 350));
 
 		mountList = new ArrayList<MountFile>();
 
 		JPanel panel = new JPanel(new BorderLayout());
-		JLabel infoLabel = new JLabel("<html>Installed Custom DLCs</html>",SwingConstants.CENTER);
+		JLabel infoLabel = new JLabel("<html><center>Installed Custom DLCs<br>Disabled DLCs start with an x. Mass Effect 3 only loads DLCs that start with DLC_.</center></html>");
+		infoLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		panel.add(infoLabel, BorderLayout.NORTH);
 
 		File mainDlcDir = new File(ModManager.appendSlash(bioGameDir) + "DLC/");
 		String[] directories = mainDlcDir.list(new FilenameFilter() {
 			@Override
 			public boolean accept(File current, String name) {
-				return new File(current, name).isDirectory();
+				System.out.println(name);
+				return new File(current, name).isDirectory() && (name.toLowerCase().startsWith("xdlc_") || name.toLowerCase().startsWith("dlc_"));
 			}
 		});
 
@@ -73,8 +77,8 @@ public class CustomDLCWindow extends JDialog {
 			if (ModType.isKnownDLCFolder(dir)) {
 				continue;
 			}
-			datasize ++;
-			String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath()+ File.separator + dir);
+			datasize++;
+			String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath() + File.separator + dir);
 			String dlcName = "Unknown";
 			File metaFile = new File(path + ModInstallWindow.CUSTOMDLC_METADATA_FILE);
 			if (metaFile.exists()) {
@@ -85,18 +89,22 @@ public class CustomDLCWindow extends JDialog {
 				}
 			} else {
 				//try to lookup via 3rd party service
-				dlcName = ME3TweaksUtils.getThirdPartyModName(dir);
+				String displayDir = dir;
+				if (dir.toLowerCase().startsWith("xdlc_")) {
+					displayDir = dir.substring(1);
+				}
+				dlcName = ME3TweaksUtils.getThirdPartyModName(displayDir);
 			}
-			
-			String pcConsole = path+"CookedPCConsole/";
-			File mountFile = new File(pcConsole+"Mount.dlc");
-			File sfarFile = new File(pcConsole+"Default.sfar");
+
+			String pcConsole = path + "CookedPCConsole/";
+			File mountFile = new File(pcConsole + "Mount.dlc");
+			File sfarFile = new File(pcConsole + "Default.sfar");
 			MountFile mount = new MountFile(mountFile.getAbsolutePath());
-			ModManager.debugLogger.writeMessage("Found mount file: "+mount);
+			ModManager.debugLogger.writeMessage("Found mount file: " + mount);
 			mount.setAssociatedDLCName(dir);
-			if (!mountFile.exists()){
+			if (!mountFile.exists()) {
 				mount.setReason("No Mount.dlc file");
-			} else if (!sfarFile.exists()){
+			} else if (!sfarFile.exists()) {
 				mount.setReason("No SFAR");
 			} else {
 				//String mount = MountFileEditorWindow.getMountDescription(mountFile);
@@ -104,55 +112,114 @@ public class CustomDLCWindow extends JDialog {
 			}
 			mountList.add(mount);
 		}
-		
-		Collections.sort(mountList);
 
+		Collections.sort(mountList);
+		Collections.reverse(mountList); //Descending
 		//TABLE
 		Object[][] data = new Object[datasize][5];
 		for (int i = 0; i < datasize; i++) {
 			MountFile mount = mountList.get(i);
 			data[i][COL_FOLDER] = mount.getAssociatedDLCName();
 			data[i][COL_NAME] = mount.getAssociatedModName();
-			data[i][COL_MOUNT] = mount.getMountFlagString();
 			data[i][COL_MOUNT_PRIORITY] = mount.getMountPriority();
+			data[i][COL_TOGGLE] = mount.getAssociatedDLCName().toLowerCase().startsWith("xdlc_") ? CustomDLCManagerToggleButtonColumn.STR_ENABLE : CustomDLCManagerToggleButtonColumn.STR_DISABLE;
 			data[i][COL_ACTION] = "Delete DLC";
 		}
 
 		Action delete = new AbstractAction() {
 			public void actionPerformed(ActionEvent e) {
 				if (ModManager.isMassEffect3Running()) {
-					JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can delete DLC.","MassEffect3.exe is running", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can delete DLC.", "MassEffect3.exe is running",
+							JOptionPane.ERROR_MESSAGE);
 					return;
 				}
 				JTable table = (JTable) e.getSource();
 				int modelRow = Integer.valueOf(e.getActionCommand());
-				String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath() + File.separator+ table.getModel().getValueAt(modelRow, COL_FOLDER));
-				ModManager.debugLogger.writeMessage("Deleting Custom DLC folder: "+path);
-				FileUtils.deleteQuietly(new File(path));
-				((DefaultTableModel) table.getModel()).removeRow(modelRow);
+				String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath() + File.separator + table.getModel().getValueAt(modelRow, COL_FOLDER));
+				ModManager.debugLogger.writeMessage("Deleting Custom DLC folder: " + path);
+				if (FileUtils.deleteQuietly(new File(path))) {
+					((DefaultTableModel) table.getModel()).removeRow(modelRow);
+				} else {
+					//Failed
+					ModManager.debugLogger.writeError("Failed to delete folder!");
+				}
 			}
 		};
-		String[] columnNames = { "DLC Folder", "DLC Name", "Mount Flag", "Mount Priority","Delete DLC" };
+
+		Action toggle = new AbstractAction() {
+			public void actionPerformed(ActionEvent e) {
+				if (ModManager.isMassEffect3Running()) {
+					JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can enable or disable DLC.",
+							"MassEffect3.exe is running", JOptionPane.ERROR_MESSAGE);
+					return;
+				}
+				JTable table = (JTable) e.getSource();
+				int modelRow = Integer.valueOf(e.getActionCommand());
+				String dlcname = (String) table.getModel().getValueAt(modelRow, COL_FOLDER);
+				String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath() + File.separator + dlcname);
+				ModManager.debugLogger.writeMessage("Toggling Custom DLC folder: " + path);
+				String newname = "MM_PLACEHOLDER";
+				boolean disabling = false;
+				if (dlcname.toLowerCase().startsWith("x")) {
+					//Enable
+					newname = dlcname.substring(1);
+					disabling = false;
+				} else {
+					//Disable
+					newname = "x" + dlcname;
+					disabling = true;
+				}
+
+				File currentPath = new File(path);
+				File toggledPath = new File(mainDlcDir.getAbsolutePath() + File.separator + newname);
+				if (currentPath.renameTo(toggledPath)) {
+					table.setValueAt(disabling ? CustomDLCManagerToggleButtonColumn.STR_ENABLE : CustomDLCManagerToggleButtonColumn.STR_DISABLE, modelRow, COL_TOGGLE);
+					table.setValueAt(newname, modelRow, COL_FOLDER);
+				}
+			}
+		};
+		String[] columnNames = { "DLC Folder", "DLC Name", "Mount Priority", "Toggle DLC", "Delete DLC" };
 		DefaultTableModel model = new DefaultTableModel(data, columnNames);
 		JTable table = new JTable(model) {
 			public boolean isCellEditable(int row, int column) {
-				return column == COL_ACTION;
+				return column == COL_ACTION || column == COL_TOGGLE;
 			}
 		};
-		table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+		table.setRowHeight(30);
+
 		ButtonColumn buttonColumn = new ButtonColumn(table, delete, COL_ACTION);
-		
+		CustomDLCManagerToggleButtonColumn buttonColumn2 = new CustomDLCManagerToggleButtonColumn(table, toggle, COL_TOGGLE);
+
 		DefaultTableCellRenderer centerRenderer = new DefaultTableCellRenderer();
-		centerRenderer.setHorizontalAlignment( JLabel.CENTER );
+		centerRenderer.setHorizontalAlignment(JLabel.CENTER);
 		table.getColumnModel().getColumn(COL_MOUNT_PRIORITY).setCellRenderer(centerRenderer);
-		
+
 		JScrollPane scrollpane = new JScrollPane(table);
 		panel.add(scrollpane, BorderLayout.CENTER);
-		
-		JLabel mpLabel = new JLabel("<html><div style=\"text-align: center;\">Custom DLC will never authorize unless you use a DLC bypass.<br>You can check for Custom DLC conflicts using the Custom DLC Conflict Detector tool in the Mod Management menu.<br>Custom DLCs that have MP in their Mount Flag will make all players require that DLC in order to join the lobby.</div></html>",SwingConstants.CENTER);
-		panel.add(mpLabel,BorderLayout.SOUTH);
-		panel.setBorder(new EmptyBorder(5,5,5,5));
+
+		JLabel mpLabel = new JLabel(
+				"<html><div style=\"text-align: center;\">Custom DLC will never authorize unless you use a DLC bypass.<br>You can check for Custom DLC conflicts using the Custom DLC Conflict Detector tool in the Mod Management menu.<br>Custom DLCs that have MP in their Mount Flag will make all players require that DLC in order to join the lobby.</div></html>",
+				SwingConstants.CENTER);
+		panel.add(mpLabel, BorderLayout.SOUTH);
+		panel.setBorder(new EmptyBorder(5, 5, 5, 5));
 		add(panel);
 		pack();
+		updateRowHeights(table);
+	}
+	
+	private void updateRowHeights(JTable table)
+	{
+	    for (int row = 0; row < table.getRowCount(); row++)
+	    {
+	        int rowHeight = table.getRowHeight();
+
+	        for (int column = 0; column < table.getColumnCount(); column++)
+	        {
+	            Component comp = table.prepareRenderer(table.getCellRenderer(row, column), row, column);
+	            rowHeight = Math.max(rowHeight, comp.getPreferredSize().height);
+	        }
+
+	        table.setRowHeight(row, rowHeight);
+	    }
 	}
 }

--- a/src/com/me3tweaks/modmanager/FailedModsWindow.java
+++ b/src/com/me3tweaks/modmanager/FailedModsWindow.java
@@ -93,7 +93,9 @@ public class FailedModsWindow extends JDialog implements ListSelectionListener {
 		actionsPanel.setLayout(new BoxLayout(actionsPanel, BoxLayout.LINE_AXIS));
 		websiteButton = new JButton("Visit Mod Website");
 		restoreButton = new JButton("Restore online");
-
+		websiteButton.setEnabled(false);
+		restoreButton.setEnabled(false);
+		
 		websiteButton.addActionListener(new ActionListener() {
 
 			@Override
@@ -113,24 +115,27 @@ public class FailedModsWindow extends JDialog implements ListSelectionListener {
 
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				Mod mod = failedModsModel.get(failedModList.getSelectedIndex());
-				mod = new Mod(mod); //make clone
-				if (mod.getModMakerCode() <= 0 || ModManagerWindow.validateBIOGameDir()) {
-					if (mod.getModMakerCode() <= 0 || ModManager.validateNETFrameworkIsInstalled()) {
-						ModManager.debugLogger.writeMessage("Running (restore mode) for failed mod " + mod.getModName());
-						mod.setVersion(0.001);
-						ModManagerWindow.ACTIVE_WINDOW.startSingleModUpdate(mod);
-						dispose();
+				int modelIndex = failedModList.getSelectedIndex();
+				if (modelIndex > -1) {
+					Mod mod = failedModsModel.get(modelIndex);
+					mod = new Mod(mod); //make clone
+					if (mod.getModMakerCode() <= 0 || ModManagerWindow.validateBIOGameDir()) {
+						if (mod.getModMakerCode() <= 0 || ModManager.validateNETFrameworkIsInstalled()) {
+							ModManager.debugLogger.writeMessage("Running (restore mode) for failed mod " + mod.getModName());
+							mod.setVersion(0.001);
+							ModManagerWindow.ACTIVE_WINDOW.startSingleModUpdate(mod);
+							dispose();
+						} else {
+							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(".NET Framework 4.5 or higher is missing");
+							ModManager.debugLogger.writeMessage("Fail Mod Restore: Missing .NET Framework");
+							new NetFrameworkMissingWindow("You must install .NET Framework 4.5 to restore ModMaker mods.");
+						}
 					} else {
-						ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(".NET Framework 4.5 or higher is missing");
-						ModManager.debugLogger.writeMessage("Fail Mod Restore: Missing .NET Framework");
-						new NetFrameworkMissingWindow("You must install .NET Framework 4.5 to restore ModMaker mods.");
+						ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Restoring ModMaker mods requires valid BIOGame");
+						JOptionPane.showMessageDialog(null,
+								"The BIOGame directory is not valid.\nCannot restore ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
+								"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 					}
-				} else {
-					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Restoring ModMaker mods requires valid BIOGame");
-					JOptionPane.showMessageDialog(null,
-							"The BIOGame directory is not valid.\nCannot restore ModMaker mods without a valid BIOGame directory.\nFix the BIOGame directory before continuing.",
-							"Invalid BioGame Directory", JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		});
@@ -154,10 +159,11 @@ public class FailedModsWindow extends JDialog implements ListSelectionListener {
 
 	@Override
 	public void valueChanged(ListSelectionEvent e) {
-		System.out.println("values have changed.");
 		if (e.getValueIsAdjusting() == false) {
 			if (failedModList.getSelectedIndex() == -1) {
 				failedModDesc.setText("Select a mod on the left to see why it failed to load.");
+				websiteButton.setEnabled(false);
+				restoreButton.setEnabled(false);
 			} else {
 				updateDescription();
 			}
@@ -185,7 +191,7 @@ public class FailedModsWindow extends JDialog implements ListSelectionListener {
 			websiteButton.setEnabled(false);
 		}
 		if (mod.isME3TweaksUpdatable()) {
-			description += "\n\nThis mod is can be updated online via the ME3Tweaks updater service. Select Restore Online to force this mod to perform an update and match the version on the server.";
+			description += "\n\nThis mod can attempt a restore via the ME3Tweaks updater service. Select Restore Online to force this mod to perform an update and match the version on the server.\nIf the issue is from additional files, the service won't be able to fix it.";
 			restoreButton.setEnabled(true);
 		} else {
 			restoreButton.setEnabled(false);

--- a/src/com/me3tweaks/modmanager/ImportEntryWindow.java
+++ b/src/com/me3tweaks/modmanager/ImportEntryWindow.java
@@ -213,7 +213,7 @@ public class ImportEntryWindow extends JDialog {
 			setTitle("Importing " + tpmi.getModname());
 			//Check if an update telemetry is required
 			MountFile mf = new MountFile(importPath + "CookedPCConsole" + File.separator + "Mount.dlc");
-			if (mf.getMountPriority() != tpmi.getMountpriority()) {
+			if (mf.getMountPriority() != tpmi.getMountPriority()) {
 				//TELEMETRY UPDATE
 				telemetryCheckbox.setText("Send updated mod info to ME3Tweaks");
 				telemetryCheckbox.setToolTipText(

--- a/src/com/me3tweaks/modmanager/ImportEntryWindow.java
+++ b/src/com/me3tweaks/modmanager/ImportEntryWindow.java
@@ -81,7 +81,7 @@ public class ImportEntryWindow extends JDialog {
 		this.importDisplayStr = diplayname;
 		this.importPath = importPath;
 		if (importPath.endsWith(File.separator)) {
-			importPath = importPath.substring(0, importPath.length()-2);
+			importPath = importPath.substring(0, importPath.length() - 2);
 		}
 		this.callingWindow = modImportWindow;
 		setupWindow(modImportWindow);
@@ -212,7 +212,7 @@ public class ImportEntryWindow extends JDialog {
 			modDescField.setText(tpmi.getModdescription());
 			setTitle("Importing " + tpmi.getModname());
 			//Check if an update telemetry is required
-			MountFile mf = new MountFile(importPath + "CookedPCConsole" + File.separator + "Mount.dlc");
+			MountFile mf = new MountFile(ModManager.appendSlash(importPath) + "CookedPCConsole" + File.separator + "Mount.dlc");
 			if (mf.getMountPriority() != tpmi.getMountPriority()) {
 				//TELEMETRY UPDATE
 				telemetryCheckbox.setText("Send updated mod info to ME3Tweaks");
@@ -425,6 +425,7 @@ public class ImportEntryWindow extends JDialog {
 
 	/**
 	 * Validates input into the Mod Import Window
+	 * 
 	 * @return
 	 */
 	public boolean inputValidate() {

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -80,9 +80,9 @@ import com.sun.jna.win32.W32APIOptions;
 
 public class ModManager {
 
-	public static final String VERSION = "4.5.2";
-	public static long BUILD_NUMBER = 70L;
-	public static final String BUILD_DATE = "3/11/2017";
+	public static final String VERSION = "4.5.3";
+	public static long BUILD_NUMBER = 71L;
+	public static final String BUILD_DATE = "3/30/2017";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
@@ -118,6 +118,7 @@ public class ModManager {
 	public static String THIRD_PARTY_MOD_JSON;
 	protected final static int COALESCED_MAGIC_NUMBER = 1836215654;
 	public final static String[] KNOWN_GUI_CUSTOMDLC_MODS = { "DLC_CON_XBX", "DLC_CON_UIScaling", "DLC_CON_UIScaling_Shared" };
+	public static final String[] SUPPORTED_GAME_LANGAUGES = { "INT", "ESN", "DEU", "ITA", "FRA", "RUS", "POL", "JPN", "ITA" };
 
 	public static final class Lock {
 	} //threading wait() and notifyall();
@@ -500,8 +501,7 @@ public class ModManager {
 			new ModManagerWindow(isUpdate);
 		} catch (Throwable e) {
 			ModManager.debugLogger.writeErrorWithException("Uncaught throwable during runtime:", e);
-			JOptionPane.showMessageDialog(null,
-					"Mod Manager had an uncaught exception during runtime:\n" + e.getMessage() + "\nPlease report this to FemShep.",
+			JOptionPane.showMessageDialog(null, "Mod Manager had an uncaught exception during runtime:\n" + e.getMessage() + "\nPlease report this to FemShep.",
 					"Mod Manager has crashed", JOptionPane.ERROR_MESSAGE);
 		}
 	}

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -82,7 +82,7 @@ public class ModManager {
 
 	public static final String VERSION = "4.5.2";
 	public static long BUILD_NUMBER = 70L;
-	public static final String BUILD_DATE = "3/10/2017";
+	public static final String BUILD_DATE = "3/11/2017";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
@@ -189,13 +189,15 @@ public class ModManager {
 					}
 				}
 
+				debugLogger.writeMessage("--------Mod Manager Init--------");
+
 				String verString = settingsini.get("Settings", "initialmodmanagerversionbuild");
 				if (verString == null || verString.equals("")) {
 					settingsini.put("Settings", "initialmodmanagerversionbuild", "Before " + ModManager.VERSION + "-b" + ModManager.BUILD_NUMBER);
 					settingsini.store();
 					debugLogger.writeMessage("me3cmm.ini was created before " + ModManager.VERSION + "-b" + ModManager.BUILD_NUMBER);
 				} else {
-					debugLogger.writeMessage("me3cmm.ini was created by Mod Manager " + ModManager.VERSION + "-b" + ModManager.BUILD_NUMBER + ".");
+					debugLogger.writeMessage("me3cmm.ini was created by Mod Manager " + verString);
 				}
 
 				// .NET encforcement check
@@ -499,7 +501,8 @@ public class ModManager {
 		} catch (Throwable e) {
 			ModManager.debugLogger.writeErrorWithException("Uncaught throwable during runtime:", e);
 			JOptionPane.showMessageDialog(null,
-					"Mod Manager had an uncaught exception during runtime:\n" + e.getMessage() + "\nThis error has been logged if logging was on.\nPlease report this to FemShep.");
+					"Mod Manager had an uncaught exception during runtime:\n" + e.getMessage() + "\nPlease report this to FemShep.",
+					"Mod Manager has crashed", JOptionPane.ERROR_MESSAGE);
 		}
 	}
 

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -80,8 +80,8 @@ import com.sun.jna.win32.W32APIOptions;
 
 public class ModManager {
 
-	public static final String VERSION = "4.5.1 MR1";
-	public static long BUILD_NUMBER = 69L;
+	public static final String VERSION = "4.5.2";
+	public static long BUILD_NUMBER = 70L;
 	public static final String BUILD_DATE = "3/10/2017";
 	public static DebugLogger debugLogger;
 	public static boolean IS_DEBUG = false;

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1258,7 +1258,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 		// MOD TOOLS
 		modMenu = new JMenu("Mod Utils");
-		mountMenu = new JMenu("Manage Custom DLC Mount files");
+		mountMenu = new JMenu("Manage [PLACEHOLDER] Mount files");
 		mountMenu.setVisible(false);
 		modutilsHeader = new JMenuItem("No mod selected");
 		modutilsHeader.setEnabled(false);
@@ -1326,7 +1326,6 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		modMenu.add(modDeltaMenu);
 		modMenu.add(modNoDeltas);
 		modMenu.add(modAlternatesMenu);
-		modMenu.add(mountMenu);
 		modMenu.addSeparator();
 		modMenu.add(modutilsInstallCustomKeybinds);
 		modMenu.add(modutilsInfoEditor);
@@ -1386,6 +1385,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		moddevOfficialDLCManager = new JMenuItem("Official DLC Toggler");
 		moddevOfficialDLCManager.addActionListener(this);
 		moddevOfficialDLCManager.setToolTipText("Allows you to quickly enable or disable official BioWare DLC for testing");
+		devMenu.add(mountMenu);
 		devMenu.add(modDevStarterKit);
 		devMenu.add(moddevOfficialDLCManager);
 		devMenu.add(moddevUpdateXMLGenerator);
@@ -2824,6 +2824,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 				if (selectedMod.containsCustomDLCJob()) {
 					mountMenu.setVisible(true);
+					mountMenu.setText(selectedMod.getModName()+" Mount.dlc files");
 					for (ModJob job : selectedMod.getJobs()) {
 						if (job.getJobType() == ModJob.CUSTOMDLC) {
 							// has custom dlc task

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -2854,17 +2854,20 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				}
 
 				modAlternatesMenu.removeAll();
-				if (selectedMod.getAlternateFiles().size() > 0 || selectedMod.getAlternateCustomDLC().size() > 0) {
-					modAlternatesMenu.setEnabled(true);
-					ArrayList<AlternateFile> alts = selectedMod.getAlternateFiles();
-					ArrayList<AlternateCustomDLC> altdlcs = selectedMod.getAlternateCustomDLC();
-					int numoptions = altdlcs.size() + alts.size();
-					for (ModJob job : selectedMod.getJobs()) {
-						if (job.getJobType() == ModJob.CUSTOMDLC) {
-							continue; //don't parse these
-						}
-						numoptions += job.getAlternateFiles().size();
+				//Count number of alternates
+				ArrayList<AlternateFile> alts = selectedMod.getAlternateFiles();
+				ArrayList<AlternateCustomDLC> altdlcs = selectedMod.getAlternateCustomDLC();
+				int numoptions = altdlcs.size() + alts.size();
+
+				for (ModJob job : selectedMod.getJobs()) {
+					if (job.getJobType() == ModJob.CUSTOMDLC) {
+						continue; //don't parse these
 					}
+					numoptions += job.getAlternateFiles().size();
+				}
+				
+				if (numoptions > 0) {
+					modAlternatesMenu.setEnabled(true);
 					modAlternatesMenu.setText(numoptions + " alternate installation option" + (numoptions != 1 ? "s" : ""));
 					if (numoptions > 0) {
 						modAlternatesMenu.setToolTipText("<html>This mod has " + numoptions + " additional installation configuration" + (numoptions != 1 ? "s" : "") + "</html>");

--- a/src/com/me3tweaks/modmanager/OfficialDLCWindow.java
+++ b/src/com/me3tweaks/modmanager/OfficialDLCWindow.java
@@ -1,0 +1,253 @@
+package com.me3tweaks.modmanager;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.DefaultRowSorter;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableColumnModel;
+
+import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
+import com.me3tweaks.modmanager.objects.ModType;
+import com.me3tweaks.modmanager.objects.ThirdPartyModInfo;
+import com.me3tweaks.modmanager.ui.CustomDLCManagerToggleButtonColumn;
+
+public class OfficialDLCWindow extends JDialog {
+
+	protected static final int COL_FOLDER = 0;
+	protected static final int COL_NAME = 1;
+	public static final int COL_MOUNT_PRIORITY = 2;
+	protected static final int COL_TOGGLE = 3;
+	private String bioGameDir;
+	private ArrayList<OfficialDLCInfo> installedOfficialDLCList = new ArrayList<OfficialDLCInfo>();
+	boolean somethingChanged;
+
+	public OfficialDLCWindow(String bioGameDir) {
+		ModManager.debugLogger.writeMessage("Opening Official DLC window.");
+		this.bioGameDir = bioGameDir;
+		setupWindow();
+		setLocationRelativeTo(ModManagerWindow.ACTIVE_WINDOW);
+		setVisible(true);
+	}
+
+	private void setupWindow() {
+		JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW,
+				"Items in here are only for mod developers and users testing different game configurations.\nIf you don't know what you're doing, don't use this tool!",
+				"DEVELOPERS ONLY", JOptionPane.WARNING_MESSAGE);
+		setIconImages(ModManager.ICONS);
+		setTitle("Official DLC Manager");
+		setModal(true);
+		setPreferredSize(new Dimension(800, 600));
+		setMinimumSize(new Dimension(700, 350));
+
+		JPanel panel = new JPanel(new BorderLayout());
+		JLabel infoLabel = new JLabel(
+				"<html><center>Installed Official DLCs<br>Disabled DLCs start with an x. Mass Effect 3 only loads DLCs that start with DLC_.</center></html>");
+		infoLabel.setHorizontalAlignment(SwingConstants.CENTER);
+		panel.add(infoLabel, BorderLayout.NORTH);
+
+		File mainDlcDir = new File(ModManager.appendSlash(bioGameDir) + "DLC/");
+		String[] directories = mainDlcDir.list(new FilenameFilter() {
+			@Override
+			public boolean accept(File current, String name) {
+				System.out.println(name);
+				return new File(current, name).isDirectory() && (name.toLowerCase().startsWith("xdlc_") || name.toLowerCase().startsWith("dlc_"));
+			}
+		});
+
+		for (String dir : directories) {
+			String checkDir = dir;
+			if (checkDir.startsWith("xDLC_")) {
+				checkDir = checkDir.substring(1);
+			}
+			if (!ModType.isKnownDLCFolder(checkDir)) {
+				continue;
+			} else {
+				OfficialDLCInfo odi = new OfficialDLCInfo(dir);
+				installedOfficialDLCList.add(odi); //add unmodified
+			}
+		}
+
+		//TABLE
+		Collections.sort(installedOfficialDLCList);
+		Collections.reverse(installedOfficialDLCList);
+
+		Object[][] data = new Object[installedOfficialDLCList.size()][4];
+		int datasize = installedOfficialDLCList.size();
+
+		for (int i = 0; i < datasize; i++) {
+			OfficialDLCInfo odi = installedOfficialDLCList.get(i);
+			data[i][COL_FOLDER] = odi.getFolderName();
+			data[i][COL_NAME] = odi.getDisplayName();
+			data[i][COL_MOUNT_PRIORITY] = odi.getMountPriority();
+			data[i][COL_TOGGLE] = odi.getFolderName().toLowerCase().startsWith("xdlc_") ? CustomDLCManagerToggleButtonColumn.STR_ENABLE
+					: CustomDLCManagerToggleButtonColumn.STR_DISABLE;
+		}
+
+		Action toggle = new AbstractAction() {
+			public void actionPerformed(ActionEvent e) {
+				if (ModManager.isMassEffect3Running()) {
+					JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed before you can enable or disable DLC.",
+							"MassEffect3.exe is running", JOptionPane.ERROR_MESSAGE);
+					return;
+				}
+				JTable table = (JTable) e.getSource();
+				int modelRow = table.convertRowIndexToModel(Integer.valueOf(e.getActionCommand()));
+				String dlcname = (String) table.getModel().getValueAt(modelRow, COL_FOLDER);
+				String path = ModManager.appendSlash(mainDlcDir.getAbsolutePath() + File.separator + dlcname);
+				ModManager.debugLogger.writeMessage("Toggling Official DLC folder: " + path);
+				String newname = "MM_PLACEHOLDER";
+				boolean disabling = false;
+				if (dlcname.toLowerCase().startsWith("x")) {
+					//Enable
+					newname = dlcname.substring(1);
+					disabling = false;
+				} else {
+					//Disable
+					newname = "x" + dlcname;
+					disabling = true;
+				}
+
+				File currentPath = new File(path);
+				File toggledPath = new File(mainDlcDir.getAbsolutePath() + File.separator + newname);
+				if (currentPath.renameTo(toggledPath)) {
+					table.setValueAt(disabling ? CustomDLCManagerToggleButtonColumn.STR_ENABLE : CustomDLCManagerToggleButtonColumn.STR_DISABLE, modelRow, COL_TOGGLE);
+					table.setValueAt(newname, modelRow, COL_FOLDER);
+					somethingChanged = true;
+				}
+			}
+		};
+		String[] columnNames = { "DLC Folder", "DLC Name", "Mount Priority", "Toggle DLC" };
+		DefaultTableModel model = new DefaultTableModel(data, columnNames);
+		JTable table = new JTable(model) {
+			public boolean isCellEditable(int row, int column) {
+				return column == COL_TOGGLE;
+			}
+
+			@Override
+			public Class<?> getColumnClass(int columnIndex) {
+				if (columnIndex == COL_MOUNT_PRIORITY) {
+					return Short.class;
+				}
+				return getValueAt(0, columnIndex).getClass();
+			}
+		};
+		table.setAutoResizeMode(JTable.AUTO_RESIZE_NEXT_COLUMN);
+
+		TableColumnModel tcm = table.getColumnModel();
+		tcm.getColumn(COL_NAME).setMinWidth(200);
+		tcm.getColumn(COL_MOUNT_PRIORITY).setMaxWidth(150);
+		tcm.getColumn(COL_MOUNT_PRIORITY).setMinWidth(150);
+
+		CustomDLCManagerToggleButtonColumn buttonColumn2 = new CustomDLCManagerToggleButtonColumn(table, toggle, COL_TOGGLE);
+
+		DefaultTableCellRenderer centerRenderer = new DefaultTableCellRenderer();
+		centerRenderer.setHorizontalAlignment(JLabel.CENTER);
+		table.getColumnModel().getColumn(COL_MOUNT_PRIORITY).setCellRenderer(centerRenderer);
+
+		JScrollPane scrollpane = new JScrollPane(table);
+		panel.add(scrollpane, BorderLayout.CENTER);
+
+		//JLabel mpLabel = new JLabel(
+		//		"<html><div style=\"text-align: center;\">Custom DLC will never authorize unless you use a DLC bypass.<br>You can check for Custom DLC conflicts using the Custom DLC Conflict Detector tool in the Mod Management menu.</div></html>",
+		//		SwingConstants.CENTER);
+		//panel.add(mpLabel, BorderLayout.SOUTH);
+		panel.setBorder(new EmptyBorder(5, 5, 5, 5));
+		add(panel);
+		pack();
+		updateRowHeights(table);
+		addWindowListener(new java.awt.event.WindowAdapter() {
+			@Override
+			public void windowClosing(java.awt.event.WindowEvent windowEvent) {
+				if (somethingChanged) {
+					JOptionPane.showMessageDialog(OfficialDLCWindow.this, "The DLC configuration has changed.\nMods will reload to update their configuration.",
+							"Mods require reloading", JOptionPane.INFORMATION_MESSAGE);
+					new ModManagerWindow(false);
+				}
+			}
+		});
+	}
+
+	private class OfficialDLCInfo implements Comparable<OfficialDLCInfo> {
+		private String initialFolderName, displayName;
+		private int mountPriority;
+
+		public OfficialDLCInfo(String dir) {
+			initialFolderName = dir;
+			String realName = dir;
+			if (realName.startsWith("xDLC_")) {
+				realName = realName.substring(1);
+			}
+			ThirdPartyModInfo tpmi = ME3TweaksUtils.getThirdPartyModInfo(realName);
+			if (tpmi != null) {
+				displayName = tpmi.getModname();
+				mountPriority = tpmi.getMountPriority();
+			} else {
+				displayName = "Lookup failed";
+				mountPriority = 0;
+			}
+		}
+
+		public String getFolderName() {
+			return initialFolderName;
+		}
+
+		public void setFolderName(String folderName) {
+			this.initialFolderName = folderName;
+		}
+
+		public String getDisplayName() {
+			return displayName;
+		}
+
+		public void setDisplayName(String displayName) {
+			this.displayName = displayName;
+		}
+
+		public int getMountPriority() {
+			return mountPriority;
+		}
+
+		public void setMountPriority(int mountPriority) {
+			this.mountPriority = mountPriority;
+		}
+
+		@Override
+		public int compareTo(OfficialDLCInfo other) {
+			return mountPriority > other.mountPriority ? +1 : mountPriority < other.mountPriority ? -1 : 0;
+		}
+
+	}
+
+	private void updateRowHeights(JTable table) {
+		for (int row = 0; row < table.getRowCount(); row++) {
+			int rowHeight = table.getRowHeight();
+
+			for (int column = 0; column < table.getColumnCount(); column++) {
+				Component comp = table.prepareRenderer(table.getCellRenderer(row, column), row, column);
+				rowHeight = Math.max(rowHeight, comp.getPreferredSize().height);
+			}
+
+			table.setRowHeight(row, rowHeight);
+		}
+	}
+}

--- a/src/com/me3tweaks/modmanager/StarterKitWindow.java
+++ b/src/com/me3tweaks/modmanager/StarterKitWindow.java
@@ -453,7 +453,7 @@ public class StarterKitWindow extends JDialog {
 			ModManager.ExportResource("/Mount.dlc", cookedPath + "Mount.dlc");
 			String coalpath = cookedPath + "Default_DLC_MOD_" + internaldlcname + ".bin";
 			ModManager.ExportResource("/Default_DLC_MOD_StarterKit.bin", coalpath);
-			String[] langs = { "INT", "DEU", "ESN", "FRA", "POL", "RUS" };
+			String[] langs = ModManager.SUPPORTED_GAME_LANGAUGES;
 
 			for (String lang : langs) {
 				publish(new ThreadCommand("SET_DIALOG_TEXT", "Updating TLK for " + lang));
@@ -481,6 +481,12 @@ public class StarterKitWindow extends JDialog {
 					break;
 				case "POL":
 					langcode = "pl-pl";
+					break;
+				case "ITA":
+					langcode = "it-it";
+					break;
+				case "JPN":
+					langcode = "ja"; //Unsure, could not find a file to verify this with...
 					break;
 				}
 

--- a/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ME3TweaksUtils.java
@@ -647,6 +647,11 @@ public class ME3TweaksUtils {
 		return "Unknown Mod";
 	}
 	
+	/**
+	 * Retreives information about a 3rd party mod based on its folder name. Returns null if not in the database.
+	 * @param customdlcfoldername Folder to search against
+	 * @return
+	 */
 	public static ThirdPartyModInfo getThirdPartyModInfo(String customdlcfoldername) {
 		if (ModManager.THIRD_PARTY_MOD_JSON == null) {
 			return null;

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -553,6 +553,8 @@ public class ModMakerCompilerWindow extends JDialog {
 			return "BIOGame_RUS.tlk";
 		case "POL":
 			return "BIOGame_POL.tlk";
+		case "JPN":
+			return "BIOGame_JPN.tlk";
 		default:
 			ModManager.debugLogger.writeMessage("UNRECOGNIZED TLK FILE: " + shortTLK);
 			return null;
@@ -1656,7 +1658,7 @@ public class ModMakerCompilerWindow extends JDialog {
 				if (reqcoal.equals("Coalesced.bin")) {
 					ModManager.debugLogger.writeMessage("Coalesced pass: Checking for TLK files");
 					//it is basegame. copy the tlk files!
-					String[] tlkFiles = { "INT", "ESN", "DEU", "ITA", "FRA", "RUS", "POL" };
+					String[] tlkFiles = ModManager.SUPPORTED_GAME_LANGAUGES;
 					for (String tlkFilename : tlkFiles) {
 						File compiledTLKFile = new File(ModManager.getCompilingDir() + "tlk\\" + "BIOGame_" + tlkFilename + ".tlk");
 						if (!compiledTLKFile.exists()) {
@@ -1689,7 +1691,7 @@ public class ModMakerCompilerWindow extends JDialog {
 					//}
 
 					//tlk, if they exist.
-					String[] tlkFiles = { "INT", "ESN", "DEU", "ITA", "FRA", "RUS", "POL" };
+					String[] tlkFiles = ModManager.SUPPORTED_GAME_LANGAUGES;
 					for (String tlkFilename : tlkFiles) {
 						File basegameTLKFile = new File(compCoalDir + "\\BIOGame_" + tlkFilename + ".tlk");
 						if (basegameTLKFile.exists()) {

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerEntryWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerEntryWindow.java
@@ -57,6 +57,7 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 	private static final String FRENCH = "French";
 	private static final String ITALIAN = "Italian";
 	private static final String GERMAN = "German";
+	private static final String JAPANESE = "Japanese";
 	private static final int DIALOG_WIDTH = 400;
 	private static final int DIALOG_HEIGHT = 245;
 	JLabel infoLabel;
@@ -64,7 +65,7 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 	JTextField codeField;
 	String biogameDir;
 	private JComboBox<String> languageChoices;
-	private String[] languages = { ALL_LANG, ENGLISH, RUSSIAN, SPANISH, POLISH, FRENCH, ITALIAN, GERMAN };
+	private String[] languages = { ALL_LANG, ENGLISH, RUSSIAN, SPANISH, POLISH, FRENCH, ITALIAN, GERMAN, JAPANESE };
 	boolean hasDLCBypass = false;
 	ModManagerWindow callingWindow;
 	private JButton makeModButton;
@@ -373,6 +374,7 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 			languagesToCompile.add("FRA");
 			languagesToCompile.add("ITA");
 			languagesToCompile.add("DEU");
+			languagesToCompile.add("JPN");
 			break;
 		case ENGLISH:
 			languagesToCompile.add("INT");
@@ -395,6 +397,8 @@ public class ModMakerEntryWindow extends JDialog implements ActionListener {
 		case GERMAN:
 			languagesToCompile.add("DEU");
 			break;
+		case JAPANESE:
+			languagesToCompile.add("JPN");
 		default:
 			break;
 		}

--- a/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
@@ -197,7 +197,7 @@ public class AllModsUpdateWindow extends JDialog {
 					}
 					String updatetext = upackages.size() + " mod" + (upackages.size() == 1 ? " has" : "s have") + " available updates on ME3Tweaks:\n";
 					for (UpdatePackage upackage : upackages) {
-						ModManager.debugLogger.writeMessage("Parsing upackage " + upackage.getServerModName() + ", Preparing user prompt.");
+						ModManager.debugLogger.writeMessage("Parsing upackage " + upackage.getServerModName() + "");
 						updatetext += getVersionUpdateString(upackage);
 					}
 					if (upackages.size() > 1) {
@@ -205,6 +205,7 @@ public class AllModsUpdateWindow extends JDialog {
 					} else {
 						updatetext += "Update this mod?";
 					}
+					ModManager.debugLogger.writeMessage("Prompting users for updates");
 					int result = JOptionPane.showConfirmDialog(AllModsUpdateWindow.this, updatetext, "Mod updates available", JOptionPane.YES_NO_OPTION);
 					switch (result) {
 					case JOptionPane.YES_OPTION:
@@ -222,7 +223,10 @@ public class AllModsUpdateWindow extends JDialog {
 					operationLabel.setText("Updating mods from ME3Tweaks");
 					break;
 				case "MANIFEST_DOWNLOADED":
-					statusLabel.setText("Calculating files to update");
+					statusLabel.setText("Calculating files for update");
+					break;
+				case "CALCULATING_PROGRESS" :
+					statusLabel.setText(obj.getMessage());
 					break;
 				case "NUM_REMAINING":
 					Integer i = (Integer) obj.getData();
@@ -314,6 +318,10 @@ public class AllModsUpdateWindow extends JDialog {
 
 		public void setManifestDownloaded() {
 			publish(new ThreadCommand("MANIFEST_DOWNLOADED"));
+		}
+		
+		public void setUpdateCalculationProgress(int done, int total) {
+			publish(new ThreadCommand("CALCULATING_PROGRESS", "Calculating files for update ["+done+"/"+total+"]"));
 		}
 
 		public void publishUpdate(String update) {

--- a/src/com/me3tweaks/modmanager/objects/ThirdPartyModInfo.java
+++ b/src/com/me3tweaks/modmanager/objects/ThirdPartyModInfo.java
@@ -74,7 +74,7 @@ public class ThirdPartyModInfo {
 		this.modsite = modsite;
 	}
 
-	public short getMountpriority() {
+	public short getMountPriority() {
 		return mountpriority;
 	}
 

--- a/src/com/me3tweaks/modmanager/ui/CustomDLCManagerToggleButtonColumn.java
+++ b/src/com/me3tweaks/modmanager/ui/CustomDLCManagerToggleButtonColumn.java
@@ -1,0 +1,239 @@
+package com.me3tweaks.modmanager.ui;
+
+import java.awt.*;
+import java.awt.event.*;
+
+import javax.swing.*;
+import javax.swing.border.*;
+import javax.swing.table.*;
+
+/**
+ * The ButtonColumn class provides a renderer and an editor that looks like a
+ * JButton. The renderer and editor will then be used for a specified column in
+ * the table. The TableModel will contain the String to be displayed on the
+ * button.
+ *
+ * The button can be invoked by a mouse click or by pressing the space bar when
+ * the cell has focus. Optionally a mnemonic can be set to invoke the button.
+ * When the button is invoked the provided Action is invoked. The source of the
+ * Action will be the table. The action command will contain the model row
+ * number of the button that was clicked.
+ *
+ */
+public class CustomDLCManagerToggleButtonColumn extends AbstractCellEditor implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
+	private static final Color COLOR_ENABLE = new Color(204, 43, 22);
+	public static final String STR_ENABLE = "<html><center>DLC is disabled<br>Click to enable DLC</center></html>";
+	private static final Color COLOR_DISABLE = new Color(60, 219, 39);
+	public static final String STR_DISABLE = "<html><center>DLC is enabled<br>Click to disable DLC</center></html>";
+
+	private JTable table;
+	private Action action;
+	private int mnemonic;
+	private Border originalBorder;
+	private Border focusBorder;
+
+	private JGradientButton renderButton;
+	private JGradientButton editButton;
+	private Object editorValue;
+	private boolean isButtonColumnEditor;
+	private DefaultTableCellRenderer defaultCell;
+
+	/**
+	 * Create the ButtonColumn to be used as a renderer and editor. The renderer
+	 * and editor will automatically be installed on the TableColumn of the
+	 * specified column.
+	 *
+	 * @param table
+	 *            the table containing the button renderer/editor
+	 * @param action
+	 *            the Action to be invoked when the button is invoked
+	 * @param column
+	 *            the column to which the button renderer/editor is added
+	 */
+	public CustomDLCManagerToggleButtonColumn(JTable table, Action action, int column) {
+		this.table = table;
+		this.action = action;
+		defaultCell = new DefaultTableCellRenderer();
+		defaultCell.setHorizontalAlignment(JLabel.CENTER);
+		renderButton = new JGradientButton();
+		editButton = new JGradientButton();
+		editButton.setFocusPainted(false);
+		editButton.addActionListener(this);
+		originalBorder = editButton.getBorder();
+		setFocusBorder(new LineBorder(Color.BLUE));
+
+		TableColumnModel columnModel = table.getColumnModel();
+		columnModel.getColumn(column).setCellRenderer(this);
+		columnModel.getColumn(column).setCellEditor(this);
+		table.addMouseListener(this);
+	}
+
+	/**
+	 * Get foreground color of the button when the cell has focus
+	 *
+	 * @return the foreground color
+	 */
+	public Border getFocusBorder() {
+		return focusBorder;
+	}
+
+	/**
+	 * The foreground color of the button when the cell has focus
+	 *
+	 * @param focusBorder
+	 *            the foreground color
+	 */
+	public void setFocusBorder(Border focusBorder) {
+		this.focusBorder = focusBorder;
+		editButton.setBorder(focusBorder);
+	}
+
+	public int getMnemonic() {
+		return mnemonic;
+	}
+
+	/**
+	 * The mnemonic to activate the button when the cell has focus
+	 *
+	 * @param mnemonic
+	 *            the mnemonic
+	 */
+	public void setMnemonic(int mnemonic) {
+		this.mnemonic = mnemonic;
+		renderButton.setMnemonic(mnemonic);
+		editButton.setMnemonic(mnemonic);
+	}
+
+	@Override
+	public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+		if (value == null) {
+			editButton.setText("");
+			editButton.setIcon(null);
+		} else if (value instanceof Icon) {
+			editButton.setText("");
+			editButton.setIcon((Icon) value);
+		} else {
+			editButton.setText(value.toString());
+			editButton.setIcon(null);
+		}
+
+		this.editorValue = value;
+		return editButton;
+	}
+
+	@Override
+	public Object getCellEditorValue() {
+		return editorValue;
+	}
+
+	//
+	//  Implement TableCellRenderer interface
+	//
+	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+		if (value == null) {
+			return defaultCell;
+		}
+		if (value instanceof String) {
+			defaultCell.setText("");
+			defaultCell.setBackground(null);
+		}
+		if (isSelected) {
+			renderButton.setForeground(table.getSelectionForeground());
+			if (value.toString().toLowerCase().contains(STR_DISABLE.toLowerCase())) {
+				renderButton.setBackground(COLOR_DISABLE.darker());
+			} else if (value.toString().toLowerCase().contains(STR_ENABLE.toLowerCase())) {
+				renderButton.setBackground(COLOR_ENABLE.darker());
+			} else {
+				renderButton.setBackground(UIManager.getColor("Button.background"));
+			}
+		} else {
+			renderButton.setForeground(table.getForeground());
+			if (value.toString().toLowerCase().contains(STR_DISABLE.toLowerCase())) {
+				renderButton.setBackground(COLOR_DISABLE);
+			} else if (value.toString().toLowerCase().contains(STR_ENABLE.toLowerCase())) {
+				renderButton.setBackground(COLOR_ENABLE);
+			} else {
+				renderButton.setBackground(UIManager.getColor("Button.background"));
+			}
+		}
+
+		if (hasFocus) {
+			renderButton.setBorder(focusBorder);
+		} else {
+			renderButton.setBorder(originalBorder);
+		}
+		if (value instanceof Icon) {
+			renderButton.setText("");
+			renderButton.setIcon((Icon) value);
+		} else {
+			renderButton.setText(value.toString());
+			renderButton.setIcon(null);
+		}
+
+		return renderButton;
+	}
+
+	//
+	//  Implement ActionListener interface
+	//
+	/*
+	 * The button has been pressed. Stop editing and invoke the custom Action
+	 */
+	public void actionPerformed(ActionEvent e) {
+		int row = table.convertRowIndexToModel(table.getEditingRow());
+		fireEditingStopped();
+
+		//  Invoke the Action
+
+		ActionEvent event = new ActionEvent(table, ActionEvent.ACTION_PERFORMED, "" + row);
+		action.actionPerformed(event);
+	}
+
+	//
+	//  Implement MouseListener interface
+	//
+	/*
+	 * When the mouse is pressed the editor is invoked. If you then then drag
+	 * the mouse to another cell before releasing it, the editor is still
+	 * active. Make sure editing is stopped when the mouse is released.
+	 */
+	public void mousePressed(MouseEvent e) {
+		if (table.isEditing() && table.getCellEditor() == this)
+			isButtonColumnEditor = true;
+	}
+
+	public void mouseReleased(MouseEvent e) {
+		if (isButtonColumnEditor && table.isEditing())
+			table.getCellEditor().stopCellEditing();
+
+		isButtonColumnEditor = false;
+	}
+
+	public void mouseClicked(MouseEvent e) {
+	}
+
+	public void mouseEntered(MouseEvent e) {
+	}
+
+	public void mouseExited(MouseEvent e) {
+	}
+
+	private final class JGradientButton extends JButton {
+		private JGradientButton() {
+			super();
+			setContentAreaFilled(false);
+		}
+
+		@Override
+		protected void paintComponent(Graphics g) {
+			Graphics2D g2 = (Graphics2D) g.create();
+			g2.setPaint(new GradientPaint(new Point(0, 0), getBackground(), new Point(0, getHeight() / 3), Color.WHITE));
+			g2.fillRect(0, 0, getWidth(), getHeight() / 3);
+			g2.setPaint(new GradientPaint(new Point(0, getHeight() / 3), Color.WHITE, new Point(0, getHeight()), getBackground()));
+			g2.fillRect(0, getHeight() / 3, getWidth(), getHeight());
+			g2.dispose();
+
+			super.paintComponent(g);
+		}
+	}
+}


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 4.5.2 Build 70
This is a feature release build that adds some DLC togglers and fixes a few bugs.

## New Features
 - FOR DEVELOPERS: Official DLC Toggler, available in the Tools > Mod Development menu. Allows you to quickly and easily turn official bioware DLC on and off so you can test the compatibility
 of your mod.

![dlctoggler](https://cloud.githubusercontent.com/assets/2738836/23829235/157857e0-06aa-11e7-910c-4c0c98aa967c.gif)

## Changed Features
 - The mount flag in the custom DLC window is now gone, and has been replaced with a button that toggles the state of the DLC.
 - Custom DLC window only show Custom DLCs - if you disable an official dlc by preceeding it with x, it won't show up there still. It will still show up if you preceed it with anything else.
![custdlctoggler](https://cloud.githubusercontent.com/assets/2738836/23829310/741da5d2-06ac-11e7-9dbd-a67027c0c77c.gif)


## Bug Fixes
 - altdlc specification now works on official headers even if none are on the customdlc header. Previously if you didn't have an altdlc on the customdlc header, it wouldn't be able to show the options for official dlc. (Affected MP Controller Mods)
 - Fix 4.5.1 bug where you could send telemetry data even if we already had the correct info. The path checking the mount file was missing a slash so it wouldn't read.
 - Custom DLC Manager now only removes the row if the DLC is actually deleted. Previously it always deleted the row.
 - Mod Manager logging has been improved. Always improving the logging...