### PR TITLE
Mass Effect 3 Mod Manager 5.1 Build 88

### DIFF
--- a/src/com/me3tweaks/modmanager/FailedModsWindow.java
+++ b/src/com/me3tweaks/modmanager/FailedModsWindow.java
@@ -149,9 +149,9 @@ public class FailedModsWindow extends JDialog implements ListSelectionListener {
 							ModManagerWindow.ACTIVE_WINDOW.startSingleModUpdate(mod);
 							dispose();
 						} else {
-							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
 							ModManager.debugLogger.writeMessage("Fail Mod Restore: Missing .NET Framework");
-							new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 to restore ModMaker mods.");
+							new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" to restore ModMaker mods.");
 						}
 					} else {
 						ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Restoring ModMaker mods requires valid BIOGame");

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -43,7 +43,7 @@ public class ModManager {
     public static boolean IS_DEBUG = false;
     public static final String VERSION = "5.1";
     public static long BUILD_NUMBER = 88L;
-    public static final String BUILD_DATE = "09/20/2018";
+    public static final String BUILD_DATE = "09/30/2018";
     public static final String SETTINGS_FILENAME = "me3cmm.ini";
     public static DebugLogger debugLogger;
     public static boolean logging = false;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -1,51 +1,13 @@
 package com.me3tweaks.modmanager;
 
-import java.awt.Image;
-import java.awt.Toolkit;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Scanner;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.prefs.Preferences;
-
-import javax.swing.ImageIcon;
-import javax.swing.JOptionPane;
-import javax.swing.ToolTipManager;
-import javax.swing.UIManager;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
+import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
+import com.me3tweaks.modmanager.objects.*;
+import com.me3tweaks.modmanager.utilities.*;
+import com.me3tweaks.modmanager.utilities.Version;
+import com.sun.jna.Native;
+import com.sun.jna.platform.win32.*;
+import com.sun.jna.win32.W32APIOptions;
+import javafx.embed.swing.JFXPanel;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -56,29 +18,26 @@ import org.ini4j.InvalidFileFormatException;
 import org.ini4j.Wini;
 import org.w3c.dom.Document;
 
-import com.me3tweaks.modmanager.modmaker.ME3TweaksUtils;
-import com.me3tweaks.modmanager.objects.CustomDLC;
-import com.me3tweaks.modmanager.objects.Mod;
-import com.me3tweaks.modmanager.objects.ModList;
-import com.me3tweaks.modmanager.objects.ModTypeConstants;
-import com.me3tweaks.modmanager.objects.PCCDumpOptions;
-import com.me3tweaks.modmanager.objects.Patch;
-import com.me3tweaks.modmanager.objects.ProcessResult;
-import com.me3tweaks.modmanager.utilities.DebugLogger;
-import com.me3tweaks.modmanager.utilities.EXEFileInfo;
-import com.me3tweaks.modmanager.utilities.MD5Checksum;
-import com.me3tweaks.modmanager.utilities.ResourceUtils;
-import com.me3tweaks.modmanager.utilities.Version;
-import com.sun.jna.Native;
-import com.sun.jna.platform.win32.Advapi32Util;
-import com.sun.jna.platform.win32.Kernel32;
-import com.sun.jna.platform.win32.Tlhelp32;
-import com.sun.jna.platform.win32.WinDef;
-import com.sun.jna.platform.win32.WinNT;
-import com.sun.jna.platform.win32.WinReg;
-import com.sun.jna.win32.W32APIOptions;
-
-import javafx.embed.swing.JFXPanel;
+import javax.swing.*;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.awt.*;
+import java.io.*;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.prefs.Preferences;
 
 public class ModManager {
     public static boolean IS_DEBUG = false;
@@ -103,7 +62,9 @@ public class ModManager {
     public final static int MIN_REQUIRED_CMDLINE_BUILD = 0;
     public static int MIN_REQUIRED_CMDLINE_REV = 31; //not static as i can force this via update manifest
 
-    private final static int MIN_REQUIRED_NET_FRAMEWORK_RELNUM = 461308; //4.7.1
+    private final static int MIN_REQUIRED_NET_FRAMEWORK_RELNUM = 461808; //4.7.2
+    public final static String MIN_REQUIRED_NET_FRAMEWORK_STR = "4.7.2";
+
     public static ArrayList<Image> ICONS;
     public static boolean AUTO_INJECT_KEYBINDS = false;
     public static boolean AUTO_UPDATE_MOD_MANAGER = true;
@@ -532,7 +493,7 @@ public class ModManager {
             doFileSystemUpdate();
             if (!validateNETFrameworkIsInstalled()) {
                 new NetFrameworkMissingWindow(
-                        "Mod Manager was unable to detect a usable .NET Framework. Mod Manager requires Microsoft .NET Framework 4.7.1 or higher in order to function properly. ");
+                        "Mod Manager was unable to detect a usable .NET Framework. Mod Manager requires Microsoft .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to function properly. ");
             }
 
             if (checkIfCMMPatchIsTooLong()) {
@@ -791,7 +752,7 @@ public class ModManager {
                 resStreamOut.write(buffer, 0, readBytes);
             }
         } catch (Exception ex) {
-            ModManager.debugLogger.writeErrorWithException("Error extracting resource "+resourceName,ex);
+            ModManager.debugLogger.writeErrorWithException("Error extracting resource " + resourceName, ex);
             throw ex;
         } finally {
             stream.close();
@@ -1852,7 +1813,7 @@ public class ModManager {
         if (os.contains("Windows")) {
             int releaseNum = 0;
             String netFrameWork4Key = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full";
-            ModManager.debugLogger.writeMessage("Checking for .NET Framework 4.7.1 or higher registry key");
+            ModManager.debugLogger.writeMessage("Checking for .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher registry key");
             try {
                 releaseNum = Advapi32Util.registryGetIntValue(WinReg.HKEY_LOCAL_MACHINE, netFrameWork4Key, "Release");
                 ModManager.debugLogger.writeMessage(".NET Framework release detected: " + releaseNum);
@@ -1866,11 +1827,11 @@ public class ModManager {
                     return false;
                 }
             } catch (com.sun.jna.platform.win32.Win32Exception keynotfoundException) {
-                ModManager.debugLogger.writeError(".NET Framework 4.7.1 registry key was not found: " + netFrameWork4Key);
+                ModManager.debugLogger.writeError(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " registry key was not found: " + netFrameWork4Key);
                 NET_FRAMEWORK_IS_INSTALLED = false;
                 return false;
             } catch (Throwable e) {
-                ModManager.debugLogger.writeErrorWithException(".NET Framework 4.7.1 detection exception:", e);
+                ModManager.debugLogger.writeErrorWithException(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " detection exception:", e);
                 NET_FRAMEWORK_IS_INSTALLED = false;
                 return false;
             }
@@ -2693,13 +2654,13 @@ public class ModManager {
     public static String getBackupPatchSource(String targetPath, String targetModule, boolean vanillaBackupCopy) {
         String cmmbackup = new File(ModManagerWindow.GetBioGameDir()).getParent() + "\\cmmbackup";
         if (vanillaBackupCopy) {
-                String vanillaBackupPath = VanillaBackupWindow.GetFullBackupPath(false);
-                if (vanillaBackupPath == null) {
-                    //no full vanilla backup exists
-                    ModManager.debugLogger.writeError("Vanilla backup does not exist: cannot use for mixin file fetch");
-                    return null;
-                }
-                cmmbackup = vanillaBackupPath;
+            String vanillaBackupPath = VanillaBackupWindow.GetFullBackupPath(false);
+            if (vanillaBackupPath == null) {
+                //no full vanilla backup exists
+                ModManager.debugLogger.writeError("Vanilla backup does not exist: cannot use for mixin file fetch");
+                return null;
+            }
+            cmmbackup = vanillaBackupPath;
         }
         ModManager.debugLogger.writeMessage("Looking for backup patch source: " + targetPath + " in module " + targetModule);
         File sourceDestination = new File(getPatchesDir() + "source/" + ME3TweaksUtils.headerNameToInternalName(targetModule) + File.separator + targetPath);

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1365,7 +1365,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
         if (ModManager.NET_FRAMEWORK_IS_INSTALLED) {
             buttonApplyMod.setToolTipText("Select a mod on the left");
         } else {
-            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework 4.7.1 or higher in order to install mods");
+            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
         }
         buttonStartGame = new JButton("Start Game");
         buttonStartGame.addActionListener(this);
@@ -1444,7 +1444,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
             }
         } else {
             buttonApplyMod.setText(".NET Missing");
-            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework 4.7.1 or higher in order to install mods");
+            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
             buttonApplyMod.setEnabled(false);
         }
     }
@@ -2099,9 +2099,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         new SingleModUpdateCheckThread(mod).execute();
                     } else {
                         updateApplyButton();
-                        labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                        labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                         ModManager.debugLogger.writeMessage("Single mode updater: Missing .NET Framework");
-                        new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 to update ModMaker mods.");
+                        new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" to update ModMaker mods.");
                     }
                 } else {
                     labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
@@ -2124,9 +2124,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         new SingleModUpdateCheckThread(cloneMod).execute();
                     } else {
                         updateApplyButton();
-                        labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                        labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                         ModManager.debugLogger.writeMessage("Single mode updater: Missing .NET Framework");
-                        new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 to update ModMaker mods.");
+                        new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" to update ModMaker mods.");
                     }
                 } else {
                     labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
@@ -2148,9 +2148,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         new DeltaWindow(mod, delta, true, false);
                     }
                 } else {
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("Patch Library: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher to switch mod variants.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher to switch mod variants.");
                 }
             }
         });
