### PR TITLE
Fix some more bugs in target switcher

### DIFF
--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -81,7 +81,7 @@ import com.sun.jna.win32.W32APIOptions;
 import javafx.embed.swing.JFXPanel;
 
 public class ModManager {
-	public static boolean IS_DEBUG = true;
+	public static boolean IS_DEBUG = false;
 	public final static boolean FORCE_32BIT_MODE = false; //set to true to force it to think it is running 32-bit for (most things)
 
 	public static final String VERSION = "5.0.7 MR2";

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1011,14 +1011,19 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		setPreferredSize(minSize);
 		setMinimumSize(minSize);
 		ArrayList<String> directories = ModManager.getSavedBIOGameDirectories();
-
+		ArrayList<String> displayedDirectories = new ArrayList<String>();
 		DefaultComboBoxModel<String> biogameDirectoriesModel = new DefaultComboBoxModel<>();
 
 		comboboxBiogameDir = new JComboBox<String>();
 		comboboxBiogameDir.setModel(biogameDirectoriesModel);
 
 		for (String dir : directories) {
-			biogameDirectoriesModel.addElement(dir);
+			if (internalValidateBIOGameDir(dir)) {
+				biogameDirectoriesModel.addElement(dir);
+				displayedDirectories.add(dir);
+			} else {
+				ModManager.debugLogger.writeError("Saved biogame directory failed validation: " + dir);
+			}
 		}
 
 		ModManager.debugLogger.writeMessage("Setting active biogame directory from registry...");
@@ -1026,7 +1031,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		boolean useAddInstead = comboboxBiogameDir.getModel().getSize() > 0;
 		if (registrykey != null) {
 			registrykey = ResourceUtils.removeTrailingSlashes(registrykey);
-			int index = directories.indexOf(registrykey);
+			int index = displayedDirectories.indexOf(registrykey);
 			String gamedir = new File(registrykey).getParent();
 			if (index >= 0) {
 				comboboxBiogameDir.setSelectedIndex(index);
@@ -3852,7 +3857,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 		@Override
 		public void itemStateChanged(ItemEvent event) {
 			if (event.getStateChange() == ItemEvent.SELECTED) {
+
 				String selectedPath = (String) event.getItem();
+				ModManager.debugLogger.writeMessage("Switching game targets to " + selectedPath);
+
 				String selectedGamePath = new File(selectedPath).getParent();
 
 				//UPDATE REGISTRY KEY
@@ -3906,6 +3914,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 						}
 					}
 				}
+				validateBIOGameDir(); //reset upper state
 			}
 		}
 	}


### PR DESCRIPTION
 - For users that do not have registry key properly set this will fix some bugs in the version switcher. 
 - It also fixes a bug where switching to valid target would not set it as valid in the display (cosmetic only).
 - Invalid biogame directories will no longer load at startup.