### PR TITLE
Mass Effect 3 Mod Manager 5.0.1 Build 76

### DIFF
--- a/src/com/me3tweaks/modmanager/AutoTocWindow.java
+++ b/src/com/me3tweaks/modmanager/AutoTocWindow.java
@@ -51,7 +51,7 @@ public class AutoTocWindow extends JDialog {
 	 * @param biogameDir
 	 */
 	public AutoTocWindow(String biogameDir) {
-        super(null, Dialog.ModalityType.APPLICATION_MODAL);
+		super(null, Dialog.ModalityType.APPLICATION_MODAL);
 		if (ModManager.isMassEffect3Running()) {
 			JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Mass Effect 3 must be closed in order to run AutoTOC on it.", "MassEffect3.exe is running",
 					JOptionPane.ERROR_MESSAGE);
@@ -78,7 +78,7 @@ public class AutoTocWindow extends JDialog {
 	 *            Directory of biogame. Can be null.
 	 */
 	public AutoTocWindow(Mod mod, int mode, String biogameDir) {
-        super(null, Dialog.ModalityType.APPLICATION_MODAL);
+		super(null, Dialog.ModalityType.APPLICATION_MODAL);
 		this.mode = mode;
 		this.mod = mod;
 		updatedGameTOCs = new HashMap<String, String>();
@@ -174,15 +174,17 @@ public class AutoTocWindow extends JDialog {
 						return true; //skip, this is done AFTER mod has been installed, and will run outside of autotoc window.
 					}
 					ArrayList<String> folders = new ArrayList<>();
+					int tocd = 0;
 					for (String srcFolder : job.getSourceFolders()) {
 						folders.add(mod.getModPath() + srcFolder);
+						tocd++;
 					}
 					ProcessResult pr = ModManager.runAutoTOCOnFolders(folders);
 					int returncode = pr.getReturnCode();
 					if (returncode != 0 || pr.hadError()) {
 						ModManager.debugLogger.writeError("Command line AutoTOC did not return with code 0! An error has occured.");
 					} else {
-						completed.incrementAndGet();
+						completed.addAndGet(tocd);
 						ModManager.debugLogger
 								.writeMessage("[" + job.getJobName() + "]Number of completed tasks: " + completed + ", num left to do: " + (numtoc - completed.get()));
 						publish(Integer.toString(completed.get()));
@@ -255,14 +257,6 @@ public class AutoTocWindow extends JDialog {
 					commandBuilder.add(tocPath);
 					commandBuilder.add("--tocupdates");
 
-					/*
-					 * for (AbstractMap.SimpleEntry<String, Long> tocEntryMap :
-					 * batchJob.getNameSizePairs()) {
-					 * commandBuilder.add(tocEntryMap.getKey()); //internal
-					 * filename (if in DLC)
-					 * commandBuilder.add(Long.toString(tocEntryMap.getValue()))
-					 * ; }
-					 */
 					ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Performing a batch TOC update on the following files:\n");
 					String str = "";
 					int numinbatch = 0;
@@ -297,7 +291,6 @@ public class AutoTocWindow extends JDialog {
 				if (job.getFilesToReplace().size() == 0) {
 					return true;
 				}
-
 				return false;
 			}
 		}

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -1669,7 +1669,8 @@ public class ModManager {
 		File bink32 = new File(gamedir.toString() + "\\Binaries\\Win32\\binkw32.dll");
 		File bink23 = new File(gamedir.toString() + "\\Binaries\\Win32\\binkw23.dll");
 		try {
-			String[] asiBinkHashes = { "65eb0d2e5c3ccb1cdab5e48d1a9d598d" };
+			// Original ASI hash, July 8 2017 v3 hash
+			String[] asiBinkHashes = { "65eb0d2e5c3ccb1cdab5e48d1a9d598d", "bc37adee806059822c972b71df36775d" }; 
 			ArrayList<String> asihashlist = new ArrayList<>(Arrays.asList(asiBinkHashes));
 			String binkhash = MD5Checksum.getMD5Checksum(bink32.toString());
 			if (asihashlist.contains(binkhash) && bink23.exists()) {


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 5.0.1 CHECKPOINT
This is a minor improvement release that complements a few features and fixes some bugs.

Note: This build was soaktested, but was withdrawn. Only a few users saw it.

# Changed Features
 - Mixins will now attempt a secondary fetch if the primary one fails due to DLC missing or an incorrect size. These file will be pulled from backups - for example, say you've already installed a mod, if the file size is not correct (E.g. a finalizer, has textures installed, etc), the file can be pulled from Mod Manager backups instead which should be vanilla.
 - The binkw32 ASI bypass dll has been updated. This fixes a potential crash issue that could occur when loading ASIs. Installing the loader now requires Visual C++ 2015 x86 (or 2017 x86 as they are compatible). A download will start if one is not found. [Thanks to ErikJS for fixing it](https://github.com/Erik-JS/masseffect-binkw32/issues/12).
 - Cached mixin files that are not the right size are now deleted automatically, rather than kept and prompting for a deletion. This coupled with the secondary file fetch makes it more reliable with less dialogs for the user.
 - The game database window will close when the update is complete. I've seen a few reports around the web that the window was confusing as the button was still clickable.

# Bugfixes
 - Mixin installation will now pause if an error occurs, rather than throw 9000 dialogs all at once - now you can click through them individually like it should have been.
 - Java 9 compatibility has been improved. Older builds will *not* properly work on Java 9 when it is released in a few months due to them moving some classes to Java Enterprise Edition.
 - Mixin installation window looks better, it used to be cramped for some reason, now it is the correct height and width.
 - Requires command line tools v22 - fixes issues dumping only specific items in pcc's with SWFs and Coalesced values
 - (POST CHECKPOINT): Mod Deployment would not account for Alternate Custom DLC. It now properly stages the mod.
 - (POST CHECKPOINT): The binkw32 ASI hash list has been updated, so it will not continuously think the updated ASI is not installed.

# Internal only
 - Some of the TLK code has been changed for some work I am doing on some of my mods. This code (you can see in some of the commits below) is not used by any part of Mod Manager.