### PR TITLE
Mass Effect 3 Mod Manager 5.0.5 Build 80

### DIFF
--- a/src/com/me3tweaks/modmanager/AutoTocWindow.java
+++ b/src/com/me3tweaks/modmanager/AutoTocWindow.java
@@ -57,7 +57,8 @@ public class AutoTocWindow extends JDialog {
 					JOptionPane.ERROR_MESSAGE);
 			return;
 		}
-		setupWindow("Updating Basegame and DLC TOC files");
+		setupWindow("<center>Updating Basegame and DLC TOC files<br>This may take some time</center>");
+		progressBar.setStringPainted(false);
 		updatedGameTOCs = new HashMap<String, String>();
 		ModManager.debugLogger.writeMessage("===Starting AutoTOC. Mode: GAME-WIDE ===");
 		this.setTitle("Mod Manager AutoTOC");
@@ -86,9 +87,11 @@ public class AutoTocWindow extends JDialog {
 		switch (mode) {
 		case LOCALMOD_MODE:
 			setupWindow("Updating " + mod.getModName() + "'s PCConsoleTOC files");
+			progressBar.setStringPainted(true);
 			break;
 		case INSTALLED_MODE:
 			setupWindow("Updating installed PCConsoleTOCs for " + mod.getModName());
+			progressBar.setStringPainted(false);
 			break;
 		default:
 			ModManager.debugLogger.writeError("Unknown AutoTOC mode: " + mode);
@@ -110,7 +113,6 @@ public class AutoTocWindow extends JDialog {
 		infoLabel = new JLabel("<html>" + labelText + "</html>");
 		aboutPanel.add(infoLabel, BorderLayout.NORTH);
 		progressBar = new JProgressBar(0, 100);
-		progressBar.setStringPainted(true);
 		progressBar.setIndeterminate(false);
 		aboutPanel.add(progressBar, BorderLayout.CENTER);
 		aboutPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));

--- a/src/com/me3tweaks/modmanager/ModImportArchiveWindow.java
+++ b/src/com/me3tweaks/modmanager/ModImportArchiveWindow.java
@@ -457,12 +457,16 @@ public class ModImportArchiveWindow extends JDialog {
 				ModManagerWindow.ACTIVE_WINDOW.reloadModlist();
 				if (modsToImport.size() == 1) {
 					//Highlight it
-					
+					//don't have a way to figure out what was just imported...
 				}
 				return;
 			} else {
 				ModManager.debugLogger.writeError("[IMPORTWORKER] Import was not fully successful");
 				ModManagerWindow.ACTIVE_WINDOW.reloadModlist();
+				progressBar.setVisible(false);
+				importButton.setVisible(true);
+				importButton.setEnabled(true);
+				importButton.setText("Import Selected");
 				JOptionPane.showMessageDialog(ModImportArchiveWindow.this, "Error occured during mod import.\nSome mods may have successfully imported.", "Import Unsuccessful",
 						JOptionPane.ERROR_MESSAGE);
 			}

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -85,9 +85,9 @@ public class ModManager {
 	public static boolean IS_DEBUG = false;
 	public final static boolean FORCE_32BIT_MODE = false; //set to true to force it to think it is running 32-bit for (most things)
 
-	public static final String VERSION = "5.0.4";
-	public static long BUILD_NUMBER = 79L;
-	public static final String BUILD_DATE = "8/12/2017";
+	public static final String VERSION = "5.0.5";
+	public static long BUILD_NUMBER = 80L;
+	public static final String BUILD_DATE = "09/08/2017";
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static DebugLogger debugLogger;
 	public static boolean logging = false;
@@ -104,7 +104,7 @@ public class ModManager {
 	public static final int MIN_REQUIRED_CMDLINE_MAIN = 1;
 	public static final int MIN_REQUIRED_CMDLINE_MINOR = 0;
 	public final static int MIN_REQUIRED_CMDLINE_BUILD = 0;
-	public final static int MIN_REQUIRED_CMDLINE_REV = 23;
+	public final static int MIN_REQUIRED_CMDLINE_REV = 24;
 
 	private final static int MIN_REQUIRED_NET_FRAMEWORK_RELNUM = 379893; //4.5.2
 	public static ArrayList<Image> ICONS;

--- a/src/com/me3tweaks/modmanager/utilities/SevenZipCompressedModInspector.java
+++ b/src/com/me3tweaks/modmanager/utilities/SevenZipCompressedModInspector.java
@@ -263,8 +263,11 @@ public class SevenZipCompressedModInspector {
 					if (!deletesuccessful) {
 						ModManager.debugLogger.writeError("FAILED TO DELETE FOLDER: " + outputdir);
 					}
-				} else {
+				} else if (result ==ModImportArchiveWindow.IMPORT_AS_SIDELOAD_OPTION){
 					ModManagerWindow.forceUpdateOnReloadList.add(cm.getModDescMod().getClassicUpdateCode());
+				} else {
+					//cancel
+					return false;
 				}
 
 			}


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 5.0.5 Build 80
This is a bugfix update to help prevent user confusion. This is being released to help alleviate issues that may occur with an upcoming mod I am releasing.

## Bugfixes 
 - Mod Importer cancel button would still import the button as a sideload if the same mod already existed. This now will throw a "not all mods could be imported" error instead, which is technically correct.
 - Mod Manager AutoTOC in GameWide mode now says it may take some time and removes the % indicator which could cause confusing with users thinking it hung when it was just taking a while to do its 1 process task.
 - Requires v27 of Mod Manager Command Line to help with diagnosing issues.
