### PR TITLE
Mass Effect 3 Mod Manager 5.0.2 Build 77

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -25,6 +25,6 @@
 	</classpathentry>
 	<classpathentry kind="lib" path="libraries/jna-4.4.0.jar"/>
 	<classpathentry kind="lib" path="libraries/jna-platform-4.4.0.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/Java 8 32-bit"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/Java 8 64-bit"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/com/me3tweaks/modmanager/ModImportArchiveWindow.java
+++ b/src/com/me3tweaks/modmanager/ModImportArchiveWindow.java
@@ -383,6 +383,7 @@ public class ModImportArchiveWindow extends JDialog {
 			this.archiveFilePath = archiveFilePath;
 			this.modsToImport = modsToImport;
 			descriptionArea.setText("Importing mods into Mod Manager...");
+			progressBar.setIndeterminate(true);
 			browseButton.setEnabled(false);
 			ModManager.debugLogger.writeMessage("[IMPORTWORKER] Starting ImportWorker. The following mods will be extracted: ");
 			for (CompressedMod cm : modsToImport) {
@@ -401,6 +402,7 @@ public class ModImportArchiveWindow extends JDialog {
 			for (ThreadCommand command : commands) {
 				switch (command.getCommand()) {
 				case "PROGRESS_UPDATE":
+					progressBar.setIndeterminate(false);
 					progressBar.setValue(Integer.parseInt((String) command.getMessage()));
 					break;
 				case "SIDELOAD_OR_NEW_PROMPT":

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -77,12 +77,12 @@ import com.sun.jna.platform.win32.WinReg;
 import com.sun.jna.win32.W32APIOptions;
 
 public class ModManager {
-	public static boolean IS_DEBUG = true;
+	public static boolean IS_DEBUG = false;
 	public final static boolean FORCE_32BIT_MODE = false; //set to true to force it to think it is running 32-bit for (most things)
 
 	public static final String VERSION = "5.0.2";
 	public static long BUILD_NUMBER = 77L;
-	public static final String BUILD_DATE = "7/16/2017";
+	public static final String BUILD_DATE = "7/18/2017";
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static DebugLogger debugLogger;
 	public static boolean logging = false;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -56,7 +56,6 @@ import org.ini4j.Wini;
 import org.w3c.dom.Document;
 
 import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
-import com.me3tweaks.modmanager.modmaker.ModMakerCompilerWindow;
 import com.me3tweaks.modmanager.objects.CustomDLC;
 import com.me3tweaks.modmanager.objects.Mod;
 import com.me3tweaks.modmanager.objects.ModList;
@@ -77,14 +76,12 @@ import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinReg;
 import com.sun.jna.win32.W32APIOptions;
 
-import javafx.application.Platform;
-
 public class ModManager {
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public final static boolean FORCE_32BIT_MODE = false; //set to true to force it to think it is running 32-bit for (most things)
 
-	public static final String VERSION = "5.0.1";
-	public static long BUILD_NUMBER = 76L;
+	public static final String VERSION = "5.0.2";
+	public static long BUILD_NUMBER = 77L;
 	public static final String BUILD_DATE = "7/16/2017";
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static DebugLogger debugLogger;
@@ -125,7 +122,6 @@ public class ModManager {
 	protected static boolean COMPRESS_COMPAT_OUTPUT = false;
 
 	public static String MASSEFFECTMODDER_DOWNLOADLINK;
-
 	public static int MASSEFFECTMODDER_LATESTVERSION;
 
 	public static String TIPS_SERVICE_JSON;
@@ -137,6 +133,7 @@ public class ModManager {
 	} //threading wait() and notifyall();
 
 	public static void main(String[] args) {
+
 		loadLogger();
 		boolean emergencyMode = false;
 		boolean isUpdate = false;
@@ -168,17 +165,13 @@ public class ModManager {
 				logging = true;
 				debugLogger.writeMessage("Starting logger. Logger was able to start up with no issues.");
 				debugLogger.writeMessage("Mod Manager version " + ModManager.VERSION + "; Build " + ModManager.BUILD_NUMBER + "; Build Date " + BUILD_DATE);
-				debugLogger.writeMessage("--------Mod Manager Main Startup--------");
-
-				//JVM Check
-				if (!System.getProperty("sun.arch.data.model").equals("32") && !IS_DEBUG) {
-					ModManager.debugLogger.writeError("Running in " + System.getProperty("sun.arch.data.model") + "-bit java!");
-					JOptionPane.showMessageDialog(null,
-							"Mod Manager is tested against 32-bit Java.\nThere are known issues with 64-bit Java with Mod Manager, due to bugs in the JNA library that Mod Manager uses.\n64-bit Java usage is not supported by FemShep - if you have issues I will ask you to install 32-bit java.",
-							"Untested JVM", JOptionPane.ERROR_MESSAGE);
-					//ResourceUtils.openWebpage(new URL("https://java.com/en/download/manual.jsp"));
-					//System.exit(1);
+				debugLogger.writeMessage("JVM can use a maximum of " + ResourceUtils.humanReadableByteCount(Runtime.getRuntime().maxMemory(), true) + " of memory");
+				if (ModManager.isUsingBundledJRE()) {
+					debugLogger.writeMessage("Using bundled 64-bit JRE.");
+				} else {
+					debugLogger.writeMessage("Using system JRE, not the bundled version.");
 				}
+				debugLogger.writeMessage("--------Mod Manager Main Startup--------");
 
 				String verString = settingsini.get("Settings", "initialmodmanagerversionbuild");
 				if (verString == null || verString.equals("")) {
@@ -1670,7 +1663,7 @@ public class ModManager {
 		File bink23 = new File(gamedir.toString() + "\\Binaries\\Win32\\binkw23.dll");
 		try {
 			// Original ASI hash, July 8 2017 v3 hash
-			String[] asiBinkHashes = { "65eb0d2e5c3ccb1cdab5e48d1a9d598d", "bc37adee806059822c972b71df36775d" }; 
+			String[] asiBinkHashes = { "65eb0d2e5c3ccb1cdab5e48d1a9d598d", "bc37adee806059822c972b71df36775d" };
 			ArrayList<String> asihashlist = new ArrayList<>(Arrays.asList(asiBinkHashes));
 			String binkhash = MD5Checksum.getMD5Checksum(bink32.toString());
 			if (asihashlist.contains(binkhash) && bink23.exists()) {
@@ -2560,6 +2553,7 @@ public class ModManager {
 				String memsize = ResourceUtils.humanReadableByteCount(bytecount, false);
 				ModManager.debugLogger.writeMessage("Total memory (including virtual): " + memsize);
 				dictsize = (int) (bytecount / 43 / 1024 / 1024); //MB
+				dictsize = Math.max(dictsize, 256); //avoid out of memory error on 32-bit java
 				ModManager.debugLogger.writeMessage("Chosen dictionary size: " + dictsize + "MB");
 			}
 		}
@@ -2665,5 +2659,31 @@ public class ModManager {
 
 			}
 		}
+	}
+
+	/**
+	 * Checks if Mod Manager is running from the bundled JRE, or an installed
+	 * system one.
+	 * 
+	 * @return true if using the JRE from data/jre-x64. false if using any other
+	 *         JRE.
+	 */
+	public static boolean isUsingBundledJRE() {
+		String jrepath = System.getProperty("java.home");
+		String modmanpath = System.getProperty("user.dir");
+		String relpath = "data\\jre-x64";
+		try {
+			String calculatedRelativePath = ResourceUtils.getRelativePath(jrepath, modmanpath, File.separator);
+			if (calculatedRelativePath.equals(relpath)) {
+				return true;
+			}
+		} catch (Exception e) {
+			return false;
+		}
+		return false;
+	}
+
+	public static String getBundledJREPath() {
+		return getDataDir() + "jre-x64\\";
 	}
 }

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -3028,13 +3028,18 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			chosenPath = new File(chosenPath).getParent();
 			// Check to make sure mod manager folder is not a subset
 			String localpath = System.getProperty("user.dir");
+			ModManager.debugLogger.writeMessage("Checking if biogame directory is a subdirectory of the game: " + chosenPath);
+			ModManager.debugLogger.writeMessage("CMM Directory: " + localpath);
 			try {
-				ResourceUtils.getRelativePath(localpath, chosenPath, File.separator);
-				// common path
-				JOptionPane.showMessageDialog(null,
-						"Mod Manager will not work if it is run from the Mass Effect 3 game directory, or any of its subdirectories.\nMove the Mod Manager folder out of the game directory, as Mod Manager will not work until you do this.",
-						"Invalid Mod Manager Location", JOptionPane.ERROR_MESSAGE);
-				return;
+				String relativePath = ResourceUtils.getRelativePath(localpath, chosenPath, File.separator);
+				if (!relativePath.contains("..")) {
+					ModManager.debugLogger.writeMessage("Relative path detected: " + relativePath);
+					// common path
+					JOptionPane.showMessageDialog(null,
+							"Mod Manager will not work if it is run from the Mass Effect 3 game directory, or any of its subdirectories.\nMove the Mod Manager folder out of the game directory, as Mod Manager will not work until you do this.",
+							"Invalid Mod Manager Location", JOptionPane.ERROR_MESSAGE);
+					return;
+				}
 			} catch (ResourceUtils.PathResolutionException e) {
 				// we're OK
 			}

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -642,7 +642,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			JSONObject latest_object = null;
 			// Check for update
 			try {
-				String update_check_link = "https://me3tweaks.com/modmanager/updatecheck-testing?currentversion=" + ModManager.BUILD_NUMBER;
+				String update_check_link = "https://me3tweaks.com/modmanager/updatecheck?currentversion=" + ModManager.BUILD_NUMBER;
 				String serverJSON = null;
 				try {
 					serverJSON = IOUtils.toString(new URL(update_check_link), StandardCharsets.UTF_8);

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -70,6 +70,8 @@ import javax.swing.event.ListSelectionListener;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ArchUtils;
+import org.apache.commons.lang3.arch.Processor;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.derby.iapi.services.loader.GeneratedMethod;
@@ -392,7 +394,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 
 			if (ModManager.AUTO_UPDATE_MOD_MANAGER && !ModManager.CHECKED_FOR_UPDATE_THIS_SESSION) {
-				checkForModManagerUpdates();
+				JSONObject latestinfo = checkForModManagerUpdates();
+				checkForJREUpdates(latestinfo);
 			}
 			//checkForME3ExplorerUpdates();
 			checkForCommandLineToolUpdates();
@@ -589,12 +592,57 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 		}
 
-		private Void checkForModManagerUpdates() {
+		private void checkForJREUpdates(JSONObject latest_object) {
+			if (!ResourceUtils.is64BitWindows()) {
+				return;
+			}
+
+			if (latest_object == null) {
+				return;
+			}
+
+			String latestjavaexehash = (String) latest_object.get("jre_latest_version");
+
+			if (ModManager.isUsingBundledJRE() || ResourceUtils.is64BitWindows() && ArchUtils.getProcessor().isX86()) {
+				//32-bit JVM on 64-bit windows - should check
+				//I using the bundled x64 JRE  - should check
+				boolean hashMismatch = false;
+				File f = new File(ModManager.getBundledJREPath() + "bin\\java.exe");
+				if (f.exists()) {
+					//get hash
+					String bundledHash = "";
+					try {
+						bundledHash = MD5Checksum.getMD5Checksum(f.getAbsolutePath());
+					} catch (Exception e) {
+						ModManager.debugLogger.writeErrorWithException("Unable to hash java.exe. Due to the significance of this issue, we are not going to attempt a JRE update.",
+								e);
+						return;
+					}
+					if (!bundledHash.equals(latestjavaexehash)) {
+						hashMismatch = true;
+						ModManager.debugLogger.writeMessage("Bundled JRE hash does not match server - likely out of date.");
+					}
+				} else {
+					//doesn't exist - failed hash check
+					hashMismatch = true;
+					ModManager.debugLogger.writeMessage("Bundled JRE does not exist, but we should be using one.");
+				}
+
+				if (hashMismatch) {
+					new UpdateJREAvailableWindow(latest_object);
+				} else {
+					ModManager.debugLogger.writeMessage("No JRE upgrade recommended");
+				}
+			}
+		}
+
+		private JSONObject checkForModManagerUpdates() {
 			labelStatus.setText("Checking for Mod Manager updates");
 			ModManager.debugLogger.writeMessage("Checking for update...");
+			JSONObject latest_object = null;
 			// Check for update
 			try {
-				String update_check_link = "https://me3tweaks.com/modmanager/updatecheck?currentversion=" + ModManager.BUILD_NUMBER;
+				String update_check_link = "https://me3tweaks.com/modmanager/updatecheck-testing?currentversion=" + ModManager.BUILD_NUMBER;
 				String serverJSON = null;
 				try {
 					serverJSON = IOUtils.toString(new URL(update_check_link), StandardCharsets.UTF_8);
@@ -604,17 +652,17 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					ModManager.debugLogger.writeException(e);
 					labelStatus.setText("Error checking for update (check logs)");
 					ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-					return null;
+					return latest_object;
 				}
 				if (serverJSON == null) {
 					ModManager.debugLogger.writeError("No response from server");
 					labelStatus.setText("Updater: No response from server");
 					ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-					return null;
+					return latest_object;
 				}
 
 				JSONParser parser = new JSONParser();
-				JSONObject latest_object = (JSONObject) parser.parse(serverJSON);
+				latest_object = (JSONObject) parser.parse(serverJSON);
 				String buildHash = (String) latest_object.get("build_md5");
 				boolean hashMismatch = false;
 				if (new File("ME3CMM.exe").exists()) {
@@ -656,9 +704,8 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					if (latestCommandLineToolsLink != null) {
 						ModManager.COMMANDLINETOOLS_URL = latestCommandLineToolsLink;
 					}
-					return null;
+					return latest_object;
 				}
-
 				if (latest_build == ModManager.BUILD_NUMBER && !hashMismatch) {
 					// build is same as server version
 					labelStatus.setVisible(true);
@@ -669,7 +716,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					if (latestCommandLineToolsLink != null) {
 						ModManager.COMMANDLINETOOLS_URL = latestCommandLineToolsLink;
 					}
-					return null;
+					return latest_object;
 				}
 
 				ModManager.debugLogger
@@ -724,7 +771,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				ModManager.debugLogger.writeErrorWithException("Error parsing server response:", e);
 			}
 			ModManager.CHECKED_FOR_UPDATE_THIS_SESSION = true;
-			return null;
+			return latest_object;
 		}
 
 		/**
@@ -3598,12 +3645,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 					ModManager.debugLogger.writeMessage("Selected path: " + selectedGamePath);
 					if (currentpath != null && !currentpath.equalsIgnoreCase(selectedGamePath)) {
 						//Update registry key.
-						boolean is64bit = false;
-						if (System.getProperty("os.name").contains("Windows")) {
-							is64bit = (System.getenv("ProgramFiles(x86)") != null);
-						} else {
-							is64bit = (System.getProperty("os.arch").indexOf("64") != -1);
-						}
+						boolean is64bit = ResourceUtils.is64BitWindows();
 						String keypath = is64bit ? "HKLM\\SOFTWARE\\Wow6432Node\\BioWare\\Mass Effect 3" : "HKLM\\SOFTWARE\\BioWare\\Mass Effect 3";
 						ArrayList<String> command = new ArrayList<String>();
 						command.add(ModManager.getCommandLineToolsDir() + "elevate.exe");


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 5.0.2 Build 77
This is a QOL and bugfix update for Mod Manager.

Note: 5.0.1 was only soaktested, but never released beyond a few users when other issues came up. To see the changelog for 5.0.1, see https://github.com/Mgamerz/me3modmanager/pull/49.

## Changed Features
 - Mod Manager is no longer 32-bit JVM preferred - I am finding some compressed mods crash the 32-bit JVM as it runs out of memory, especially with 7z archives. As such I have removed the 32-bit preferred dialog and am switching the EXE to prefer 64-bit again.
   - You don't need to install a 64-bit JRE (unless you really want to). I know many users don't like having to install Oracle's... "value enhanced content" so I've bundled a JRE with new Mod Manager installations. This does not install onto your system, it just downloads like a portable application transparently and then restarts Mod Manager and uses that instead - after installation, if you don't use java for anything else you can uninstall it. 
   - This JRE will be updated to JRE 9 in the future. I have built a JRE updater into Mod Manager so I can push a new JRE I have tested against. JRE 9 (when released) should make Mod Manager much more usable on high-dpi screens.
    - When this update (5.0.2) is applied, if you are on 64-bit windows but have a 32-bit JVM, Mod Manager will download the 64-bit MM JRE and install it to the data directory, and then restart to use it.
    - While I have not tested, if you nuke the data/jre-x64 folder you can use the system JRE. This means, in 7 years, you can *maybe* still run Mod Manager on modern Windows since the bundled JRE probably won't work on Windows 10 then.
    - **But what about those "bugs in 64-bit versions!" messages!?** - well, the JVM can outright crash (outside of my control) or we can try to work through the bugs if they come up. You don't have to accept the JRE update. This is not something I really wanted to do, I did not see 32-bit java being an issue until I tried to extract a large mod.
 - Update Available now shows how many MB the update is when downloading

32-bit java is still supported, but I no longer will be testing against it. If you are running 32-bit windows, you obviously will have to use 32-bit java still - on fresh downloads, you'll have to install a 32-bit JRE as I don't bundle a 32-bit JRE. I expect the 32-bit pool of users is pretty small these days.

## Bugfixes
 - Setting the biogame directory manually with the game on the same partition as ME3MM will now work and not throw the "can't be a subdirectory of the game" message