### PR TITLE
Mass Effect 3 Mod Manager 5.0.8 Build 83

### DIFF
--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -84,9 +84,9 @@ public class ModManager {
 	public static boolean IS_DEBUG = false;
 	public final static boolean FORCE_32BIT_MODE = false; //set to true to force it to think it is running 32-bit for (most things)
 
-	public static final String VERSION = "5.0.7 MR2";
-	public static long BUILD_NUMBER = 82L;
-	public static final String BUILD_DATE = "12/30/2017";
+	public static final String VERSION = "5.0.8";
+	public static long BUILD_NUMBER = 83L;
+	public static final String BUILD_DATE = "01/23/2017";
 	public static final String SETTINGS_FILENAME = "me3cmm.ini";
 	public static DebugLogger debugLogger;
 	public static boolean logging = false;
@@ -103,7 +103,7 @@ public class ModManager {
 	public static final int MIN_REQUIRED_CMDLINE_MAIN = 1;
 	public static final int MIN_REQUIRED_CMDLINE_MINOR = 0;
 	public final static int MIN_REQUIRED_CMDLINE_BUILD = 0;
-	public final static int MIN_REQUIRED_CMDLINE_REV = 27;
+	public final static int MIN_REQUIRED_CMDLINE_REV = 29;
 
 	private final static int MIN_REQUIRED_NET_FRAMEWORK_RELNUM = 379893; //4.5.2
 	public static ArrayList<Image> ICONS;


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 5.0.8 Build 83
This build updates the Mod Manager Command Line Tools minimum requirement. While it doesn't fix or change anything in Mod Manager, the tools update includes the following changes which will make some behind the scenes things in Mod Manager different:

 - Should be MUCH faster first time (windows) FullAutoTOC. The performance was incredibly inconsistent before as it would open file streams to read the size rather than just NTFS metadata, which means it filled up your disks' memory cache as it opened every file for reading.
 - Implemented support in GUI Transplanter for interface files from another mod, as well as expanded the list of supported transplants to cover things like horizontal progress bars.
 - Small optimizations with if/else statements.