@@ -2163,9 +2163,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     ModManager.debugLogger.writeMessage("Reverting a delta.");
                     new DeltaWindow(mod);
                 } else {
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("Revert Delta: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher to switch mod variants.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher to switch mod variants.");
                 }
             }
         });
@@ -2179,9 +2179,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new KeybindsInjectionWindow(ModManagerWindow.this, mod, false);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("Keybinds Injector: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to use the Keybinds Injector.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use the Keybinds Injector.");
                 }
             }
         });
@@ -2202,9 +2202,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     autoTOC(AutoTocWindow.LOCALMOD_MODE);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("AutoTOC: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to use the AutoTOC feature.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use the AutoTOC feature.");
                 }
             }
         });
@@ -2296,9 +2296,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 } else {
 
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("ModMaker: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to use ModMaker.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use ModMaker.");
                 }
             } else {
                 labelStatus.setText("ModMaker requires valid BIOGame directory to start");
@@ -2343,9 +2343,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new CustomDLCConflictWindow();
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeError("Custom DLC Conflict Window: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to fully use the conflict detection tool.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to fully use the conflict detection tool.");
                 }
             } else {
                 labelStatus.setText("Conflict detector requires valid BIOGame directory");
@@ -2620,9 +2620,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         applyMod();
                     } else {
                         updateApplyButton();
-                        labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                        labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                         ModManager.debugLogger.writeMessage("Applying selected mod: .NET is not installed");
-                        new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to install mods.");
+                        new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods.");
                     }
                 } else {
                     labelStatus.setText("Installing a mod requires valid BIOGame path");
@@ -2651,9 +2651,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 new PCCDataDumperWindow();
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                 ModManager.debugLogger.writeMessage("Run PCC Data Dumper: .NET is not installed");
-                new NetFrameworkMissingWindow("The PCC Data Dumper tool requires .NET 4.7.1 or higher to be installed.");
+                new NetFrameworkMissingWindow("The PCC Data Dumper tool requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher to be installed.");
             }
 
         } else if (e.getSource() == toolME3Explorer) {
@@ -2725,9 +2725,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 }
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                 ModManager.debugLogger.writeMessage("Run ME3Explorer: .NET is not installed");
-                new NetFrameworkMissingWindow("ME3Explorer requires .NET 4.7.1 or higher in order to run.");
+                new NetFrameworkMissingWindow("ME3Explorer requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
             }
         } else if (e.getSource() == toolAlotInstaller) {
             if (ModManager.validateNETFrameworkIsInstalled()) {
@@ -2788,9 +2788,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                 ModManager.debugLogger.writeMessage("Run ALOT Installer: .NET is not installed");
-                new NetFrameworkMissingWindow("ALOT Installer requires .NET 4.7.1 or higher in order to run.");
+                new NetFrameworkMissingWindow("ALOT Installer requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
             }
 
         } else if (e.getSource() == modManagementOpenModsFolder)
@@ -2835,18 +2835,18 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 }
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                 ModManager.debugLogger.writeMessage("Run TLK: .NET is not installed");
-                new NetFrameworkMissingWindow("Tankmaster's TLK Tool requires .NET 4.7.1 or higher in order to run.");
+                new NetFrameworkMissingWindow("Tankmaster's TLK Tool requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
             }
         } else if (e.getSource() == toolTankmasterCoalUI) {
             if (ModManager.validateNETFrameworkIsInstalled()) {
                 new CoalescedWindow();
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                 ModManager.debugLogger.writeMessage("Run ME3Explorer: .NET is not installed");
-                new NetFrameworkMissingWindow("ME3Explorer requires .NET 4.7.1 or higher in order to run.");
+                new NetFrameworkMissingWindow("ME3Explorer requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
             }
         } else if (e.getSource() == actionOptions) {
             new OptionsWindow(this);
@@ -2859,10 +2859,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
              * ModManager.debugLogger.writeMessage("Opening Mod Merging utility"
              * ); updateApplyButton(); new MergeModWindow(this); } else {
              * updateApplyButton();
-             * labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+             * labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
              * ModManager.debugLogger.
              * writeMessage("Merge Tool: Missing .NET Framework"); new
-             * NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to merge mods."
+             * NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to merge mods."
              * ); }
              */
         } else if (e.getSource() == toolME3Config) {
@@ -2894,9 +2894,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new UnpackWindow(this);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("Unpack DLC Tool: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to unpack DLC.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to unpack DLC.");
                 }
             } else {
                 labelStatus.setText("Unpacking DLC requires a valid BIOGame directory");
@@ -2922,9 +2922,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new AutoTocWindow(ModManagerWindow.GetBioGameDir());
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("AutoTOC: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to use the AutoTOC feature.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use the AutoTOC feature.");
                 }
             } else {
                 labelStatus.setText("Game AutoTOC requires a valid BIOGame directory");
@@ -2942,9 +2942,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new PatchLibraryWindow(PatchLibraryWindow.MANUAL_MODE);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("Patch Library: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to use MixIns.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use MixIns.");
                 }
             } else {
                 labelStatus.setText("Use of the patch library requires a valid BIOGame folder");
@@ -2960,9 +2960,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new ModGroupWindow();
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework 4.7.1 or higher is missing");
+                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
                     ModManager.debugLogger.writeMessage("Batch Mod Installer: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework 4.7.1 or higher in order to batch install mods.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to batch install mods.");
                 }
             } else {
                 labelStatus.setText("Use of the patch library requires a valid BIOGame folder");
@@ -3489,7 +3489,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 if (ModManager.NET_FRAMEWORK_IS_INSTALLED) {
                     buttonApplyMod.setToolTipText("Select a mod on the left");
                 } else {
-                    buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework 4.7.1 or higher in order to install mods");
+                    buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
                 }
                 fieldDescription.setText(getNoSelectedModDescription());
                 modWebsiteLink.setVisible(false);
@@ -3517,7 +3517,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         buttonApplyMod.setToolTipText(
                                 "<html>Apply this mod to the game.<br>If other mods are installed, you should consider uninstalling them by<br>using the Restore Menu if they are known to not work together.</html>");
                     } else {
-                        buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework 4.7.1 or higher in order to install mods");
+                        buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
                         buttonApplyMod.setText("Missing .NET");
                         buttonApplyMod.setEnabled(false);
                     }

