### PR TITLE
Mass Effect 3 Mod Manager 5.0.7 Build 82

### DIFF
--- a/src/com/me3tweaks/modmanager/ALOTInstallerUpdaterWindow.java
+++ b/src/com/me3tweaks/modmanager/ALOTInstallerUpdaterWindow.java
@@ -39,18 +39,19 @@ import org.w3c.dom.Node;
 
 import com.me3tweaks.modmanager.objects.ThreadCommand;
 import com.me3tweaks.modmanager.utilities.ResourceUtils;
+import com.me3tweaks.modmanager.utilities.Version;
 
 @SuppressWarnings("serial")
-public class MassEffectModderUpdaterWindow extends JDialog implements PropertyChangeListener {
+public class ALOTInstallerUpdaterWindow extends JDialog implements PropertyChangeListener {
 	// String downloadLink, updateScriptLink;
 	boolean error = false;
-	int version;
+	Version version;
 	JLabel introLabel, statusLabel;
 	JProgressBar downloadProgress;
 	private boolean startAfterFinish;
 
-	public MassEffectModderUpdaterWindow(int version, boolean startAfterFinish) {
-		ModManager.debugLogger.writeMessage("Opening MassEffecTModderUpdaterWindow - Download link: " + ModManager.MASSEFFECTMODDER_DOWNLOADLINK);
+	public ALOTInstallerUpdaterWindow(Version version, boolean startAfterFinish) {
+		ModManager.debugLogger.writeMessage("Opening ALOTInstaller - Download link: " + ModManager.ALOTINSTALLER_DOWNLOADLINK);
 		this.startAfterFinish = startAfterFinish;
 		this.version = version;
 
@@ -58,13 +59,13 @@ public class MassEffectModderUpdaterWindow extends JDialog implements PropertyCh
 
 		DownloadTask task = new DownloadTask(ModManager.getTempDir());
 		task.addPropertyChangeListener(this);
-		ModManager.debugLogger.writeMessage("Downloading Mass Effect Modder v" + version);
+		ModManager.debugLogger.writeMessage("Downloading ALOT Installer v" + version);
 		task.execute();
 		setVisible(true);
 	}
 
 	private void setupWindow() {
-		setTitle("Downloading Mass Effect Modder");
+		setTitle("Downloading ALOT Installer");
 		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
 		setResizable(false);
 		setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
@@ -73,8 +74,8 @@ public class MassEffectModderUpdaterWindow extends JDialog implements PropertyCh
 		JPanel panel = new JPanel(new BorderLayout());
 		JPanel updatePanel = new JPanel();
 		updatePanel.setLayout(new BoxLayout(updatePanel, BoxLayout.Y_AXIS));
-		introLabel = new JLabel("Mod Manager is downloading Mass Effect Modder.");
-		statusLabel = new JLabel("<html>Downloading MEM from GitHub...<br>Mass Effect Modder is not part of Mod Manager.</html>");
+		introLabel = new JLabel("Mod Manager is downloading ALOT Installer.");
+		statusLabel = new JLabel("<html>Downloading ALOT Installer from GitHub...<br>ALOT Installer is not part of Mod Manager.</html>");
 
 		downloadProgress = new JProgressBar();
 		downloadProgress.setStringPainted(true);
@@ -133,7 +134,7 @@ public class MassEffectModderUpdaterWindow extends JDialog implements PropertyCh
 
 				// Download update
 				HTTPDownloadUtil util = new HTTPDownloadUtil();
-				util.downloadFile(ModManager.MASSEFFECTMODDER_DOWNLOADLINK);
+				util.downloadFile(ModManager.ALOTINSTALLER_DOWNLOADLINK);
 
 				// set file information on the GUI
 
@@ -161,21 +162,21 @@ public class MassEffectModderUpdaterWindow extends JDialog implements PropertyCh
 
 				util.disconnect();
 				publish(new ThreadCommand("SET_PROGRESSBAR_INDETERMINATE"));
-				publish(new ThreadCommand("SET_STATUS_TEXT", "<html>Extracting Mass Effect Modder...<br>Mass Effect Modder is not part of Mod Manager.</html>"));
+				publish(new ThreadCommand("SET_STATUS_TEXT", "<html>Extracting ALOT Installer...<br>ALOT Installer is not part of Mod Manager.</html>"));
 
 				ArrayList<String> commandBuilder = new ArrayList<String>();
 				commandBuilder.add(ModManager.get7zExePath());
 				commandBuilder.add("-y"); // overwrite
 				commandBuilder.add("x"); // extract
 				commandBuilder.add(saveFilePath);// 7z file
-				commandBuilder.add("-o" + ModManager.getMEMDirectory()); // extraction path
+				commandBuilder.add("-o" + ModManager.getALOTInstallerDirectory()); // extraction path
 				String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
-				ModManager.debugLogger.writeMessage("Extracting Mass Effect Modder...");
+				ModManager.debugLogger.writeMessage("Extracting ALOT Installer...");
 				ProcessBuilder pb = new ProcessBuilder(command);
 				ModManager.runProcess(pb);
 
 			} catch (IOException ex) {
-				ModManager.debugLogger.writeErrorWithException("Error downloading Mass Effect Modder: ", ex);
+				ModManager.debugLogger.writeErrorWithException("Error downloading ALOT Installer: ", ex);
 				publish(new ThreadCommand("DOWNLOAD_ERROR","Error downloading file:\n" + ex.getMessage()));
 				setProgress(0);
 				error = true;
@@ -196,7 +197,7 @@ public class MassEffectModderUpdaterWindow extends JDialog implements PropertyCh
 					statusLabel.setText(tc.getMessage());
 					break;
 				case "DOWNLOAD_ERROR":
-					JOptionPane.showMessageDialog(MassEffectModderUpdaterWindow.this, tc.getMessage(), "Download Error", JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(ALOTInstallerUpdaterWindow.this, tc.getMessage(), "Download Error", JOptionPane.ERROR_MESSAGE);
 					break;
 				}
 			}
@@ -207,10 +208,11 @@ public class MassEffectModderUpdaterWindow extends JDialog implements PropertyCh
 		 */
 		@Override
 		protected void done() {
-			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Updated Mass Effect Modder");
+			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Updated ALOT Installer");
 			dispose();
 			if (startAfterFinish) {
-				ProcessBuilder pb = new ProcessBuilder(ModManager.getMEMDirectory() + "MassEffectModder.exe");
+				ProcessBuilder pb = new ProcessBuilder(ModManager.getALOTInstallerDirectory() + "ALOTInstaller.exe");
+				pb.directory(new File(ModManager.getALOTInstallerDirectory()));
 				ModManager.runProcessDetached(pb);
 			}
 		}
@@ -231,7 +233,7 @@ public class MassEffectModderUpdaterWindow extends JDialog implements PropertyCh
 		 */
 		private InputStream inputStream;
 
-		private String fileName = "MassEffectModderUpdate.7z";
+		private String fileName = "ALOTInstallerUpdate.7z";
 		private int contentLength;
 
 		/**

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -85,11 +85,11 @@ import com.sun.jna.win32.W32APIOptions;
 import javafx.embed.swing.JFXPanel;
 
 public class ModManager {
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public final static boolean FORCE_32BIT_MODE = false; //set to true to force it to think it is running 32-bit for (most things)
 
-	public static final String VERSION = "5.0.6";
-	public static long BUILD_NUMBER = 81L;
+	public static final String VERSION = "5.0.7";
+	public static long BUILD_NUMBER = 82L;
 	public static final String BUILD_DATE = "12/03/2017";
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static DebugLogger debugLogger;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -73,6 +73,7 @@ import com.me3tweaks.modmanager.utilities.DebugLogger;
 import com.me3tweaks.modmanager.utilities.EXEFileInfo;
 import com.me3tweaks.modmanager.utilities.MD5Checksum;
 import com.me3tweaks.modmanager.utilities.ResourceUtils;
+import com.me3tweaks.modmanager.utilities.Version;
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.Kernel32;
@@ -90,7 +91,7 @@ public class ModManager {
 
 	public static final String VERSION = "5.0.7";
 	public static long BUILD_NUMBER = 82L;
-	public static final String BUILD_DATE = "12/03/2017";
+	public static final String BUILD_DATE = "12/25/2017";
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static DebugLogger debugLogger;
 	public static boolean logging = false;
@@ -131,8 +132,8 @@ public class ModManager {
 	public static boolean USE_WINDOWS_UI;
 	protected static boolean COMPRESS_COMPAT_OUTPUT = false;
 
-	public static String MASSEFFECTMODDER_DOWNLOADLINK;
-	public static int MASSEFFECTMODDER_LATESTVERSION;
+	public static String ALOTINSTALLER_DOWNLOADLINK;
+	public static Version ALOTINSTALLER_LATESTVERSION;
 
 	public static String TIPS_SERVICE_JSON;
 	protected final static int COALESCED_MAGIC_NUMBER = 1836215654;
@@ -1705,6 +1706,9 @@ public class ModManager {
 	 * @return true if bink23 exists and bink32 hash fails, false otherwise
 	 */
 	public static boolean checkIfBinkBypassIsInstalled(String biogameDir) {
+		if (biogameDir == null) {
+			return false;
+		}
 		File bgdir = new File(biogameDir);
 		if (!bgdir.exists()) {
 			return false;
@@ -2581,10 +2585,10 @@ public class ModManager {
 
 	/**
 	 * 
-	 * @return data\MassEffectModder\
+	 * @return data\ALOTInstaller\
 	 */
-	public static String getMEMDirectory() {
-		File file = new File(getDataDir() + "MassEffectModder\\");
+	public static String getALOTInstallerDirectory() {
+		File file = new File(getDataDir() + "ALOTInstaller\\");
 		file.mkdirs();
 		return appendSlash(file.getAbsolutePath());
 	}

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -181,7 +181,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	private JMenuItem toolsAutoTOCGame;
 	private JMenu restoreMenuAdvanced;
 	private boolean loadedFirstTime = false;
-	private JMenuItem toolMassEffectModder;
+	private JMenuItem toolAlotInstaller;
 	private ArrayList<MainUIBackgroundJob> backgroundJobs;
 	private JXCollapsiblePane activityPanel;
 
@@ -458,7 +458,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				isUpdate = false; //no mas
 				checkForContentUpdates(force || forcedByUpdate == true);
 			}
-			checkForMassEffectModderUpdates();
+			checkForALOTInstallerUpdates();
 			return null;
 		}
 
@@ -568,25 +568,16 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		 * Checks for the latest github release of MEM and stores the values in
 		 * memory. The values are used when attempting to start MEM.
 		 */
-		private void checkForMassEffectModderUpdates() {
+		private void checkForALOTInstallerUpdates() {
 			try {
-				String memEXELoc = ModManager.getMEMDirectory() + "MassEffectModder.exe";
-				File memEXE = new File(memEXELoc);
-				int localversion = 0;
-				if (memEXE.exists()) {
-					localversion = EXEFileInfo.getMajorVersionOfProgram(memEXELoc);
-				}
-
-				String memReleaseAPIEndpoint = "https://api.github.com/repos/MassEffectModder/MassEffectModder/releases/latest";
-				String response = IOUtils.toString(new URL(memReleaseAPIEndpoint), StandardCharsets.UTF_8);
+				String alotInstallerReleaseAPIEndpoint = "https://api.github.com/repos/Mgamerz/ALOTAddonGUI/releases/latest";
+				String response = IOUtils.toString(new URL(alotInstallerReleaseAPIEndpoint), StandardCharsets.UTF_8);
 				JSONParser parser = new JSONParser();
 				JSONObject latestRelease = (JSONObject) parser.parse(response);
 				String version = (String) latestRelease.get("tag_name");
-				int serverVersion = 0;
 				try {
-					serverVersion = Integer.parseInt(version);
-					ModManager.MASSEFFECTMODDER_LATESTVERSION = serverVersion;
-					ModManager.debugLogger.writeMessage("Latest MEM version on github: v" + ModManager.MASSEFFECTMODDER_LATESTVERSION);
+					ModManager.ALOTINSTALLER_LATESTVERSION = new Version(version);
+					ModManager.debugLogger.writeMessage("Latest ALOT Installer version on github: v" + ModManager.ALOTINSTALLER_LATESTVERSION);
 				} catch (NumberFormatException e) {
 					return;
 				}
@@ -594,12 +585,12 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				JSONArray assets = (JSONArray) latestRelease.get("assets");
 				if (assets.size() > 0) {
 					JSONObject releaseAsset = (JSONObject) assets.get(0);
-					ModManager.MASSEFFECTMODDER_DOWNLOADLINK = (String) releaseAsset.get("browser_download_url");
+					ModManager.ALOTINSTALLER_DOWNLOADLINK = (String) releaseAsset.get("browser_download_url");
 				}
 			} catch (IOException e) {
-				ModManager.debugLogger.writeErrorWithException("I/O Exception when checking Github for MEM update check:", e);
+				ModManager.debugLogger.writeErrorWithException("I/O Exception when checking Github for ALOT Installer update check:", e);
 			} catch (ParseException e1) {
-				ModManager.debugLogger.writeErrorWithException("Error in JSON returned from Github for MEM update check:", e1);
+				ModManager.debugLogger.writeErrorWithException("Error in JSON returned from Github for ALOT Installer update check:", e1);
 			}
 		}
 
@@ -1424,13 +1415,13 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		actionOptions = new JMenuItem("Options");
 		actionOptions.setToolTipText("Configure Mod Manager Options");
 
-		toolMassEffectModder = new JMenuItem("Mass Effect Modder");
+		toolAlotInstaller = new JMenuItem("ALOT Installer");
 		if (ResourceUtils.is64BitWindows()) {
-			toolMassEffectModder.setToolTipText(
-					"<html>Runs Mass Effect Modder.<br>Mass Effect Modder is a texturing tool for the Mass Effect series.<br>This tool is used to install ALOT and is much faster than ME3Explorer for installing textures.<br>Note: This is an external program and is not supported by ME3Tweaks.</html>");
+			toolAlotInstaller.setToolTipText(
+					"<html>Runs the ALOT installer.<br>The ALOT installer allows you to install high resolution texture packs for all three Mass Effect Trilogy games. It also includes ALOT Installer, a texturing program.<br>Note: This is an external program.</html>");
 		} else {
-			toolMassEffectModder.setToolTipText("<html>Mass Effect Modder requires 64-bit Windows</html>");
-			toolMassEffectModder.setEnabled(false);
+			toolAlotInstaller.setToolTipText("<html>ALOT Installer requires 64-bit Windows</html>");
+			toolAlotInstaller.setEnabled(false);
 		}
 		toolME3Explorer = new JMenuItem("ME3Explorer (ME3Tweaks Fork)");
 		toolME3Explorer.setToolTipText(
@@ -1597,7 +1588,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolME3Config.addActionListener(this);
 		toolsPCCDataDumper.addActionListener(this);
 		toolME3Explorer.addActionListener(this);
-		toolMassEffectModder.addActionListener(this);
+		toolAlotInstaller.addActionListener(this);
 		toolTankmasterTLK.addActionListener(this);
 		toolTankmasterCoalUI.addActionListener(this);
 
@@ -1625,7 +1616,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		toolsMenu.add(toolsGrantWriteAccess);
 		toolsMenu.addSeparator();
 		toolsMenu.add(toolME3Config);
-		toolsMenu.add(toolMassEffectModder);
+		toolsMenu.add(toolAlotInstaller);
 		toolsMenu.add(toolME3Explorer);
 		toolsMenu.add(toolsPCCDataDumper);
 		//toolsMenu.add(parsersMenu); not enough content for this to be useful.
@@ -2045,7 +2036,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				JOptionPane.showMessageDialog(ModManagerWindow.this, "This tool is under construction and is not fully functional in this build yet.");
+				//JOptionPane.showMessageDialog(ModManagerWindow.this, "This tool is under construction and is not fully functional in this build yet.");
 				new ModDescEditorWindow(mod);
 			}
 
@@ -2691,69 +2682,73 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				ModManager.debugLogger.writeMessage("Run ME3Explorer: .NET is not installed");
 				new NetFrameworkMissingWindow("ME3Explorer requires .NET 4.5.2 or higher in order to run.");
 			}
-		} else if (e.getSource() == toolMassEffectModder) {
+		} else if (e.getSource() == toolAlotInstaller) {
 			if (ModManager.validateNETFrameworkIsInstalled()) {
 				updateApplyButton();
 				boolean prompt = false;
-				String extVersionStr = null;
-				File memEXE = new File(ModManager.getMEMDirectory() + "MassEffectModder.exe");
+				File alotInstallerEXE = new File(ModManager.getALOTInstallerDirectory() + "ALOTInstaller.exe");
 				String promptMessage = "Placeholder";
 				String promptTitle = "Placeholder";
 				int promptIcon = JOptionPane.ERROR_MESSAGE;
 
-				if (!memEXE.exists()) {
-					promptMessage = "Mass Effect Modder is not included in Mod Manager and must be downloaded.\nMod Manager can download version "
-							+ ModManager.MASSEFFECTMODDER_LATESTVERSION + " for you.\nDownload?";
+				if (!alotInstallerEXE.exists() && ModManager.ALOTINSTALLER_LATESTVERSION != null && ModManager.ALOTINSTALLER_DOWNLOADLINK != null) {
+					String latestVersion = ModManager.ALOTINSTALLER_LATESTVERSION.toString();
+					promptMessage = "ALOT Installer is not included in Mod Manager and must be downloaded.\nMod Manager can download version " + latestVersion
+							+ " for you.\nDownload?";
 					promptIcon = JOptionPane.WARNING_MESSAGE;
 					promptTitle = "Download required";
 					prompt = true;
-				} else {
-					if (ModManager.MASSEFFECTMODDER_LATESTVERSION > 0) {
-						int existingVersion = EXEFileInfo.getMajorVersionOfProgram(memEXE.getAbsolutePath());
-						if (existingVersion < ModManager.MASSEFFECTMODDER_LATESTVERSION) {
-							promptMessage = "Your local copy of Mass Effect Modder is out of date.\nLocal version: " + existingVersion + "\nLatest version: "
-									+ ModManager.MASSEFFECTMODDER_LATESTVERSION + "\nDownload latest version?";
-							promptIcon = JOptionPane.WARNING_MESSAGE;
-							promptTitle = "Update available";
-							prompt = true;
-						}
+				} else if (ModManager.ALOTINSTALLER_LATESTVERSION != null && ModManager.ALOTINSTALLER_DOWNLOADLINK != null) {
+					Version existingVersion = EXEFileInfo.getVersion(alotInstallerEXE.getAbsolutePath());
+					if (existingVersion.compareTo(ModManager.ALOTINSTALLER_LATESTVERSION) < 0) {
+						promptMessage = "Your local copy of ALOT Installer is out of date.\nLocal version: " + existingVersion + "\nLatest version: "
+								+ ModManager.ALOTINSTALLER_LATESTVERSION + "\nDownload latest version?";
+						promptIcon = JOptionPane.WARNING_MESSAGE;
+						promptTitle = "Update available";
+						prompt = true;
 					}
+				} else {
+					ModManager.debugLogger.writeMessage("No network connection at startup - no known way to download ALOT Installer.");
+					labelStatus.setText("Mod Manager needs network connection at startup");
 				}
 				if (prompt) {
 					// Show update
 					int update = JOptionPane.showConfirmDialog(ModManagerWindow.ACTIVE_WINDOW, promptMessage, promptTitle, JOptionPane.YES_NO_OPTION, promptIcon);
 					if (update == JOptionPane.YES_OPTION) {
-						new MassEffectModderUpdaterWindow(ModManager.MASSEFFECTMODDER_LATESTVERSION, true);
+						new ALOTInstallerUpdaterWindow(ModManager.ALOTINSTALLER_LATESTVERSION, true);
 					} else {
-						if (memEXE.exists()) {
-							ModManager.debugLogger.writeMessage("Launching Mass Effect Modder");
-							ProcessBuilder pb = new ProcessBuilder(memEXE.getAbsolutePath());
+						if (alotInstallerEXE.exists()) {
+							ModManager.debugLogger.writeMessage("Launching ALOT Installer");
+							ProcessBuilder pb = new ProcessBuilder(alotInstallerEXE.getAbsolutePath());
+							pb.directory(new File(ModManager.getALOTInstallerDirectory()));
 							ModManager.runProcessDetached(pb);
-							labelStatus.setText("Launched Mass Effect Modder");
+							labelStatus.setText("Launched ALOT Installer");
 
 						} else {
-							ModManager.debugLogger.writeMessage("Aboring MEM launch - does not exist locally");
-							labelStatus.setText("Mass Effect Modder not available");
+							ModManager.debugLogger.writeMessage("Aboring ALOT Installer launch - does not exist locally");
+							labelStatus.setText("ALOT Installer not available");
 						}
 					}
 				} else {
-					if (memEXE.exists()) {
+					if (alotInstallerEXE.exists()) {
 						//run it
-						ModManager.debugLogger.writeMessage("Launching Mass Effect Modder");
-						ProcessBuilder pb = new ProcessBuilder(memEXE.getAbsolutePath());
+						ModManager.debugLogger.writeMessage("Launching ALOT Installer");
+						ProcessBuilder pb = new ProcessBuilder(alotInstallerEXE.getAbsolutePath());
 						ModManager.runProcessDetached(pb);
-						labelStatus.setText("Launched Mass Effect Modder");
+						labelStatus.setText("Launched ALOT Installer");
 					}
 				}
 
 			} else {
 				updateApplyButton();
 				labelStatus.setText(".NET Framework 4.5.2 or higher is missing");
-				ModManager.debugLogger.writeMessage("Run MEM: .NET is not installed");
-				new NetFrameworkMissingWindow("Mass Effect Modder requires .NET 4.5.2 or higher in order to run.");
+				ModManager.debugLogger.writeMessage("Run ALOT Installer: .NET is not installed");
+				new NetFrameworkMissingWindow("ALOT Installer requires .NET 4.5.2 or higher in order to run.");
 			}
 
-		} else if (e.getSource() == modManagementOpenModsFolder) {
+		} else if (e.getSource() == modManagementOpenModsFolder)
+
+		{
 			ResourceUtils.openDir(ModManager.getModsDir());
 		} else if (e.getSource() == modManagementClearPatchLibraryCache) {
 			File libraryDir = new File(ModManager.getPatchesDir() + "source");
@@ -3335,6 +3330,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 						continue; //we don't are about this
 					}
 					for (String destFile : job.getFilesToReplaceTargets()) {
+						String extension = FilenameUtils.getExtension(destFile);
 						if (FilenameUtils.getExtension(destFile).toLowerCase().equals("pcc")) {
 							hasPCCInstall = true;
 							ModManager.debugLogger.writeMessage("Detected PCC file attempting to install over ALOT installation: " + destFile);

--- a/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
+++ b/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
@@ -711,12 +711,12 @@ public class RestoreFilesWindow extends JDialog {
 
 			if (backupSfar == null) {
 				//no normal backup.
-				String vanillaBackupPath = VanillaBackupWindow.GetFullBackupPath();
+				String vanillaBackupPath = VanillaBackupWindow.GetFullBackupPath(false);
 				if (vanillaBackupPath == null) {
 					//no backup!
 					publish(jobName + ": No backup exists, cannot restore.");
 					JOptionPane.showMessageDialog(RestoreFilesWindow.this, "<html>No backup for " + jobName
-							+ " exists, you'll have to restore through Origin's Repair Game.<br>Select Tools > Backup DLC to avoid this issue after the game is restored.</html>",
+							+ " exists, you'll have to restore through Origin's Repair Game.<br>Select Backup > Backup DLC to avoid this issue after the game is restored.</html>",
 							"Error", JOptionPane.ERROR_MESSAGE);
 					return false;
 				}

--- a/src/com/me3tweaks/modmanager/TLKTool.java
+++ b/src/com/me3tweaks/modmanager/TLKTool.java
@@ -1,9 +1,11 @@
 package com.me3tweaks.modmanager;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,6 +47,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import com.me3tweaks.modmanager.objects.ProcessResult;
+import com.me3tweaks.modmanager.utilities.ResourceUtils;
 import com.me3tweaks.modmanager.utilities.datatypeconverter.DatatypeConverter;
 
 public class TLKTool {
@@ -66,6 +69,40 @@ public class TLKTool {
 	}
 
 	public static void main(String[] args) throws Exception {
+		ArrayList<String> sizeLines = new ArrayList<String>();
+		File f = new File("E:\\Documents\\Visual Studio 2015\\Projects\\AlotAddOnGUI\\AlotAddOnGUI\\bin\\x64\\Debug\\logs\\alotaddoninstaller-20171210.txt");
+		try (BufferedReader br = new BufferedReader(new FileReader(f))) {
+			for (String line; (line = br.readLine()) != null;) {
+				// process the line.
+				if (line.contains("[SIZE]")) {
+					sizeLines.add(line);
+					System.out.println(line);
+				}
+			}
+			// line is not visible here.
+		}
+		long firstSize = 0;
+		long biggestSize = Long.MAX_VALUE;
+
+		int lastIndexOfSpace = sizeLines.get(0).lastIndexOf(" ");
+		firstSize = Long.parseLong(sizeLines.get(0).substring(lastIndexOfSpace + 1, sizeLines.get(0).length()));
+
+		System.out.println("Starting size: " + firstSize);
+
+		for (String str : sizeLines) {
+			lastIndexOfSpace = str.lastIndexOf(" ");
+			long size = Long.parseLong(str.substring(lastIndexOfSpace + 1, str.length()));
+			if (size < biggestSize) {
+				biggestSize = size;
+			}
+		}
+
+		System.out.println("Smallest size is " + biggestSize);
+		System.out.println("At most the disk space required was " + ResourceUtils.humanReadableByteCount((firstSize - biggestSize), true));
+
+		if (true) {
+			return;
+		}
 		orderINTFile();
 		buildITAFromINTSPController();
 		replacePCPlaceholdersWithXbox();

--- a/src/com/me3tweaks/modmanager/moddesceditor/MDEConditionalFileItem.java
+++ b/src/com/me3tweaks/modmanager/moddesceditor/MDEConditionalFileItem.java
@@ -18,6 +18,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
 import org.jdesktop.swingx.HorizontalLayout;
+import org.jdesktop.swingx.JXCollapsiblePane;
 
 import com.me3tweaks.modmanager.objects.AlternateFile;
 import com.me3tweaks.modmanager.objects.Mod;
@@ -30,10 +31,10 @@ import javafx.application.Platform;
 import javafx.stage.FileChooser;
 
 public class MDEConditionalFileItem {
-	private JPanel panel;
+	private JXCollapsiblePane collapsablePanel;
 
-	public JPanel getPanel() {
-		return panel;
+	public JXCollapsiblePane getPanel() {
+		return collapsablePanel;
 	}
 
 	public AlternateFile getAf() {
@@ -96,15 +97,30 @@ public class MDEConditionalFileItem {
 	public MDEConditionalFileItem(ModDescEditorWindow owningWindow, AlternateFile af) {
 		this.mod = owningWindow.getMod();
 		this.owningWindow = owningWindow;
+		boolean startCollapsed = false;
+		if (af == null) {
+			af = new AlternateFile();
+			startCollapsed = true;
+		}
 		this.af = af;
 		setupPanel();
+		collapsablePanel.setCollapsed(startCollapsed);
 	}
 
 	private void setupPanel() {
-		panel = new JPanel(new HorizontalLayout());
-
+		collapsablePanel = new JXCollapsiblePane();
+		JPanel panel = new JPanel(new HorizontalLayout());
+		collapsablePanel.add(panel);
 		minusButton = new JButton("-");
 		panel.add(minusButton);
+		minusButton.addActionListener(new ActionListener() {
+			
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				collapsablePanel.setCollapsed(true);
+				owningWindow.removeConditionalFileItem(MDEConditionalFileItem.this);
+			}
+		});
 
 		conditionBox = new JComboBox<String>(conditionsHuman);
 		operationBox = new JComboBox<String>(operationsHuman);
@@ -227,29 +243,42 @@ public class MDEConditionalFileItem {
 			}
 		});
 
-		switch (af.getCondition()) {
-		case AlternateFile.CONDITION_DLC_NOT_PRESENT:
-			conditionBox.setSelectedIndex(0);
-			break;
-		case AlternateFile.CONDITION_DLC_PRESENT:
-			conditionBox.setSelectedIndex(1);
-			break;
-		case AlternateFile.CONDITION_MANUAL:
+		if (af.getCondition() != null) {
+			switch (af.getCondition()) {
+			case AlternateFile.CONDITION_DLC_NOT_PRESENT:
+				conditionBox.setSelectedIndex(0);
+				break;
+			case AlternateFile.CONDITION_DLC_PRESENT:
+				conditionBox.setSelectedIndex(1);
+				break;
+			case AlternateFile.CONDITION_MANUAL:
+				conditionBox.setSelectedIndex(2);
+				break;
+			}
+		} else {
 			conditionBox.setSelectedIndex(2);
-			break;
 		}
 
-		switch (af.getOperation()) {
-		case AlternateFile.OPERATION_INSTALL:
-			operationBox.setSelectedIndex(0);
-			break;
-		case AlternateFile.OPERATION_NOINSTALL:
-			operationBox.setSelectedIndex(1);
-			break;
-		case AlternateFile.OPERATION_SUBSTITUTE:
+		if (af.getOperation() != null) {
+			switch (af.getOperation()) {
+			case AlternateFile.OPERATION_INSTALL:
+				operationBox.setSelectedIndex(0);
+				break;
+			case AlternateFile.OPERATION_NOINSTALL:
+				operationBox.setSelectedIndex(1);
+				break;
+			case AlternateFile.OPERATION_SUBSTITUTE:
+				operationBox.setSelectedIndex(2);
+				break;
+			}
+		} else {
 			operationBox.setSelectedIndex(2);
-			break;
 		}
 
+	}
+
+	private JPanel JXCollapsablePanel() {
+		// TODO Auto-generated method stub
+		return null;
 	}
 }

--- a/src/com/me3tweaks/modmanager/objects/AlternateFile.java
+++ b/src/com/me3tweaks/modmanager/objects/AlternateFile.java
@@ -69,6 +69,13 @@ public class AlternateFile {
 		associatedJobName = alt.associatedJobName;
 	}
 
+	/**
+	 * Empty constructor. Used for adding a new AlternateFile to a mod.
+	 */
+	public AlternateFile() {
+		// TODO Auto-generated constructor stub
+	}
+
 	public String getDescription() {
 		return description;
 	}

--- a/src/com/me3tweaks/modmanager/utilities/EXEFileInfo.java
+++ b/src/com/me3tweaks/modmanager/utilities/EXEFileInfo.java
@@ -1,86 +1,111 @@
 package com.me3tweaks.modmanager.utilities;
 
-	import com.me3tweaks.modmanager.ModManager;
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.VerRsrc.VS_FIXEDFILEINFO;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
-	
-	public class EXEFileInfo {
-		public static int MAJOR = 0;
-		public static int MINOR = 1;
-		public static int BUILD = 2;
-		public static int REVISION = 3;
-	
-		public static int getMajorVersionOfProgram(String path) {
-			return getVersionInfo(path)[MAJOR];
-		}
-	
-		public static int getMinorVersionOfProgram(String path) {
-			return getVersionInfo(path)[MINOR];
-		}
-	
-		public static int getBuildOfProgram(String path) {
-			return getVersionInfo(path)[BUILD];
-		}
-	
-		public static int getRevisionOfProgram(String path) {
-			return getVersionInfo(path)[REVISION];
-		}
-	
-		public static int[] getVersionInfo(String path) {
-			IntByReference dwDummy = new IntByReference();
-			dwDummy.setValue(0);
-	
-			int versionlength = com.sun.jna.platform.win32.Version.INSTANCE.GetFileVersionInfoSize(path, dwDummy);
-	
-			byte[] bufferarray = new byte[versionlength];
-			Pointer lpData = new Memory(bufferarray.length);
-			PointerByReference lplpBuffer = new PointerByReference();
-			IntByReference puLen = new IntByReference();
-			boolean fileInfoResult = com.sun.jna.platform.win32.Version.INSTANCE.GetFileVersionInfo(path, 0, versionlength, lpData);
-			boolean verQueryVal = com.sun.jna.platform.win32.Version.INSTANCE.VerQueryValue(lpData, "\\", lplpBuffer, puLen);
-	
-			VS_FIXEDFILEINFO lplpBufStructure = new VS_FIXEDFILEINFO(lplpBuffer.getValue());
-			lplpBufStructure.read();
-	
-			int v1 = (lplpBufStructure.dwFileVersionMS).intValue() >> 16;
-			int v2 = (lplpBufStructure.dwFileVersionMS).intValue() & 0xffff;
-			int v3 = (lplpBufStructure.dwFileVersionLS).intValue() >> 16;
-			int v4 = (lplpBufStructure.dwFileVersionLS).intValue() & 0xffff;
-			return new int[] { v1, v2, v3, v4 };
-		}
-		
-		/**
-		 * Compares two version strings. 
-		 * 
-		 * Use this instead of String.compareTo() for a non-lexicographical 
-		 * comparison that works for version strings. e.g. "1.10".compareTo("1.6").
-		 * 
-		 * @note It does not work if "1.10" is supposed to be equal to "1.10.0".
-		 * 
-		 * @param str1 a string of ordinal numbers separated by decimal points. 
-		 * @param str2 a string of ordinal numbers separated by decimal points.
-		 * @return The result is a negative integer if str1 is _numerically_ less than str2. 
-		 *         The result is a positive integer if str1 is _numerically_ greater than str2. 
-		 *         The result is zero if the strings are _numerically_ equal.
-		 */
-		public static int versionCompare(String str1, String str2) {
-		    String[] vals1 = str1.split("\\.");
-		    String[] vals2 = str2.split("\\.");
-		    int i = 0;
-		    // set index to first non-equal ordinal or length of shortest version string
-		    while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
-		      i++;
-		    }
-		    // compare first non-equal ordinal number
-		    if (i < vals1.length && i < vals2.length) {
-		        int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
-		        return Integer.signum(diff);
-		    }
-		    // the strings are equal or one string is a substring of the other
-		    // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
-		    return Integer.signum(vals1.length - vals2.length);
-		}
+
+public class EXEFileInfo {
+	public static int MAJOR = 0;
+	public static int MINOR = 1;
+	public static int BUILD = 2;
+	public static int REVISION = 3;
+
+	public static int getMajorVersionOfProgram(String path) {
+		return getVersionInfo(path)[MAJOR];
 	}
+
+	public static int getMinorVersionOfProgram(String path) {
+		return getVersionInfo(path)[MINOR];
+	}
+
+	public static int getBuildOfProgram(String path) {
+		return getVersionInfo(path)[BUILD];
+	}
+
+	public static int getRevisionOfProgram(String path) {
+		return getVersionInfo(path)[REVISION];
+	}
+
+	public static int[] getVersionInfo(String path) {
+		IntByReference dwDummy = new IntByReference();
+		dwDummy.setValue(0);
+
+		int versionlength = com.sun.jna.platform.win32.Version.INSTANCE.GetFileVersionInfoSize(path, dwDummy);
+
+		byte[] bufferarray = new byte[versionlength];
+		Pointer lpData = new Memory(bufferarray.length);
+		PointerByReference lplpBuffer = new PointerByReference();
+		IntByReference puLen = new IntByReference();
+		boolean fileInfoResult = com.sun.jna.platform.win32.Version.INSTANCE.GetFileVersionInfo(path, 0, versionlength, lpData);
+		boolean verQueryVal = com.sun.jna.platform.win32.Version.INSTANCE.VerQueryValue(lpData, "\\", lplpBuffer, puLen);
+
+		VS_FIXEDFILEINFO lplpBufStructure = new VS_FIXEDFILEINFO(lplpBuffer.getValue());
+		lplpBufStructure.read();
+
+		int v1 = (lplpBufStructure.dwFileVersionMS).intValue() >> 16;
+		int v2 = (lplpBufStructure.dwFileVersionMS).intValue() & 0xffff;
+		int v3 = (lplpBufStructure.dwFileVersionLS).intValue() >> 16;
+		int v4 = (lplpBufStructure.dwFileVersionLS).intValue() & 0xffff;
+		return new int[] { v1, v2, v3, v4 };
+	}
+
+	public static Version getVersion(String path) {
+		IntByReference dwDummy = new IntByReference();
+		dwDummy.setValue(0);
+
+		int versionlength = com.sun.jna.platform.win32.Version.INSTANCE.GetFileVersionInfoSize(path, dwDummy);
+
+		byte[] bufferarray = new byte[versionlength];
+		Pointer lpData = new Memory(bufferarray.length);
+		PointerByReference lplpBuffer = new PointerByReference();
+		IntByReference puLen = new IntByReference();
+		boolean fileInfoResult = com.sun.jna.platform.win32.Version.INSTANCE.GetFileVersionInfo(path, 0, versionlength, lpData);
+		boolean verQueryVal = com.sun.jna.platform.win32.Version.INSTANCE.VerQueryValue(lpData, "\\", lplpBuffer, puLen);
+
+		VS_FIXEDFILEINFO lplpBufStructure = new VS_FIXEDFILEINFO(lplpBuffer.getValue());
+		lplpBufStructure.read();
+
+		int v1 = (lplpBufStructure.dwFileVersionMS).intValue() >> 16;
+		int v2 = (lplpBufStructure.dwFileVersionMS).intValue() & 0xffff;
+		int v3 = (lplpBufStructure.dwFileVersionLS).intValue() >> 16;
+		int v4 = (lplpBufStructure.dwFileVersionLS).intValue() & 0xffff;
+		return new Version(v1 + "." + v2 + "." + v3 + "." + v4);
+	}
+
+	/**
+	 * Compares two version strings.
+	 * 
+	 * Use this instead of String.compareTo() for a non-lexicographical
+	 * comparison that works for version strings. e.g. "1.10".compareTo("1.6").
+	 * 
+	 * @note It does not work if "1.10" is supposed to be equal to "1.10.0".
+	 * 
+	 * @param str1
+	 *            a string of ordinal numbers separated by decimal points.
+	 * @param str2
+	 *            a string of ordinal numbers separated by decimal points.
+	 * @return The result is a negative integer if str1 is _numerically_ less
+	 *         than str2. The result is a positive integer if str1 is
+	 *         _numerically_ greater than str2. The result is zero if the
+	 *         strings are _numerically_ equal.
+	 */
+	public static int versionCompare(String str1, String str2) {
+		String[] vals1 = str1.split("\\.");
+		String[] vals2 = str2.split("\\.");
+		int i = 0;
+		// set index to first non-equal ordinal or length of shortest version string
+		while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
+			i++;
+		}
+		// compare first non-equal ordinal number
+		if (i < vals1.length && i < vals2.length) {
+			int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
+			return Integer.signum(diff);
+		}
+		// the strings are equal or one string is a substring of the other
+		// e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+		return Integer.signum(vals1.length - vals2.length);
+	}
+}


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 5.0.7 Build 82
This is mainly a bugfix build.

# New Features
 - MEM has been swapped for ALOT installer. Mod Manager will pull whatever the latest github build is, which may be a beta build.

# Changed Features
 - Work continues on moddesc editor. Still viewer only. Have been very busy on ALOT Installer, will be returning to Mod Manager soon.
 - Vanilla backup window has a bit more detail.

# Bugfixes 
 - Show message if no download link has been calculated due to no network connection at startup when trying to run MEM (now alot installer) if it does not exist locally
 - Binkw32 startup crash should be fixed.