### PR TITLE
Mass Effect 3 Mod Manager 5.0.7 MR2 Build 82

### DIFF
--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -33,9 +33,7 @@ import java.util.Properties;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import java.util.prefs.Preferences;
-import java.util.stream.Collectors;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
@@ -53,8 +51,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.apache.commons.io.filefilter.SuffixFileFilter;
-import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.ini4j.InvalidFileFormatException;
 import org.ini4j.Wini;
@@ -68,7 +64,6 @@ import com.me3tweaks.modmanager.objects.ModTypeConstants;
 import com.me3tweaks.modmanager.objects.PCCDumpOptions;
 import com.me3tweaks.modmanager.objects.Patch;
 import com.me3tweaks.modmanager.objects.ProcessResult;
-import com.me3tweaks.modmanager.objects.ThreadCommand;
 import com.me3tweaks.modmanager.utilities.DebugLogger;
 import com.me3tweaks.modmanager.utilities.EXEFileInfo;
 import com.me3tweaks.modmanager.utilities.MD5Checksum;
@@ -86,12 +81,12 @@ import com.sun.jna.win32.W32APIOptions;
 import javafx.embed.swing.JFXPanel;
 
 public class ModManager {
-	public static boolean IS_DEBUG = false;
+	public static boolean IS_DEBUG = true;
 	public final static boolean FORCE_32BIT_MODE = false; //set to true to force it to think it is running 32-bit for (most things)
 
-	public static final String VERSION = "5.0.7 MR1";
+	public static final String VERSION = "5.0.7 MR2";
 	public static long BUILD_NUMBER = 82L;
-	public static final String BUILD_DATE = "12/27/2017";
+	public static final String BUILD_DATE = "12/30/2017";
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static DebugLogger debugLogger;
 	public static boolean logging = false;
@@ -134,7 +129,7 @@ public class ModManager {
 
 	public static String ALOTINSTALLER_DOWNLOADLINK;
 	public static Version ALOTINSTALLER_LATESTVERSION;
-
+	public static String THIRD_PARTY_IMPORTING_JSON;
 	public static String TIPS_SERVICE_JSON;
 	protected final static int COALESCED_MAGIC_NUMBER = 1836215654;
 	public final static String[] KNOWN_GUI_CUSTOMDLC_MODS = { "DLC_CON_XBX", "DLC_CON_UIScaling", "DLC_CON_UIScaling_Shared" };
@@ -523,6 +518,13 @@ public class ModManager {
 			} else {
 				ModManager.debugLogger.writeMessage("No third party identification service JSON found. May not have been downloaded yet...");
 			}
+			
+			if (ModManager.getThirdPartyModImportingDBFile().exists()) {
+				ModManager.debugLogger.writeMessage("Loading third party importing service JSON into memory");
+				ModManager.THIRD_PARTY_IMPORTING_JSON = FileUtils.readFileToString(ModManager.getThirdPartyModImportingDBFile(), StandardCharsets.UTF_8);
+			} else {
+				ModManager.debugLogger.writeMessage("No third party importing service JSON found. May not have been downloaded yet...");
+			}
 
 			if (ModManager.getTipsServiceFile().exists()) {
 				ModManager.debugLogger.writeMessage("Loading ME3Tweaks Tips Service JSON into memory");
@@ -595,6 +597,10 @@ public class ModManager {
 					"Mod Manager had an uncaught exception during runtime:\n" + e.getMessage() + "\nPlease report this to FemShep.", "Mod Manager has crashed",
 					JOptionPane.ERROR_MESSAGE);
 		}
+	}
+
+	public static File getThirdPartyModImportingDBFile() {
+		return new File(getME3TweaksServicesCache() + "thirdpartyimportingdb.json");
 	}
 
 	/**

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -3121,11 +3121,13 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 	private void checkForValidBioGame(File chosenFile) {
 		String chosenPath = chosenFile.getAbsolutePath();
 		if (internalValidateBIOGameDir(chosenPath)) {
-			chosenPath = new File(chosenPath).getParent();
+			String biogamePath = chosenPath;
+			chosenPath = new File(chosenPath).getParent(); //Game Directory
+			ModManager.debugLogger.writeMessage("Parent (after internal validation passed):" + chosenPath);
 
 			// Check to make sure path is not a backup path
 			File cmm_vanilla = new File(chosenPath + File.separator + "cmm_vanilla");
-			ModManager.debugLogger.writeMessage("Checking if biogame directory is a vanilla backup: " + cmm_vanilla);
+			ModManager.debugLogger.writeMessage("Checking if mod manager directory is a vanilla backup: " + cmm_vanilla);
 			if (cmm_vanilla.exists()) {
 				ModManager.debugLogger.writeMessage("Selected directory is a vanilla backup, rejecting biogame choice.");
 				JOptionPane.showMessageDialog(ModManagerWindow.this, "The selected directory is marked as a vanilla backup.\nMod Manager cannot use this as a installation target.",
@@ -3156,7 +3158,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			int size = model.getSize();
 			for (int i = 0; i < size; i++) {
 				String element = model.getElementAt(i);
-				if (element.equalsIgnoreCase(chosenPath)) {
+				if (element.equalsIgnoreCase(biogamePath)) {
 					continue; //we'll put ours at the top of the list
 				}
 				biogameDirectories.add(element);
@@ -3164,7 +3166,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			}
 			comboboxBiogameDir.removeItemListener(BIOGAME_ITEM_LISTENER);
 			comboboxBiogameDir.removeAllItems();
-			comboboxBiogameDir.addItem(chosenPath); //our selected item
+			comboboxBiogameDir.addItem(biogamePath); //our selected item
 
 			for (String biodir : biogameDirectories) {
 				comboboxBiogameDir.addItem(biodir); //all the others
@@ -3175,7 +3177,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 			saveBiogamePath(biogameDirectories);
 			labelStatus.setText("Set game target directory");
 			labelStatus.setVisible(true);
-			comboboxBiogameDir.setSelectedItem(chosenPath);
+			comboboxBiogameDir.setSelectedItem(biogamePath);
 			comboboxBiogameDir.addItemListener(BIOGAME_ITEM_LISTENER);
 			validateBIOGameDir();
 		} else {
@@ -3891,10 +3893,18 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 				}
 
 				//CHECK WRITE PERMISSIONS
-				boolean hasWritePermissions = ModManager.checkWritePermissions(selectedGamePath) && ModManager.checkWritePermissions(selectedGamePath + "\\BIOGame")
-						&& ModManager.checkWritePermissions(selectedGamePath + "\\BIOGame\\CookedPCConsole");
-				if (!hasWritePermissions) {
-					showFolderPermissionsGrantDialog(selectedGamePath);
+				File biogame = new File(selectedGamePath + "\\BIOGame");
+				File selectedGamePathF = new File(selectedGamePath);
+				File cookedPCConsole = new File(selectedGamePath + "\\BIOGame\\CookedPCConsole");
+
+				if (biogame.exists() && selectedGamePathF.exists() && cookedPCConsole.exists()) { //prevents it from thinking it is unable to write due to non-existence
+					if (biogame.isDirectory() && selectedGamePathF.isDirectory() && cookedPCConsole.isDirectory()) { //make sure it is a folder so we can write into sub
+						boolean hasWritePermissions = ModManager.checkWritePermissions(selectedGamePath) && ModManager.checkWritePermissions(selectedGamePath + "\\BIOGame")
+								&& ModManager.checkWritePermissions(selectedGamePath + "\\BIOGame\\CookedPCConsole");
+						if (!hasWritePermissions) {
+							showFolderPermissionsGrantDialog(selectedGamePath);
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 5.0.7 MR2 Build 82
This is a bugfix release.

## Bugfixes
 - Fixes bug where game would become messed up if you added a new game target. If you have been affected by this bug, you can fix it by adding the game directory as a target again.

To fix it manually, you will need to fix it in your registry by adding your game directory to the end of the registry key for Mass Effect 3 (InstallDir):

![image](https://user-images.githubusercontent.com/2738836/34457832-ff97bd22-ed7a-11e7-97f4-e314d910f116.png)

The key is located at:
  - 64Bit systems: HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\BioWare\Mass Effect 3
  - 32Bit systems: HKEY_LOCAL_MACHINE\SOFTWARE\BioWare\Mass Effect 3

An affected system will have the InstallDir set one folder too high due to a bug in my validation code not resetting the variable when checking an upstream directory.