--- a/src/com/me3tweaks/modmanager/NetFrameworkMissingWindow.java
+++ b/src/com/me3tweaks/modmanager/NetFrameworkMissingWindow.java
@@ -14,7 +14,7 @@ import java.net.URL;
 public class NetFrameworkMissingWindow extends JDialog {
     JLabel introLabel;
     JButton downloadButton;
-    private static final String netPage = "https://www.microsoft.com/en-us/download/details.aspx?id=56115";
+    private static final String netPage = "https://www.microsoft.com/net/download/dotnet-framework-runtime";
 
     public NetFrameworkMissingWindow(String text) {
         this.setTitle("No usable .NET Framework installed");

--- a/src/com/me3tweaks/modmanager/NetFrameworkMissingWindow.java
+++ b/src/com/me3tweaks/modmanager/NetFrameworkMissingWindow.java
@@ -1,62 +1,55 @@
 package com.me3tweaks.modmanager;
 
-import java.awt.Dialog;
-import java.awt.Dimension;
+import com.me3tweaks.modmanager.utilities.ResourceUtils;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.border.EmptyBorder;
-
-import com.me3tweaks.modmanager.utilities.ResourceUtils;
-
 @SuppressWarnings("serial")
 public class NetFrameworkMissingWindow extends JDialog {
-	JLabel introLabel;
-	JButton downloadButton;
-	private static final String netPage = "https://www.microsoft.com/en-us/download/details.aspx?id=56115";
+    JLabel introLabel;
+    JButton downloadButton;
+    private static final String netPage = "https://www.microsoft.com/en-us/download/details.aspx?id=56115";
 
-	public NetFrameworkMissingWindow(String text) {
-		this.setTitle("No usable .NET Framework installed");
-		this.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-		this.setResizable(false);
-		this.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
-		setupWindow(text);
-		this.setIconImages(ModManager.ICONS);
-		this.pack();
-		this.setLocationRelativeTo(null);
-		this.setVisible(true);
-	}
+    public NetFrameworkMissingWindow(String text) {
+        this.setTitle("No usable .NET Framework installed");
+        this.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        this.setResizable(false);
+        this.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
+        setupWindow(text);
+        this.setIconImages(ModManager.ICONS);
+        this.pack();
+        this.setLocationRelativeTo(null);
+        this.setVisible(true);
+    }
 
-	private void setupWindow(String text) {
-		JPanel updatePanel = new JPanel();
-		updatePanel.setBorder(new EmptyBorder(5,5,5,5));
-		updatePanel.setLayout(new BoxLayout(updatePanel, BoxLayout.Y_AXIS));
-		introLabel = new JLabel("<html><div style=\"width:200px;\">"+text+"<br></div></html>");
-		downloadButton = new JButton("Download .NET 4.7.1 from Microsoft");
-		downloadButton.addActionListener(new ActionListener() {
-			
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				try {
-					ResourceUtils.openWebpage(new URL(netPage));
-				} catch (MalformedURLException e1) {
-					ModManager.debugLogger.writeError("Invalid URL for .NET! This shouldn't happen...");
-				}
-			}
-		});
+    private void setupWindow(String text) {
+        JPanel updatePanel = new JPanel();
+        updatePanel.setBorder(new EmptyBorder(5, 5, 5, 5));
+        updatePanel.setLayout(new BoxLayout(updatePanel, BoxLayout.Y_AXIS));
+        introLabel = new JLabel("<html><div style=\"width:200px;\">" + text + "<br></div></html>");
+        downloadButton = new JButton("Download .NET " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " from Microsoft");
+        downloadButton.addActionListener(new ActionListener() {
 
-		updatePanel.add(introLabel);
-		updatePanel.add(Box.createRigidArea(new Dimension(5,5)));
-		updatePanel.add(downloadButton);
-		updatePanel.add(new JLabel("<html><div style=\"width:200px;\">If you are certain that this is installed, turn off this check in the Actions > Options menu.</div></html>"));
-		this.getContentPane().add(updatePanel);
-	}
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    ResourceUtils.openWebpage(new URL(netPage));
+                } catch (MalformedURLException e1) {
+                    ModManager.debugLogger.writeError("Invalid URL for .NET! This shouldn't happen...");
+                }
+            }
+        });
+
+        updatePanel.add(introLabel);
+        updatePanel.add(Box.createRigidArea(new Dimension(5, 5)));
+        updatePanel.add(downloadButton);
+        updatePanel.add(new JLabel("<html><div style=\"width:200px;\">If you are certain that this is installed, turn off this check in the Actions > Options menu.</div></html>"));
+        this.getContentPane().add(updatePanel);
+    }
 }

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -808,9 +808,6 @@ public class Mod implements Comparable<Mod> {
 						return;
 					}
 					for (String alt : alts) {
-						if (alts.size() == 3) {
-							System.out.println("b");
-						}
 						AlternateFile af = new AlternateFile(alt, modCMMVer);
 						af.setAssociatedJobName(ModTypeConstants.CUSTOMDLC);
 						ModManager.debugLogger.writeMessageConditionally("Alternate file specified: " + af.toString(), ModManager.LOG_MOD_INIT);


### PR DESCRIPTION
This is a small update fixing a few user reported issues, as well as preparing to update to OpenJDK as Oracle has changed their licensing terms for Java SE.

The below commit history does not show all commits as some were performed on `master` instead of `dev` accidentally.

 ## Changes in this build
 - .NET 4.7.2 is now the minimum required version
 - Application will not crash when starting up if located directly alongside the Mass Effect 3 directory
 - ALOT installation status is now shown in Custom DLC Manager, Custom Restore windows
 - Bundle JRE update is more robust with a third state that I did not account for when designing the update scenarios