### PR TITLE
Mass Effect 3 Mod Manager 5.1.1 Build 89

### DIFF
--- a/src/com/me3tweaks/modmanager/BackupWindow.java
+++ b/src/com/me3tweaks/modmanager/BackupWindow.java
@@ -451,7 +451,7 @@ public class BackupWindow extends JDialog {
 				statusLabel.setText("<html><center>Preparing to backup DLC<br>Please wait</center></html>");
 			}
 
-			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("DLCBackup");
+			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("DLCBackup", "Backing up DLC...");
 			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Backing up DLC...");
 			this.closeOnComplete = closeOnComplete;
 			this.jobs = jobs;

--- a/src/com/me3tweaks/modmanager/LogOptionsWindow.java
+++ b/src/com/me3tweaks/modmanager/LogOptionsWindow.java
@@ -247,7 +247,7 @@ public class LogOptionsWindow extends JDialog {
         ArrayList<String> acceptableHashes = new ArrayList<String>();
         acceptableHashes.add("1d09c01c94f01b305f8c25bb56ce9ab4"); //1.5
         acceptableHashes.add("598bf934e0f4d269f5b1657002f453ce"); //1.6
-
+        acceptableHashes.add("90d51c84b278b273e41fbe75682c132e"); //1.5 signed by EA, not sure of the difference
         String bioGameDir = ModManagerWindow.GetBioGameDir();
         if (installeddlcoption.isSelected()) {
             log += "=========[INSTALLEDDLC] Installed DLC =============\n";

--- a/src/com/me3tweaks/modmanager/ModImportArchiveWindow.java
+++ b/src/com/me3tweaks/modmanager/ModImportArchiveWindow.java
@@ -302,7 +302,7 @@ public class ModImportArchiveWindow extends JDialog {
 		private boolean is7zfile = false;
 
 		public ScanWorker(String archiveFile) {
-			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Scanning archive for mods");
+			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("ArchiveScan","Scanning archive for mods");
 			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Scanning " + FilenameUtils.getName(archiveFile));
 			this.archiveFile = archiveFile;
 			is7zfile = archiveFile.toLowerCase().endsWith(".7z");
@@ -428,7 +428,7 @@ public class ModImportArchiveWindow extends JDialog {
 			// TODO Auto-generated constructor stub
 			this.archiveFilePath = archiveFilePath;
 			this.modsToImport = modsToImport;
-			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Importing Mods");
+			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Importing Mods", "Importing mod(s)...");
 			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Importing " + (modsToImport.size() != 1 ? "mods" : modsToImport.get(0).getModName()));
 			descriptionArea.setText("Importing mods into Mod Manager...");
 			progressBar.setIndeterminate(true);

--- a/src/com/me3tweaks/modmanager/ModInstallWindow.java
+++ b/src/com/me3tweaks/modmanager/ModInstallWindow.java
@@ -57,1280 +57,1274 @@ import com.me3tweaks.modmanager.utilities.ResourceUtils;
  * Window that injects the files into the game/dlc. Takes ArrayList<Mod> as list
  * of mods to install. However, this went unused (all instances only use 1 mod
  * in the list), but was left behind because of the extensive changes it made.
- * 
+ *
  * @author Mgamerz
  *
  */
 public class ModInstallWindow extends JDialog {
-	private boolean continueBatchInstallation = true;
-	private JLabel infoLabel;
-	private String bioGameDir;
-	private final int levelCount = 7;
-	private JTextArea consoleArea;
-	private String consoleQueue[];
-	private JProgressBar progressBar;
-	private JButton batchCancellationButton;
-	private BatchPackage batchPackage;
-	public final static String CUSTOMDLC_METADATA_FILE = "_metacmm.txt";
-	private boolean installFinished = false;
-
-	public ModInstallWindow(JFrame callingWindow, ArrayList<Mod> mods, BatchPackage batchpackage) {
-		super(null, Dialog.ModalityType.APPLICATION_MODAL);
-		this.batchPackage = batchpackage;
-		initWindow(callingWindow, mods);
-	}
-
-	public ModInstallWindow(JDialog callingWindow, ArrayList<Mod> mods, BatchPackage batchpackage) {
-		super(null, Dialog.ModalityType.APPLICATION_MODAL);
-		this.batchPackage = batchpackage;
-		initWindow(callingWindow, mods);
-	}
-
-	/**
-	 * Install a single mod, with an optional batch package.
-	 * 
-	 * @param callingWindow
-	 *            Dialog to center against
-	 * @param mod
-	 *            Mod to install
-	 * @param batchpackage
-	 *            Batch package. Used to slightly modify the UI for batch
-	 *            installation mode. Can be null.
-	 */
-	public ModInstallWindow(JDialog callingWindow, Mod mod, BatchPackage batchpackage) {
-		super(null, Dialog.ModalityType.APPLICATION_MODAL);
-		this.batchPackage = batchpackage;
-		ArrayList<Mod> mods = new ArrayList<Mod>();
-		mods.add(mod);
-		initWindow(callingWindow, mods);
-	}
-
-	/**
-	 * Install a single mod, with an optional batch package.
-	 * 
-	 * @param callingWindow
-	 *            Frame to center against
-	 * @param mod
-	 *            Mod to install
-	 * @param batchpackage
-	 *            Batch package. Used to slightly modify the UI for batch
-	 *            installation mode. Can be null.
-	 */
-	public ModInstallWindow(JFrame callingWindow, Mod mod, BatchPackage batchpackage) {
-		super(null, Dialog.ModalityType.APPLICATION_MODAL);
-		this.batchPackage = batchpackage;
-		ArrayList<Mod> mods = new ArrayList<Mod>();
-		mods.add(mod);
-		initWindow(callingWindow, mods);
-	}
-
-	private void initWindow(Component callingWindow, ArrayList<Mod> mods) {
-		this.bioGameDir = ModManagerWindow.GetBioGameDir();
-
-		consoleQueue = new String[levelCount];
-		setupWindow(mods);
-
-		if (callingWindow instanceof JFrame) {
-			setLocationRelativeTo((JFrame) callingWindow);
-		} else {
-			setLocationRelativeTo((JDialog) callingWindow);
-		}
-
-		checkModCMMVersion(callingWindow, mods);
-		boolean installMod = validateRequiredModulesAreAvailable(callingWindow, mods);
-		if (installMod) {
-			new InjectionCommander(mods).execute();
-			setVisible(true);
-		} else {
-			ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Mod install cancelled");
-			dispose();
-		}
-	}
-
-	/**
-	 * Checks to make sure that the MODDESC can be fully parsed.
-	 * 
-	 * @param mods
-	 *            mod to check against
-	 */
-	private void checkModCMMVersion(Component callingWindow, ArrayList<Mod> mods) {
-		for (Mod mod : mods) {
-			if (mod.getCMMVer() > ModManager.MODDESC_VERSION_SUPPORT) {
-				JOptionPane
-						.showMessageDialog(callingWindow,
-								mod.getModName() + "'s moddesc.ini file indicates it uses a higher version of the moddesc specification than this build supports: "
-										+ mod.getCMMVer() + ".\nMod Manager will attempt to install the mod but it may not work.",
-								"Outdated Mod Manager", JOptionPane.WARNING_MESSAGE);
-			}
-		}
-	}
-
-	/**
-	 * Checks that the modjobs required modules are available and prompts if
-	 * they aren't
-	 * 
-	 * @return true if all are available or user ignored missing
-	 */
-	private boolean validateRequiredModulesAreAvailable(Component callingWindow, ArrayList<Mod> mods) {
-		ArrayList<ModJob> missingModules = new ArrayList<ModJob>();
-		StringBuilder sb = new StringBuilder();
-		for (Mod mod : mods) {
-			for (ModJob job : mod.jobs) {
-				if (job.getJobType() == ModJob.DLC) {
-					String commandlinetoolsdir = ModManager.getCommandLineToolsDir();
-					File fullautotoc = new File(commandlinetoolsdir + "FullAutoTOC.exe");
-					File sfarinjector = new File(commandlinetoolsdir + "SFARTools-Inject.exe");
-					if (!fullautotoc.exists() || !sfarinjector.exists()) {
-						dispose();
-						ModManager.debugLogger.writeError("Mod Manager Command Line tools are not available. Aborting installation");
-						JOptionPane.showMessageDialog(ModInstallWindow.this,
-								"Installation of mods requires the Mod Manager Command Line tools library.\nThis will automatically download on startup when connected to the internet.\nMod installation cannot continue.",
-								"Required Component Missing", JOptionPane.ERROR_MESSAGE);
-						return false;
-					}
-
-					//check that sfar is available
-					String sfarName = "Default.sfar";
-					if (job.TESTPATCH) {
-						sfarName = "Patch_001.sfar";
-					}
-					String sfarPath = ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName;
-					File sfar = new File(sfarPath);
-					if (!sfar.exists()) {
-						ModManager.debugLogger.writeMessage("Installation module is missing: " + sfar);
-						missingModules.add(job);
-					}
-				}
-			}
-
-			//module is missing
-			sb.append(mod.getModName() + " has jobs for the following missing DLC.\nIf the mod descriptor details the job description, they will be listed below.\n");
-			for (ModJob job : missingModules) {
-				ModManager.debugLogger.writeMessage(mod.getModName() + " requires missing DLC Module: " + job.getJobName());
-				sb.append(" - ");
-				sb.append(job.getJobName());
-				sb.append("\n");
-				if (job.getRequirementText() != null && !job.getRequirementText().equals("")) {
-					sb.append("   - ");
-					sb.append(job.getRequirementText());
-					sb.append("\n");
-				}
-			}
-		}
-		if (missingModules.size() <= 0) {
-			ModManager.debugLogger.writeMessage("Mod has all required DLCs available");
-			return true;
-		}
-		sb.append("\nThese jobs will be skipped. Continue with the mod install?");
-		int result = JOptionPane.showConfirmDialog(callingWindow, sb.toString(), "Missing DLC", JOptionPane.WARNING_MESSAGE);
-		ModManager.debugLogger.writeMessage(result == JOptionPane.YES_OPTION ? "User continuing install even with missing DLC modules" : "User canceled Mod Install");
-		return result == JOptionPane.YES_OPTION;
-	}
-
-	private void setupWindow(ArrayList<Mod> mods) {
-		setTitle("Applying Mod" + (mods.size() > 1 ? "s" : ""));
-		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-		setPreferredSize(new Dimension(320, batchPackage != null ? 250 : 220));
-		setIconImages(ModManager.ICONS);
-		JPanel rootPanel = new JPanel(new BorderLayout());
-		JPanel northPanel = new JPanel(new BorderLayout());
-		if (mods.size() == 1) {
-			if (batchPackage != null) {
-				infoLabel = new JLabel("<html><center>Now Installing [" + batchPackage.currentBatchInstallationNumber + "/" + batchPackage.totalBatchMods + "]<br>"
-						+ mods.get(0).getModName() + "</center></html>", SwingConstants.CENTER);
-			} else {
-				infoLabel = new JLabel("<html><center>Now Installing<br>" + mods.get(0).getModName() + "</center></html>", SwingConstants.CENTER);
-			}
-		} else {
-			infoLabel = new JLabel("<html><center>Now Installing<br>" + mods.size() + " mods</center></html>", SwingConstants.CENTER);
-
-		}
-		northPanel.add(infoLabel, BorderLayout.NORTH);
-		progressBar = new JProgressBar(0, 100);
-		progressBar.setStringPainted(true);
-		progressBar.setIndeterminate(false);
-
-		northPanel.add(progressBar, BorderLayout.SOUTH);
-		northPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
-		rootPanel.add(northPanel, BorderLayout.NORTH);
-
-		consoleArea = new JTextArea();
-		consoleArea.setLineWrap(true);
-		consoleArea.setWrapStyleWord(true);
-
-		consoleArea.setEditable(false);
-
-		rootPanel.add(consoleArea, BorderLayout.CENTER);
-
-		if (batchPackage != null) {
-			batchCancellationButton = new JButton("Cancel batch installation");
-			batchCancellationButton.setToolTipText("Cancels batch mod installation. Installation of this mod will complete and then batch installation will stop.");
-			batchCancellationButton.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					batchCancellationButton.setEnabled(false);
-					batchCancellationButton.setText("Canceling batch installation");
-					continueBatchInstallation = false;
-					ModManager.debugLogger.writeMessage("BATCH INSTALLATION CANCEL BUTTON WAS PRESSED. ABORTING FURTHER BATCH MODS");
-				}
-			});
-			rootPanel.add(batchCancellationButton, BorderLayout.SOUTH);
-		}
-		getContentPane().add(rootPanel);
-		pack();
-
-		addWindowListener(new WindowAdapter() {
-			@Override
-			public void windowClosing(WindowEvent e) {
-				if (!installFinished) {
-					continueBatchInstallation = false;
-					ModManager.debugLogger.writeMessage("User clicked X on install window");
-				}
-			}
-		});
-	}
-
-	/**
-	 * Handles mod installation
-	 * 
-	 * @author mgamerz
-	 *
-	 */
-	class InjectionCommander extends SwingWorker<Boolean, String> {
-		AtomicInteger completed = new AtomicInteger(0);
-		double numjobs = 0;
-		double taskSteps = 0;
-		double completedTaskSteps = 0;
-		ArrayList<String> failedJobs;
-		private BasegameHashDB bghDB;
-		private boolean installCancelled = false;
-		private boolean failedLoadingDB = false;
-		private HashMap<String, String> outdatedinstalledfolders;
-		private boolean skipTOC = false;
-		private ArrayList<Mod> mods;
-
-		protected InjectionCommander(ArrayList<Mod> mods) {
-			this.mods = new ArrayList<Mod>();
-			for (Mod mod : mods) {
-				this.mods.add(new Mod(mod)); //CLONE
-			}
-			ModManager.debugLogger.writeMessage("========Installing Mod(s) - Preprocessor========");
-			numjobs = 0;
-			for (Mod mod : this.mods) {
-				ModManager.debugLogger.writeMessage("Preprocessing: " + mod.getModName());
-				ModManager.debugLogger.writeMessage(" - Applying Automatic and Manual Alternate files to mod object");
-				mod.applyAutomaticAlternates(bioGameDir);
-				mod.applyManualAlternates(bioGameDir);
-				ModManager.debugLogger.writeMessage(" - Applying Manual Custom DLCs to mod object");
-				mod.applyManualCustomDLCs();
-				numjobs += mod.jobs.size();
-			}
-
-			failedJobs = new ArrayList<String>();
-			ModManager.debugLogger.writeMessage("Starting the InjectionCommander thread. Number of jobs to do: " + numjobs);
-		}
-
-		@Override
-		public Boolean doInBackground() {
-			ModManager.debugLogger.writeMessage("===========INJECTION COMMANDER BACKGROUND THREAD==============");
-			ModManager.debugLogger.writeMessage("Checking for DLC Bypass.");
-			if (!ModManager.hasKnownDLCBypass(bioGameDir)) {
-				ModManager.debugLogger.writeMessage("No DLC bypass detected, installing binkw32 bypass...");
-				if (!ModManager.installBinkw32Bypass(bioGameDir)) {
-					ModManager.debugLogger.writeError("Binkw32 bypass failed to install");
-				}
-			} else {
-				ModManager.debugLogger.writeMessage("A DLC bypass is installed");
-			}
-
-			boolean checkedDB = false;
-			ArrayList<ModJob> precheckJobs = new ArrayList<>();
-			for (Mod mod : mods) {
-				precheckJobs.addAll(mod.jobs);
-			}
-			for (ModJob job : precheckJobs) {
-				if (job.getJobName().equals(ModTypeConstants.CUSTOMDLC) || job.getJobName().equals(ModTypeConstants.TESTPATCH)) {
-					continue;
-				}
-				if ((job.getJobName().equals(ModTypeConstants.BASEGAME) && job.getFilesToReplaceTargets().size() == 0 && job.getFilesToRemoveTargets().size() == 0)) {
-					continue;
-				}
-
-				checkedDB = true;
-			}
-
-			if (!checkedDB) {
-				ModManager.debugLogger.writeMessage("Mod only adds files to basegame/adds custom DLC. The Game DB check will be skipped");
-			} else {
-				if (precheckGameDB(precheckJobs)) {
-					ModManager.debugLogger.writeMessage("Precheck DB method has returned true, indicating user wants to open repair DB and cancel mod install.");
-					skipTOC = true;
-					continueBatchInstallation = false;
-					return false;
-				} else {
-					ModManager.debugLogger.writeMessage("Precheck DB method has returned false, everything is OK and mod install will continue");
-				}
-			}
-
-			ModManager.debugLogger.writeMessage("Processing mod jobs in job queue.");
-			ExecutorService modinstallExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
-			ArrayList<Future<Boolean>> futures = new ArrayList<Future<Boolean>>();
-			for (ModJob job : precheckJobs) {
-				//submit jobs
-				JobTask jtask = new JobTask(job);
-				futures.add(modinstallExecutor.submit(jtask));
-			}
-			modinstallExecutor.shutdown();
-			try {
-				modinstallExecutor.awaitTermination(5, TimeUnit.MINUTES);
-				for (Future<Boolean> f : futures) {
-					boolean b = f.get();
-					if (!b) {
-						ModManager.debugLogger.writeError("A task failed!");
-						//throw some sort of error here...
-					}
-				}
-			} catch (ExecutionException e) {
-				ModManager.debugLogger.writeErrorWithException("EXECUTION EXCEPTION WHILE INSTALLING MOD: ", e);
-				return null;
-			} catch (Exception e) {
-				ModManager.debugLogger.writeErrorWithException("UNKNOWN EXCEPTION OCCURED: ", e);
-				return null;
-			}
-
-			checkForOutdatedDLC();
-
-			return true;
-		}
-
-		private void checkForOutdatedDLC() {
-			for (Mod mod : mods) {
-				if (mod.getOutdatedDLCModules().size() > 0) {
-					outdatedinstalledfolders = new HashMap<String, String>();
-					ArrayList<String> installedDLC = ModManager.getInstalledDLC(bioGameDir);
-					for (String installeddlcitem : installedDLC) {
-						for (String outdateditem : mod.getOutdatedDLCModules()) {
-							if (installeddlcitem.toUpperCase().equals(outdateditem.toUpperCase())) {
-								//outdated item is still installed.
-								outdatedinstalledfolders.put(mod.getModName(), outdateditem);
-							}
-						}
-					}
-				}
-			}
-
-		}
-
-		class JobTask implements Callable<Boolean> {
-			private ModJob job;
-
-			public JobTask(ModJob job) {
-				this.job = job;
-			}
-
-			@Override
-			public Boolean call() throws Exception {
-				if (installCancelled) {
-					return false;
-				}
-				boolean result = false;
-				switch (job.getJobType()) {
-				case ModJob.DLC:
-					result = processDLCJob(job);
-					break;
-				case ModJob.BASEGAME:
-					result = processBasegameJob(job);
-					break;
-				case ModJob.CUSTOMDLC:
-					result = processCustomDLCJob(job);
-					break;
-				case ModJob.BALANCE_CHANGES:
-					result = processBalanceChangesJob(job);
-					break;
-				}
-				//end of each callable...
-				if (result) {
-					completed.incrementAndGet();
-					ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Successfully finished mod job.");
-				} else {
-					ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Mod job failed: " + job.getDLCFilePath());
-					failedJobs.add(job.getDLCFilePath());
-				}
-				publish(Integer.toString(completed.get()));
-				return result;
-			}
-		}
-
-		/**
-		 * Checks the game DB for files in all jobs to see if any need to be
-		 * added.
-		 * 
-		 * @param jobs
-		 *            Jobs to check
-		 * @return true if user clicks YES to open DB window, false if they
-		 *         don't (or all is Ok)
-		 */
-		private boolean precheckGameDB(ArrayList<ModJob> jobs) {
-			ModManager.debugLogger.writeMessage("---PRECHECKING GAME DATABASE---");
-			File bgdir = new File(ModManager.appendSlash(bioGameDir));
-			String me3dir = ModManager.appendSlash(bgdir.getParent());
-
-			publish("Checking game database for files that need to be backed up");
-			if (bghDB == null) {
-				publish("Loading game repair database");
-				try {
-					bghDB = new BasegameHashDB(null, me3dir, false);
-				} catch (SQLException e) {
-					while (e.getNextException() != null) {
-						ModManager.debugLogger.writeErrorWithException("DB FAILED TO LOAD.", e);
-						e = e.getNextException();
-					}
-					return true;
-				}
-				if (bghDB == null) {
-					//cannot continue
-					failedLoadingDB = true;
-					JOptionPane.showMessageDialog(ModInstallWindow.this, "<html>The game repair database failed to load.<br>"
-							+ "Only one connection to the local repair database is allowed at a time.<br>"
-							+ "Please make sure you only have one instance of Mod Manager running.<br>Mod Manager appears as Java (TM) Platform Binary (or javaw.exe on Windows Vista/7) in Task Manager.<br><br>If the issue persists and you are sure only one instance is running, close Mod Manager and<br>delete the the data\\databases folder.<br>You will need to re-create the game repair database afterwards.<br><br>If this *STILL* does not fix your issue, please send a log to Mgamerz through the help menu.</html>",
-							"Database Failure", JOptionPane.ERROR_MESSAGE);
-					return true;
-				}
-
-			}
-			//check if DB exists
-			if (!bghDB.isBasegameTableCreated()) {
-				JOptionPane.showMessageDialog(ModInstallWindow.this,
-						"The game repair database has not been created.\nMods that affect the basegame or official DLC require the game repair database to install.",
-						"No Game Repair Database", JOptionPane.ERROR_MESSAGE);
-				continueBatchInstallation = false;
-				return true; //open DB window
-			}
-
-			for (ModJob job : jobs) {
-				if (job.getJobType() == ModJob.BALANCE_CHANGES) {
-					ModManager.debugLogger.writeMessage("Skipping GRDB check for balance changes job");
-					continue;
-				}
-				publish("Checking database on " + job.getJobName());
-				if (job.getJobType() == ModJob.BASEGAME && job.getFilesToReplaceTargets().size() > 0) {
-					//BGDB files are required
-					ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
-					int numFilesToReplace = filesToReplace.size();
-					for (int i = 0; i < numFilesToReplace; i++) {
-						String fileToReplace = filesToReplace.get(i);
-						if (FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
-							continue; //skip PCConsoleTOC as they'll be updated outside of mod installs. Especially the basegame one.
-						}
-						File basegamefile = new File(me3dir + fileToReplace);
-
-						String relative = ResourceUtils.getRelativePath(basegamefile.getAbsolutePath(), me3dir, File.separator);
-						RepairFileInfo rfi = bghDB.getFileInfo(relative);
-						if (rfi == null) {
-							ModManager.debugLogger.writeMessage("File not in GameDB, showing prompt: " + relative);
-							// file is missing. Basegame DB likely hasn't been made
-							int reply = JOptionPane.showConfirmDialog(ModInstallWindow.this, "<html>" + relative
-									+ " is not in the game repair database.<br>In order to restore basegame files and unpacked DLC files this database needs to be created or updated.<br>Open the database window?</html>",
-									"Mod Installation Warning", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-							if (reply == JOptionPane.NO_OPTION) {
-								return false;
-							} else {
-								return true;
-							}
-						}
-					}
-				} else {
-					//DLC files are not required... unless all are present
-					ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
-					ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
-					int numFilesToReplace = filesToReplace.size();
-					boolean fileIsMissing = false;
-					//Check for files to replace not being present for backup
-					for (int i = 0; i < numFilesToReplace; i++) {
-						String fileToReplace = filesToReplace.get(i);
-						File unpackeddlcfile = new File(me3dir + fileToReplace);
-						if (!unpackeddlcfile.exists()) {
-							fileIsMissing = true;
-							ModManager.debugLogger.writeMessage("Game DB: unpacked DLC file not present. DLC is assumed to still be in SFAR: " + job.getJobName());
-							break;
-						}
-					}
-
-					//Check for files to remove not being present for backup
-					for (String removeFile : filesToRemove) {
-						File unpackeddlcfile = new File(me3dir + removeFile);
-						if (!unpackeddlcfile.exists()) {
-							fileIsMissing = true;
-							ModManager.debugLogger.writeMessage("Game DB: unpacked DLC file not present. DLC is assumed to still be in SFAR: " + job.getJobName());
-							break;
-						}
-					}
-
-					if (fileIsMissing) {
-						continue;
-					}
-
-					//DLC appears unpacked					
-					for (int i = 0; i < numFilesToReplace; i++) {
-						String fileToReplace = filesToReplace.get(i);
-						if (FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
-							continue; //skip PCConsoleTOC as they'll be updated outside of mod installs. Especially the basegame one.
-						}
-						File unpackeddlcfile = new File(me3dir + fileToReplace);
-
-						//check if in GDB
-						String relative = ResourceUtils.getRelativePath(unpackeddlcfile.getAbsolutePath(), me3dir, File.separator);
-						RepairFileInfo rfi = bghDB.getFileInfo(relative);
-						if (rfi == null) {
-							// file is missing. Basegame DB likely hasn't been made
-							int reply = JOptionPane.showConfirmDialog(ModInstallWindow.this,
-									"<html>One or more of the files this mod is installing is not in the game repair database.<br>In order to restore game files this database needs to be created or updated.<br>Open the database window?</html>",
-									"Mod Installation Warning", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-							if (reply == JOptionPane.NO_OPTION) {
-								return false;
-							} else {
-								return true;
-							}
-						}
-					}
-				}
-			}
-			return false;
-		}
-
-		private boolean processBasegameJob(ModJob job) {
-			ModManager.debugLogger.writeMessage("===Processing a basegame job===");
-			completedTaskSteps = 0;
-			taskSteps = job.getFilesToReplace().size() + job.getFilesToAdd().size() + job.getFilesToRemoveTargets().size();
-			publish("Processing basegame files...");
-			File bgdir = new File(ModManager.appendSlash(bioGameDir));
-			String me3dir = ModManager.appendSlash(bgdir.getParent());
-			// Make backup folder if it doesn't exist
-			String backupfolderpath = me3dir.toString() + "cmmbackup\\";
-			File cmmbackupfolder = new File(backupfolderpath);
-			if (cmmbackupfolder.mkdirs()) {
-				ModManager.debugLogger.writeMessage("Created unpacked files backup directory.");
-			}
-			// Prep replacement job
-			{
-				ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
-				ArrayList<String> newFiles = job.getFilesToReplace();
-				int numFilesToReplace = filesToReplace.size();
-				ModManager.debugLogger.writeMessage("Number of files to replace in the basegame: " + numFilesToReplace);
-				for (int i = 0; i < numFilesToReplace; i++) {
-					String fileToReplace = filesToReplace.get(i);
-					String newFile = newFiles.get(i);
-
-					boolean shouldContinue = checkBackupAndHash(me3dir, fileToReplace, job);
-					if (!shouldContinue) {
-						installCancelled = true;
-						return false;
-					}
-
-					// install file.
-					File unpacked = new File(me3dir + fileToReplace);
-					Path originalpath = Paths.get(unpacked.toString());
-					if (!unpacked.getAbsolutePath().toLowerCase().endsWith("pcconsoletoc.bin")) {
-						try {
-							publish(ModTypeConstants.BASEGAME + ": Installing " + FilenameUtils.getName(newFile));
-							Path newfilepath = Paths.get(newFile);
-							Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
-							completedTaskSteps++;
-							ModManager.debugLogger.writeMessage("Installed mod file: " + newFile + " => " + unpacked);
-						} catch (IOException e) {
-							ModManager.debugLogger.writeException(e);
-							return false;
-						}
-					} else {
-						ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Post-Install TOC indicates we should skip installing PCConsoleTOC for this job");
-					}
-				}
-			}
-
-			//ADD TASKS
-			ArrayList<String> filesToAddTargets = job.getFilesToAddTargets();
-			ArrayList<String> filesToAdd = job.getFilesToAdd();
-			int numFilesToAdd = filesToAdd.size();
-			ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Number of files to add to the basegame: " + numFilesToAdd);
-			for (int i = 0; i < numFilesToAdd; i++) {
-				String fileToAddTarget = filesToAddTargets.get(i);
-				String fileToAdd = filesToAdd.get(i);
-				// install file.
-				File installFile = new File(me3dir + fileToAddTarget);
-				Path installPath = Paths.get(installFile.toString());
-				try {
-					publish(ModTypeConstants.BASEGAME + ": Installing " + FilenameUtils.getName(fileToAdd));
-					Path newfilepath = Paths.get(fileToAdd);
-					if (installFile.exists()) {
-						installFile.delete();
-					}
-					Files.copy(newfilepath, installPath, StandardCopyOption.REPLACE_EXISTING);
-					if (job.getAddFilesReadOnlyTargets().contains(fileToAddTarget)) {
-						installFile.setReadOnly();
-						ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Set read only: " + installFile);
-					}
-					completedTaskSteps++;
-					ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Installed mod file: " + fileToAdd + " => " + installFile);
-				} catch (IOException e) {
-					ModManager.debugLogger.writeException(e);
-					return false;
-				}
-			}
-
-			//REMOVAL TASKS
-			ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
-			ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Number of files to remove: " + filesToRemove.size());
-			for (String fileToRemove : filesToRemove) {
-				boolean userCanceled = checkBackupAndHash(me3dir, fileToRemove, job);
-				if (userCanceled) {
-					installCancelled = true;
-					return false;
-				}
-
-				// remove file.
-				File unpacked = new File(me3dir + fileToRemove);
-				ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Removing file: " + unpacked);
-				publish(job.getJobName() + ": Removing " + FilenameUtils.getName(unpacked.getAbsolutePath()));
-				FileUtils.deleteQuietly(unpacked);
-				completedTaskSteps++;
-				ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Deleted game file: " + unpacked);
-			}
-			return true;
-		}
-
-		private boolean processBalanceChangesJob(ModJob job) {
-			ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]===Processing a balance changes job===");
-			completedTaskSteps = 0;
-			taskSteps = job.getFilesToReplace().size() + job.getFilesToAdd().size() + job.getFilesToRemoveTargets().size();
-			publish("Processing balance changes files...");
-			File bgdir = new File(ModManager.appendSlash(bioGameDir));
-			String me3dir = ModManager.appendSlash(bgdir.getParent());
-
-			// Prep replacement job
-			{
-				ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
-				ArrayList<String> newFiles = job.getFilesToReplace();
-				int numFilesToReplace = filesToReplace.size();
-				ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Number of files to replace in the basegame (balance changes): " + numFilesToReplace);
-				for (int i = 0; i < numFilesToReplace; i++) {
-					String fileToReplace = filesToReplace.get(i);
-					String newFile = newFiles.get(i);
-
-					// install file.
-					File unpacked = new File(me3dir + fileToReplace);
-					Path originalpath = Paths.get(unpacked.toString());
-					try {
-						publish(ModTypeConstants.BASEGAME + ": Installing " + FilenameUtils.getName(newFile));
-						Path newfilepath = Paths.get(newFile);
-						if (!unpacked.getParentFile().exists()) {
-							unpacked.getParentFile().mkdirs();
-						}
-						Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
-						completedTaskSteps++;
-						ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Installed mod file: " + newFile + " => " + unpacked);
-					} catch (IOException e) {
-						ModManager.debugLogger.writeException(e);
-						return false;
-					}
-				}
-			}
-			return true;
-		}
-
-		/**
-		 * Processes a DLC job. Installs via SFAR (injection) if files in their
-		 * unpacked location do not exist.
-		 * 
-		 * @param job
-		 *            Job to install
-		 * @return true if successful, false otherwise
-		 */
-		private boolean processDLCJob(ModJob job) {
-			ModManager.debugLogger.writeMessage("===Processing a dlc job: " + job.getJobName() + "===");
-			File bgdir = new File(ModManager.appendSlash(bioGameDir));
-			String me3dir = ModManager.appendSlash(bgdir.getParent());
-
-			//Check for files to replace not being present
-			for (int i = 0; i < job.filesToReplaceTargets.size(); i++) {
-				String fileToReplace = job.filesToReplaceTargets.get(i);
-				File unpackeddlcfile = new File(me3dir + fileToReplace);
-				if (!unpackeddlcfile.exists()) {
-					ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Game DB: unpacked DLC file not present. DLC job will use SFAR method: " + job.getJobName());
-					return processSFARDLCJob(job);
-				}
-			}
-
-			//Check that the default.sfar file is not smaller than the normal size (typically means unpacked)
-			String sfarName = "Default.sfar";
-			if (job.TESTPATCH) {
-				sfarName = "Patch_001.sfar";
-			}
-			long knownsfarsize = ModTypeConstants.getSizesMap().get(job.getJobName());
-			String sfarPath = ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName;
-			File sfarFile = new File(sfarPath);
-			if (sfarFile.exists()) {
-				if (sfarName.equals("Patch_001.sfar") || sfarFile.length() >= knownsfarsize) {
-					ModManager.debugLogger.writeMessage("[" + job.getJobName()
-							+ "]SFAR is same or larger in bytes than the known original. Likely is the vanilla one, or has been modified, but not unpacked. Using the SFAR method: "
-							+ job.getJobName());
-					return processSFARDLCJob(job);
-				}
-			} else {
-				ModManager.debugLogger.writeError("[" + job.getJobName() + "]SFAR doesn't exist for unpacked DLC... interesting... " + sfarPath);
-			}
-
-			//We don't need to check for files to remove, as if it this is an unpacked DLC we can just skip the file. If it is missing in the DLC then there would be nothing we can do.
-
-			//UNPACKED DLC METHOD
-			return updateUnpackedDLC(job);
-		}
-
-		/**
-		 * Processes a DLC job using the unpacked DLC method
-		 * 
-		 * @param job
-		 *            job to conduct
-		 * @return true is successful, false otherwise
-		 */
-		private boolean updateUnpackedDLC(ModJob job) {
-			completedTaskSteps = 0;
-			taskSteps = job.getFilesToReplace().size() + job.getFilesToAdd().size() + job.getFilesToRemoveTargets().size();
-			publish(job.getJobName() + ": Installing using unpacked DLC method");
-			File bgdir = new File(ModManager.appendSlash(bioGameDir));
-			String me3dir = ModManager.appendSlash(bgdir.getParent());
-
-			// Make backup folder if it doesn't exist
-
-			//REPLACEMENT TASKS
-			ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
-			ArrayList<String> newFiles = job.getFilesToReplace();
-			int numFilesToReplace = filesToReplace.size();
-			ModManager.debugLogger.writeMessage("Number of files to replace in the DLC: " + numFilesToReplace);
-			for (int i = 0; i < numFilesToReplace; i++) {
-				String fileToReplace = filesToReplace.get(i);
-				String newFile = newFiles.get(i);
-
-				boolean shouldContinue = checkBackupAndHash(me3dir, fileToReplace, job);
-				if (!shouldContinue) {
-					installCancelled = true;
-					return false;
-				}
-
-				// install file.
-				File unpacked = new File(me3dir + fileToReplace);
-				Path originalpath = Paths.get(unpacked.toString());
-				if (!unpacked.getAbsolutePath().toLowerCase().endsWith("pcconsoletoc.bin")) {
-
-					try {
-						Path newfilepath = Paths.get(newFile);
-						Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
-						completedTaskSteps++;
-						ModManager.debugLogger.writeMessage("Installed mod file: " + newFile + " => " + originalpath);
-					} catch (IOException e) {
-						ModManager.debugLogger.writeException(e);
-						return false;
-					}
-				} else {
-					ModManager.debugLogger.writeMessage("Post-Install TOC indicates we should skip installing PCConsoleTOC for this job");
-
-				}
-			}
-
-			//ADD TASKS
-			ArrayList<String> filesToAdd = job.getFilesToAdd();
-			ArrayList<String> filesToAddTargets = job.getFilesToAddTargets();
-			int numFilesToAdd = filesToAddTargets.size();
-			ModManager.debugLogger.writeMessage("Number of files to add in the DLC: " + numFilesToAdd);
-			for (int i = 0; i < numFilesToAdd; i++) {
-				String addFile = filesToAdd.get(i);
-				String addFileTarget = filesToAddTargets.get(i);
-
-				// install file.
-				File unpacked = new File(me3dir + addFileTarget);
-				Path originalpath = Paths.get(unpacked.toString());
-				try {
-					ModManager.debugLogger.writeMessage("Adding new mod file: " + addFile);
-					publish(job.getJobName() + ": Adding new file " + FilenameUtils.getName(addFile));
-					Path newfilepath = Paths.get(addFile);
-					if (unpacked.exists()) {
-						unpacked.delete();
-					}
-					Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
-					if (job.getAddFilesReadOnlyTargets().contains(addFileTarget)) {
-						unpacked.setReadOnly();
-						ModManager.debugLogger.writeMessage("Set read-only: " + unpacked);
-					}
-					completedTaskSteps++;
-					ModManager.debugLogger.writeMessage("Added mod file: " + addFile);
-				} catch (IOException e) {
-					ModManager.debugLogger.writeException(e);
-					return false;
-				}
-			}
-
-			//REMOVAL TASKS
-			ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
-			ModManager.debugLogger.writeMessage("Number of files to remove: " + filesToRemove.size());
-			for (String fileToRemove : filesToRemove) {
-				boolean shouldContinue = checkBackupAndHash(me3dir, fileToRemove, job);
-				if (!shouldContinue) {
-					installCancelled = true;
-					return false;
-				}
-
-				// install file.
-				File unpacked = new File(me3dir + fileToRemove);
-				Path originalpath = Paths.get(unpacked.toString());
-				if (unpacked.exists()) {
-					try {
-						ModManager.debugLogger.writeMessage("Removing file: " + unpacked);
-						publish(job.getJobName() + ": Removing " + FilenameUtils.getName(unpacked.getAbsolutePath()));
-						Files.delete(originalpath);
-						completedTaskSteps++;
-						ModManager.debugLogger.writeMessage("Deleted mod file: " + unpacked);
-					} catch (IOException e) {
-						ModManager.debugLogger.writeException(e);
-						return false;
-					}
-				} else {
-					ModManager.debugLogger.writeMessage(unpacked + " was to be removed but does not exist, skipping");
-					completedTaskSteps++;
-					publish(job.getJobName() + ": " + FilenameUtils.getName(unpacked.getAbsolutePath()) + " not present for removal, skipping");
-				}
-			}
-			return true;
-		}
-
-		/**
-		 * Checks for a backup file and the hash of the original one in the DB
-		 * to make sure they match if no backup is found.
-		 * 
-		 * @param me3dir
-		 *            ME3 DIR to use as a base
-		 * @param fileToReplace
-		 *            file that will be replaced, as a relative path
-		 * @param job
-		 *            job (for outputting name)
-		 * @return true if file is backed up (and hashed OK), false if it is not
-		 *         backed up/error/hashfail
-		 */
-		private boolean checkBackupAndHash(String me3dir, String fileToReplace, ModJob job) {
-			String backupfolderpath = me3dir.toString() + "cmmbackup\\";
-			File cmmbackupfolder = new File(backupfolderpath);
-			boolean madeDir = cmmbackupfolder.mkdirs();
-			if (madeDir) {
-				ModManager.debugLogger.writeMessage("Created unpacked files backup directory.");
-			}
-
-			// Check for backup
-			File unpacked = new File(me3dir + fileToReplace);
-			File backupfile = new File(backupfolderpath + fileToReplace);
-			Path originalpath = Paths.get(unpacked.toString());
-
-			ModManager.debugLogger.writeMessage("Checking for backup file at " + backupfile);
-			if (!backupfile.exists()) {
-				// backup the file
-				if (bghDB == null) {
-					publish(job.getJobName() + ": Loading repair database");
-					try {
-						bghDB = new BasegameHashDB(null, me3dir, false);
-					} catch (SQLException e) {
-						installCancelled = true;
-						failedLoadingDB = true;
-						ModManager.debugLogger.writeErrorWithException("DB FAILED TO LOAD!", e);
-						return false;
-					}
-				}
-				Path backuppath = Paths.get(backupfile.toString());
-				backupfile.getParentFile().mkdirs();
-
-				String relative = ResourceUtils.getRelativePath(unpacked.getAbsolutePath(), me3dir, File.separator);
-				boolean installAndUpdate = false;
-
-				if (!FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
-					RepairFileInfo rfi = bghDB.getFileInfo(relative);
-					// validate file to backup.
-					boolean justInstall = false;
-					if (rfi == null) {
-						int reply = JOptionPane.showOptionDialog(ModInstallWindow.this, "<html><div style=\"width: 400px\">The file:<br>" + relative
-								+ "<br>is not in the repair database. "
-								+ "Installing/Removing this file may overwrite your default setup if you restore and have custom mods like texture swaps installed.</div></html>",
-								"Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-								new String[] { "Add to DB and install", "Install file", "Cancel mod installation" }, "default");
-						switch (reply) {
-						case JOptionPane.CANCEL_OPTION:
-							installCancelled = true;
-							return false;
-						case JOptionPane.NO_OPTION:
-							justInstall = true;
-							break;
-						case JOptionPane.YES_OPTION:
-							installAndUpdate = true;
-							break;
-						}
-					}
-
-					// Check filesize
-					if (!justInstall && !installAndUpdate) {
-						if (unpacked.length() != rfi.filesize) {
-							// MISMATCH!
-							int reply = JOptionPane.showOptionDialog(ModInstallWindow.this,
-									"<html>The filesize of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>" + unpacked.length()
-											+ " bytes (installed) vs " + rfi.filesize + " bytes (database)<br><br>"
-											+ "This file could be corrupted or modified since the database was created.<br>"
-											+ "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when you restore.<br></html>",
-									"Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-									new String[] { "Backup and update DB", "Backup this file", "Cancel mod installation" }, "default");
-							switch (reply) {
-							case JOptionPane.CANCEL_OPTION:
-								return false;
-							case JOptionPane.NO_OPTION:
-								justInstall = true;
-								break;
-							case JOptionPane.YES_OPTION:
-								installAndUpdate = true;
-								break;
-							}
-						}
-					}
-
-					// Check hash
-					if (!justInstall && !installAndUpdate) {
-						// this is outside of the previous if statement as the
-						// previous one could set the restoreAnyways variable
-						// again.
-						try {
-							if (!MD5Checksum.getMD5Checksum(unpacked.getAbsolutePath()).equals(rfi.md5)) {
-								int reply = JOptionPane.showOptionDialog(ModInstallWindow.this,
-										"<html>The hash of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>"
-												+ "This file has changed since the database was created.<br>"
-												+ "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when restoring.<br></html>",
-										"Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-										new String[] { "Backup and update DB", "Backup this file", "Cancel mod installation" }, "default");
-								switch (reply) {
-								case JOptionPane.CANCEL_OPTION:
-									return false;
-								case JOptionPane.NO_OPTION:
-									justInstall = true;
-									break;
-								case JOptionPane.YES_OPTION:
-									installAndUpdate = true;
-									break;
-								}
-							}
-						} catch (Exception e) {
-							ModManager.debugLogger.writeException(e);
-						}
-					}
-				}
-				try {
-					// backup and then copy file
-					Files.copy(originalpath, backuppath);
-					ModManager.debugLogger.writeMessage("Backed up " + fileToReplace);
-					if (installAndUpdate) {
-						ArrayList<File> updateFile = new ArrayList<File>();
-						updateFile.add(unpacked);
-						bghDB.updateDB(updateFile);
-					}
-				} catch (IOException e) {
-					ModManager.debugLogger.writeErrorWithException("ERROR BACKING UP FILE:", e);
-					return false;
-				}
-			}
-			return true;
-		}
-
-		/**
-		 * Processes a DLC job using the SFAR method
-		 * 
-		 * @param job
-		 *            job to conduct
-		 * @return true if success, false otherwise
-		 */
-		public boolean processSFARDLCJob(ModJob job) {
-			boolean result = true;
-			completedTaskSteps = 0;
-			taskSteps = 0;
-
-			//REPLACE JOB
-			if (job.getFilesToReplaceTargets().size() > 0) {
-
-				ArrayList<String> commandBuilder = new ArrayList<String>();
-				commandBuilder.add(ModManager.getCommandLineToolsDir() + "SFARTools-Inject.exe");
-				commandBuilder.add("--sfarpath");
-				String sfarName = "Default.sfar";
-				if (job.TESTPATCH) {
-					sfarName = "Patch_001.sfar";
-				}
-				File sfarFile = new File(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
-				if (!sfarFile.exists()) {
-					//missing module
-					ModManager.debugLogger.writeMessage("Missing DLC Module, skipping: " + sfarFile.getAbsolutePath());
-					publish("DLC is missing: " + job.getDLCFilePath());
-					return true;
-				}
-				commandBuilder.add(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
-				commandBuilder.add("--replacefiles");
-				commandBuilder.add("--files");
-
-				ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
-				ArrayList<String> newFiles = job.getFilesToReplace();
-				ModManager.debugLogger.writeMessage("Number of files to replace: " + filesToReplace.size());
-
-				publish("Updating " + filesToReplace.size() + " files in " + job.getJobName());
-				for (int i = 0; i < filesToReplace.size(); i++) {
-					commandBuilder.add(filesToReplace.get(i));
-
-					String newFile = newFiles.get(i);
-					commandBuilder.add(newFile);
-				}
-				int returncode = 1;
-				ProcessBuilder pb = new ProcessBuilder(commandBuilder);
-				ModManager.debugLogger.writeMessage("Executing process for DLC Injection Job.");
-				// p = Runtime.getRuntime().exec(command);
-				ProcessResult pr = ModManager.runProcess(pb);
-				returncode = pr.getReturnCode();
-				ModManager.debugLogger.writeMessage("Return code for process was 0: " + (returncode == 0));
-				result = (returncode == 0) && result;
-			}
-
-			//ADD FILE TASK
-			if (job.getFilesToAdd().size() > 0) {
-				ArrayList<String> commandBuilder = new ArrayList<String>();
-				commandBuilder.add(ModManager.getCommandLineToolsDir() + "SFARTools-Inject.exe");
-				commandBuilder.add("--sfarpath");
-				String sfarName = "Default.sfar";
-				if (job.TESTPATCH) {
-					sfarName = "Patch_001.sfar";
-				}
-				File sfarFile = new File(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
-				if (!sfarFile.exists()) {
-					//missing module
-					ModManager.debugLogger.writeMessage("Missing DLC Module, skipping: " + sfarFile.getAbsolutePath());
-					publish("DLC is missing: " + job.getDLCFilePath());
-					return true;
-				}
-				commandBuilder.add(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
-				commandBuilder.add("--addfiles");
-				commandBuilder.add("--files");
-				ArrayList<String> filesToAdd = job.getFilesToAdd();
-				ArrayList<String> filesToAddTargets = job.getFilesToAddTargets();
-				ModManager.debugLogger.writeMessage("Number of files to add: " + filesToAdd.size());
-
-				publish("Adding " + filesToAdd.size() + " files to " + job.getJobName());
-				for (int i = 0; i < filesToAdd.size(); i++) {
-					commandBuilder.add(filesToAddTargets.get(i));
-					commandBuilder.add(filesToAdd.get(i));
-				}
-
-				String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
-				StringBuilder sb = new StringBuilder();
-				for (String arg : command) {
-					sb.append(arg + " ");
-				}
-				ModManager.debugLogger.writeMessage("[" + job.getJobName() + "] Executing injection");
-				int returncode = 1;
-				ProcessBuilder pb = new ProcessBuilder(command);
-				ModManager.debugLogger.writeMessage("Executing process for SFAR File Injection (Adding files).");
-				ProcessResult pr = ModManager.runProcess(pb, job.getJobName());
-				returncode = pr.getReturnCode();
-				ModManager.debugLogger.writeMessage("ProcessSFARJob ADD FILES returned 0: " + (returncode == 0));
-				result = (returncode == 0) && result;
-			}
-
-			//REMOVE FILE TASK
-			if (job.getFilesToRemoveTargets().size() > 0) {
-				ArrayList<String> commandBuilder = new ArrayList<String>();
-				commandBuilder.add(ModManager.getCommandLineToolsDir() + "SFARTools-Inject.exe");
-				commandBuilder.add("--sfarpath");
-				String sfarName = "Default.sfar";
-				if (job.TESTPATCH) {
-					sfarName = "Patch_001.sfar";
-				}
-				File sfarFile = new File(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
-				if (!sfarFile.exists()) {
-					//missing module
-					ModManager.debugLogger.writeMessage("Missing DLC Module, skipping: " + sfarFile.getAbsolutePath());
-					publish("DLC is missing: " + job.getDLCFilePath());
-					return true;
-				}
-				commandBuilder.add(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
-				commandBuilder.add("--deletefiles");
-				commandBuilder.add("--files");
-				ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
-				ModManager.debugLogger.writeMessage("Number of files to remove: " + filesToRemove.size());
-
-				publish("Removing " + filesToRemove.size() + " files from " + job.getJobName() + ", this may take some time...");
-				for (int i = 0; i < filesToRemove.size(); i++) {
-					commandBuilder.add(filesToRemove.get(i));
-				}
-
-				String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
-				StringBuilder sb = new StringBuilder();
-				for (String arg : command) {
-					sb.append(arg + " ");
-				}
-				ModManager.debugLogger.writeMessage("Executing removal command: " + sb.toString());
-				int returncode = 1;
-				ProcessBuilder pb = new ProcessBuilder(command);
-				returncode = ModManager.runProcess(pb).getReturnCode();
-				result = returncode == 0 && result;
-			}
-			return result;
-		}
-
-		/**
-		 * Copies the CUSTOMDLC folder to the specified directory
-		 * 
-		 * @param job
-		 *            job describing the customDLC job
-		 * @return true if successful, false otherwise.
-		 */
-		private boolean processCustomDLCJob(ModJob job) {
-			ModManager.debugLogger.writeMessage("===Processing a customdlc job===");
-			ArrayList<String> destfolders = job.getDestFolders();
-			File dlcdir = new File(ModManager.appendSlash(bioGameDir) + "DLC" + File.separator);
-			for (String folder : destfolders) {
-				File dlcFolder = new File(dlcdir + File.separator + folder);
-				if (dlcFolder.exists() && dlcFolder.isDirectory()) {
-					ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Deleting existing CustomDLC folder: " + dlcFolder);
-					FileUtils.deleteQuietly(dlcFolder);
-				}
-
-				dlcFolder = new File(dlcdir + File.separator + "x" + folder);
-				if (dlcFolder.exists() && dlcFolder.isDirectory()) {
-					ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Deleting disabled CustomDLC folder: " + dlcFolder);
-					FileUtils.deleteQuietly(dlcFolder);
-				}
-			}
-			taskSteps = job.getFilesToReplaceTargets().size();
-			completedTaskSteps = 0;
-			ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Number of files to install: " + taskSteps);
-			for (int i = 0; i < job.getFilesToReplaceTargets().size(); i++) {
-				String target = job.getFilesToReplaceTargets().get(i);
-				String fileDestination = dlcdir + target;
-				String fileSource = job.getFilesToReplace().get(i);
-				// install file.
-				try {
-					publish(ModTypeConstants.CUSTOMDLC + ": Installing " + FilenameUtils.getName(fileSource));
-					Path sourcePath = Paths.get(fileSource);
-					Path destPath = Paths.get(fileDestination);
-					File dest = new File(fileDestination);
-					dest.mkdirs();
-					Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);
-					completedTaskSteps++;
-					ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Installed mod file: " + fileSource + " => " + fileDestination);
-
-				} catch (IOException e) {
-					ModManager.debugLogger.writeErrorWithException("[CUSTOMDLC JOB]Installing custom dlc file failed:", e);
-					return false;
-				}
-			}
-			//autotoc if necessary, create metadata file
-			Set<String> destinationFoldersUnique = new HashSet<>(job.getDestFolders());
-			for (String str : destinationFoldersUnique) {
-				if (str.contains("\\") || str.contains("/")) {
-					continue; //skip
-				}
-				String metadatapath = dlcdir + File.separator + str + File.separator + CUSTOMDLC_METADATA_FILE;
-				MetaCMM.writeMetaCMMFile(job.getOwningMod(), metadatapath);
-			}
-			return true;
-		}
-
-		@Override
-		protected void process(List<String> updates) {
-			for (String update : updates) {
-				if (numjobs != 0) {
-					int fullJobCompletion = (int) (((double) completed.get() / numjobs) * 100);
-					if (taskSteps != 0) {
-						fullJobCompletion += (int) (((completedTaskSteps / taskSteps) * 100) / numjobs);
-					}
-					progressBar.setValue(fullJobCompletion);
-				}
-				try {
-					Double.parseDouble(update); // see if we got a number. if we
-					// did that means we should
-					// update the bar
-				} catch (NumberFormatException e) {
-					// this is not a progress update, it's a string update
-					addToQueue(update);
-				}
-			}
-
-		}
-
-		@Override
-		protected void done() {
-			boolean success = false;
-			boolean hasException = false;
-			try {
-				success = get();
-			} catch (InterruptedException e) {
-				ModManager.debugLogger.writeException(e);
-				hasException = true;
-			} catch (ExecutionException e) {
-				ModManager.debugLogger.writeException(e);
-				hasException = true;
-			}
-
-			if (outdatedinstalledfolders != null && outdatedinstalledfolders.size() > 0) {
-				for (Map.Entry<String, String> entry : outdatedinstalledfolders.entrySet()) {
-					String modname = entry.getKey();
-					String outdated = entry.getValue();
-
-					int result = JOptionPane.showConfirmDialog(ModInstallWindow.this, "<html><div style='width: 400px'>" + modname
-							+ "'s mod descriptor indicates that the currently installed CustomDLC " + outdated + "(" + ME3TweaksUtils.getThirdPartyModName(outdated, false)
-							+ ") is not compatible/no longer necessary for this mod. The mod indicates they should be deleted as they may conflict with this mod.<br><br>Delete the Custom DLC folder "
-							+ outdated + "?</div></html>", "Outdated CustomDLC detected", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-					if (result == JOptionPane.YES_OPTION) {
-						String deleteFolder = bioGameDir + "DLC/" + outdated;
-						ModManager.debugLogger.writeMessage("Deleting outdated custom DLC: " + deleteFolder);
-						boolean deleted = false;//FileUtils.deleteQuietly(new File(deleteFolder));
-						if (deleted) {
-							ModManager.debugLogger.writeMessage("Deleted outdated custom DLC: " + deleteFolder);
-							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Deleted " + outdated);
-						} else {
-							ModManager.debugLogger.writeError("deleteQuietly() returned false when attempting to delete outdated custom DLC: " + deleteFolder);
-							ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Failed to " + outdated);
-							JOptionPane.showMessageDialog(ModInstallWindow.this, "Failed to delete custom DLC folder:\n" + deleteFolder, "Outdated Custom DLC deletion failed",
-									JOptionPane.ERROR_MESSAGE);
-						}
-					} else {
-						ModManager.debugLogger.writeMessage("User declined deleting outdated DLC: " + outdated);
-					}
-				}
-			} else {
-				ModManager.debugLogger.writeMessage("No outdated custom dlc to remove, continuing install...");
-			}
-
-			if (!skipTOC) {
-				ModManager.debugLogger.writeMessage("Running Game-Wide AutoTOC after mod install");
-				new AutoTocWindow(bioGameDir);
-			}
-
-			if (success) {
-				if (numjobs != completed.get()) {
-					// failed something
-					StringBuilder sb = new StringBuilder();
-					sb.append(
-							"Failed to process mod installation.\nSome parts of the install may have succeeded.\nCheck the log file by copying it to the clipboard in the help menu.");
-					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Failed to install at least 1 part of mod");
-					ModManager.debugLogger
-							.writeMessage("Some mods failed to fully install. Jobs required to copmlete: " + numjobs + ", while injectioncommander only reported " + completed);
-					JOptionPane.showMessageDialog(ModInstallWindow.this, sb.toString(), "Error", JOptionPane.ERROR_MESSAGE);
-				} else {
-					// we're good
-					if (mods.size() > 1) {
-						ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(mods.size() + " mods installed");
-					} else {
-						ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(mods.get(0).getModName() + " installed");
-					}
-					for (Mod mod : mods) {
-						for (ModJob job : mod.jobs) {
-							if (job.getJobType() == ModJob.BALANCE_CHANGES) {
-								if (ModManager.checkIfASIBinkBypassIsInstalled(bioGameDir)) {
-									if (!ASIModWindow.IsASIModGroupInstalled(5)) { //update group 5 = Balance Changes on ME3Tweaks
+    private boolean continueBatchInstallation = true;
+    private JLabel infoLabel;
+    private String bioGameDir;
+    private final int levelCount = 7;
+    private JTextArea consoleArea;
+    private String consoleQueue[];
+    private JProgressBar progressBar;
+    private JButton batchCancellationButton;
+    private BatchPackage batchPackage;
+    public final static String CUSTOMDLC_METADATA_FILE = "_metacmm.txt";
+    private boolean installFinished = false;
+
+    public ModInstallWindow(JFrame callingWindow, ArrayList<Mod> mods, BatchPackage batchpackage) {
+        super(null, Dialog.ModalityType.APPLICATION_MODAL);
+        this.batchPackage = batchpackage;
+        initWindow(callingWindow, mods);
+    }
+
+    public ModInstallWindow(JDialog callingWindow, ArrayList<Mod> mods, BatchPackage batchpackage) {
+        super(null, Dialog.ModalityType.APPLICATION_MODAL);
+        this.batchPackage = batchpackage;
+        initWindow(callingWindow, mods);
+    }
+
+    /**
+     * Install a single mod, with an optional batch package.
+     *
+     * @param callingWindow Dialog to center against
+     * @param mod           Mod to install
+     * @param batchpackage  Batch package. Used to slightly modify the UI for batch
+     *                      installation mode. Can be null.
+     */
+    public ModInstallWindow(JDialog callingWindow, Mod mod, BatchPackage batchpackage) {
+        super(null, Dialog.ModalityType.APPLICATION_MODAL);
+        this.batchPackage = batchpackage;
+        ArrayList<Mod> mods = new ArrayList<Mod>();
+        mods.add(mod);
+        initWindow(callingWindow, mods);
+    }
+
+    /**
+     * Install a single mod, with an optional batch package.
+     *
+     * @param callingWindow Frame to center against
+     * @param mod           Mod to install
+     * @param batchpackage  Batch package. Used to slightly modify the UI for batch
+     *                      installation mode. Can be null.
+     */
+    public ModInstallWindow(JFrame callingWindow, Mod mod, BatchPackage batchpackage) {
+        super(null, Dialog.ModalityType.APPLICATION_MODAL);
+        this.batchPackage = batchpackage;
+        ArrayList<Mod> mods = new ArrayList<Mod>();
+        mods.add(mod);
+        initWindow(callingWindow, mods);
+    }
+
+    private void initWindow(Component callingWindow, ArrayList<Mod> mods) {
+        this.bioGameDir = ModManagerWindow.GetBioGameDir();
+
+        consoleQueue = new String[levelCount];
+        setupWindow(mods);
+        setLocationRelativeTo(callingWindow);
+        checkModCMMVersion(callingWindow, mods);
+        boolean installMod = validateRequiredModulesAreAvailable(callingWindow, mods);
+        if (installMod) {
+            new InjectionCommander(mods).execute();
+            setVisible(true);
+        } else {
+            ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Mod install cancelled");
+            dispose();
+        }
+    }
+
+    /**
+     * Checks to make sure that the MODDESC can be fully parsed.
+     *
+     * @param mods mod to check against
+     */
+    private void checkModCMMVersion(Component callingWindow, ArrayList<Mod> mods) {
+        for (Mod mod : mods) {
+            if (mod.getCMMVer() > ModManager.MODDESC_VERSION_SUPPORT) {
+                JOptionPane
+                        .showMessageDialog(callingWindow,
+                                mod.getModName() + "'s moddesc.ini file indicates it uses a higher version of the moddesc specification than this build supports: "
+                                        + mod.getCMMVer() + ".\nMod Manager will attempt to install the mod but it may not work.",
+                                "Outdated Mod Manager", JOptionPane.WARNING_MESSAGE);
+            }
+        }
+    }
+
+    /**
+     * Checks that the modjobs required modules are available and prompts if
+     * they aren't
+     *
+     * @return true if all are available or user ignored missing
+     */
+    private boolean validateRequiredModulesAreAvailable(Component callingWindow, ArrayList<Mod> mods) {
+        ArrayList<ModJob> missingModules = new ArrayList<ModJob>();
+        StringBuilder sb = new StringBuilder();
+        for (Mod mod : mods) {
+            for (ModJob job : mod.jobs) {
+                if (job.getJobType() == ModJob.DLC) {
+                    String commandlinetoolsdir = ModManager.getCommandLineToolsDir();
+                    File fullautotoc = new File(commandlinetoolsdir + "FullAutoTOC.exe");
+                    File sfarinjector = new File(commandlinetoolsdir + "SFARTools-Inject.exe");
+                    if (!fullautotoc.exists() || !sfarinjector.exists()) {
+                        dispose();
+                        ModManager.debugLogger.writeError("Mod Manager Command Line tools are not available. Aborting installation");
+                        JOptionPane.showMessageDialog(ModInstallWindow.this,
+                                "Installation of mods requires the Mod Manager Command Line tools library.\nThis will automatically download on startup when connected to the internet.\nMod installation cannot continue.",
+                                "Required Component Missing", JOptionPane.ERROR_MESSAGE);
+                        return false;
+                    }
+
+                    //check that sfar is available
+                    String sfarName = "Default.sfar";
+                    if (job.TESTPATCH) {
+                        sfarName = "Patch_001.sfar";
+                    }
+                    String sfarPath = ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName;
+                    File sfar = new File(sfarPath);
+                    if (!sfar.exists()) {
+                        ModManager.debugLogger.writeMessage("Installation module is missing: " + sfar);
+                        missingModules.add(job);
+                    }
+                }
+            }
+
+            //module is missing
+            sb.append(mod.getModName() + " has jobs for the following missing DLC.\nIf the mod descriptor details the job description, they will be listed below.\n");
+            for (ModJob job : missingModules) {
+                ModManager.debugLogger.writeMessage(mod.getModName() + " requires missing DLC Module: " + job.getJobName());
+                sb.append(" - ");
+                sb.append(job.getJobName());
+                sb.append("\n");
+                if (job.getRequirementText() != null && !job.getRequirementText().equals("")) {
+                    sb.append("   - ");
+                    sb.append(job.getRequirementText());
+                    sb.append("\n");
+                }
+            }
+        }
+        if (missingModules.size() <= 0) {
+            ModManager.debugLogger.writeMessage("Mod has all required DLCs available");
+            return true;
+        }
+        sb.append("\nThese jobs will be skipped. Continue with the mod install?");
+        int result = JOptionPane.showConfirmDialog(callingWindow, sb.toString(), "Missing DLC", JOptionPane.WARNING_MESSAGE);
+        ModManager.debugLogger.writeMessage(result == JOptionPane.YES_OPTION ? "User continuing install even with missing DLC modules" : "User canceled Mod Install");
+        return result == JOptionPane.YES_OPTION;
+    }
+
+    private void setupWindow(ArrayList<Mod> mods) {
+        setTitle("Applying Mod" + (mods.size() > 1 ? "s" : ""));
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        setPreferredSize(new Dimension(320, batchPackage != null ? 250 : 220));
+        setIconImages(ModManager.ICONS);
+        JPanel rootPanel = new JPanel(new BorderLayout());
+        JPanel northPanel = new JPanel(new BorderLayout());
+        if (mods.size() == 1) {
+            if (batchPackage != null) {
+                infoLabel = new JLabel("<html><center>Now Installing [" + batchPackage.currentBatchInstallationNumber + "/" + batchPackage.totalBatchMods + "]<br>"
+                        + mods.get(0).getModName() + "</center></html>", SwingConstants.CENTER);
+            } else {
+                infoLabel = new JLabel("<html><center>Now Installing<br>" + mods.get(0).getModName() + "</center></html>", SwingConstants.CENTER);
+            }
+        } else {
+            infoLabel = new JLabel("<html><center>Now Installing<br>" + mods.size() + " mods</center></html>", SwingConstants.CENTER);
+
+        }
+        northPanel.add(infoLabel, BorderLayout.NORTH);
+        progressBar = new JProgressBar(0, 100);
+        progressBar.setStringPainted(true);
+        progressBar.setIndeterminate(false);
+
+        northPanel.add(progressBar, BorderLayout.SOUTH);
+        northPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
+        rootPanel.add(northPanel, BorderLayout.NORTH);
+
+        consoleArea = new JTextArea();
+        consoleArea.setLineWrap(true);
+        consoleArea.setWrapStyleWord(true);
+
+        consoleArea.setEditable(false);
+
+        rootPanel.add(consoleArea, BorderLayout.CENTER);
+
+        if (batchPackage != null) {
+            batchCancellationButton = new JButton("Cancel batch installation");
+            batchCancellationButton.setToolTipText("Cancels batch mod installation. Installation of this mod will complete and then batch installation will stop.");
+            batchCancellationButton.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    batchCancellationButton.setEnabled(false);
+                    batchCancellationButton.setText("Canceling batch installation");
+                    continueBatchInstallation = false;
+                    ModManager.debugLogger.writeMessage("BATCH INSTALLATION CANCEL BUTTON WAS PRESSED. ABORTING FURTHER BATCH MODS");
+                }
+            });
+            rootPanel.add(batchCancellationButton, BorderLayout.SOUTH);
+        }
+        getContentPane().add(rootPanel);
+        pack();
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                if (!installFinished) {
+                    continueBatchInstallation = false;
+                    ModManager.debugLogger.writeMessage("User clicked X on install window");
+                }
+            }
+        });
+    }
+
+    /**
+     * Handles mod installation
+     *
+     * @author mgamerz
+     */
+    class InjectionCommander extends SwingWorker<Boolean, String> {
+        AtomicInteger completed = new AtomicInteger(0);
+        double numjobs = 0;
+        double taskSteps = 0;
+        double completedTaskSteps = 0;
+        ArrayList<String> failedJobs;
+        private BasegameHashDB bghDB;
+        private boolean installCancelled = false;
+        private boolean failedLoadingDB = false;
+        private HashMap<String, String> outdatedinstalledfolders;
+        private boolean skipTOC = false;
+        private ArrayList<Mod> mods;
+        private boolean abortInstallation;
+
+        protected InjectionCommander(ArrayList<Mod> mods) {
+            this.mods = new ArrayList<Mod>();
+            for (Mod mod : mods) {
+                this.mods.add(new Mod(mod)); //CLONE
+            }
+
+            ModManager.debugLogger.writeMessage("========Installing Mod(s) - Preprocessor========");
+            numjobs = 0;
+            for (Mod mod : this.mods) {
+                ModManager.debugLogger.writeMessage("Preprocessing: " + mod.getModName());
+                ModManager.debugLogger.writeMessage(" - Applying Automatic and Manual Alternate files to mod object");
+                mod.applyAutomaticAlternates(bioGameDir);
+                mod.applyManualAlternates(bioGameDir);
+                ModManager.debugLogger.writeMessage(" - Applying Manual Custom DLCs to mod object");
+                mod.applyManualCustomDLCs();
+                ModManager.debugLogger.writeMessage(" - Compacting installation list to only unique files");
+                mod.compactInstallationTargets();
+                if (mod.validateTargetListSizes()) {
+                    numjobs += mod.jobs.size();
+                } else {
+                    abortInstallation = true;
+                    JOptionPane.showMessageDialog(ModInstallWindow.this, "<html>The list of targets and source files is not the same.<br>"
+                                    + "This is a bug in Mod Manager. Please report this issue to Mgamerz on the ME3Tweaks Discord server.<br>You can find the link in the help menu.",
+                            "Installation precheck failure", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+
+            failedJobs = new ArrayList<String>();
+            ModManager.debugLogger.writeMessage("Starting the InjectionCommander thread. Number of jobs to do: " + numjobs);
+        }
+
+        @Override
+        public Boolean doInBackground() {
+            ModManager.debugLogger.writeMessage("===========INJECTION COMMANDER BACKGROUND THREAD==============");
+            if (abortInstallation) {
+                ModManager.debugLogger.writeMessage("Installation was aborted in thread startup");
+                return false;
+            }
+            ModManager.debugLogger.writeMessage("Checking for DLC Bypass.");
+            if (!ModManager.hasKnownDLCBypass(bioGameDir)) {
+                ModManager.debugLogger.writeMessage("No DLC bypass detected, installing binkw32 bypass...");
+                if (!ModManager.installBinkw32Bypass(bioGameDir)) {
+                    ModManager.debugLogger.writeError("Binkw32 bypass failed to install");
+                }
+            } else {
+                ModManager.debugLogger.writeMessage("A DLC bypass is installed");
+            }
+
+            boolean checkedDB = false;
+            ArrayList<ModJob> precheckJobs = new ArrayList<>();
+            for (Mod mod : mods) {
+                precheckJobs.addAll(mod.jobs);
+            }
+            for (ModJob job : precheckJobs) {
+                if (job.getJobName().equals(ModTypeConstants.CUSTOMDLC) || job.getJobName().equals(ModTypeConstants.TESTPATCH)) {
+                    continue;
+                }
+                if ((job.getJobName().equals(ModTypeConstants.BASEGAME) && job.getFilesToReplaceTargets().size() == 0 && job.getFilesToRemoveTargets().size() == 0)) {
+                    continue;
+                }
+
+                checkedDB = true;
+            }
+
+            if (!checkedDB) {
+                ModManager.debugLogger.writeMessage("Mod only adds files to basegame/adds custom DLC. The Game DB check will be skipped");
+            } else {
+                if (precheckGameDB(precheckJobs)) {
+                    ModManager.debugLogger.writeMessage("Precheck DB method has returned true, indicating user wants to open repair DB and cancel mod install.");
+                    skipTOC = true;
+                    continueBatchInstallation = false;
+                    return false;
+                } else {
+                    ModManager.debugLogger.writeMessage("Precheck DB method has returned false, everything is OK and mod install will continue");
+                }
+            }
+
+            ModManager.debugLogger.writeMessage("Processing mod jobs in job queue.");
+            ExecutorService modinstallExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+            ArrayList<Future<Boolean>> futures = new ArrayList<Future<Boolean>>();
+            for (ModJob job : precheckJobs) {
+                //submit jobs
+                JobTask jtask = new JobTask(job);
+                futures.add(modinstallExecutor.submit(jtask));
+            }
+            modinstallExecutor.shutdown();
+            try {
+                modinstallExecutor.awaitTermination(5, TimeUnit.MINUTES);
+                for (Future<Boolean> f : futures) {
+                    boolean b = f.get();
+                    if (!b) {
+                        ModManager.debugLogger.writeError("A task failed!");
+                        //throw some sort of error here...
+                    }
+                }
+            } catch (ExecutionException e) {
+                ModManager.debugLogger.writeErrorWithException("EXECUTION EXCEPTION WHILE INSTALLING MOD: ", e);
+                return null;
+            } catch (Exception e) {
+                ModManager.debugLogger.writeErrorWithException("UNKNOWN EXCEPTION OCCURED: ", e);
+                return null;
+            }
+
+            checkForOutdatedDLC();
+
+            return true;
+        }
+
+        private void checkForOutdatedDLC() {
+            for (Mod mod : mods) {
+                if (mod.getOutdatedDLCModules().size() > 0) {
+                    outdatedinstalledfolders = new HashMap<String, String>();
+                    ArrayList<String> installedDLC = ModManager.getInstalledDLC(bioGameDir);
+                    for (String installeddlcitem : installedDLC) {
+                        for (String outdateditem : mod.getOutdatedDLCModules()) {
+                            if (installeddlcitem.toUpperCase().equals(outdateditem.toUpperCase())) {
+                                //outdated item is still installed.
+                                outdatedinstalledfolders.put(mod.getModName(), outdateditem);
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
+        class JobTask implements Callable<Boolean> {
+            private ModJob job;
+
+            public JobTask(ModJob job) {
+                this.job = job;
+            }
+
+            @Override
+            public Boolean call() throws Exception {
+                if (installCancelled) {
+                    return false;
+                }
+                boolean result = false;
+                switch (job.getJobType()) {
+                    case ModJob.DLC:
+                        result = processDLCJob(job);
+                        break;
+                    case ModJob.BASEGAME:
+                        result = processBasegameJob(job);
+                        break;
+                    case ModJob.CUSTOMDLC:
+                        result = processCustomDLCJob(job);
+                        break;
+                    case ModJob.BALANCE_CHANGES:
+                        result = processBalanceChangesJob(job);
+                        break;
+                }
+                //end of each callable...
+                if (result) {
+                    completed.incrementAndGet();
+                    ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Successfully finished mod job.");
+                } else {
+                    ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Mod job failed: " + job.getDLCFilePath());
+                    failedJobs.add(job.getDLCFilePath());
+                }
+                publish(Integer.toString(completed.get()));
+                return result;
+            }
+        }
+
+        /**
+         * Checks the game DB for files in all jobs to see if any need to be
+         * added.
+         *
+         * @param jobs Jobs to check
+         * @return true if user clicks YES to open DB window, false if they
+         * don't (or all is Ok)
+         */
+        private boolean precheckGameDB(ArrayList<ModJob> jobs) {
+            ModManager.debugLogger.writeMessage("---PRECHECKING GAME DATABASE---");
+            File bgdir = new File(ModManager.appendSlash(bioGameDir));
+            String me3dir = ModManager.appendSlash(bgdir.getParent());
+
+            publish("Checking game database for files that need to be backed up");
+            if (bghDB == null) {
+                publish("Loading game repair database");
+                try {
+                    bghDB = new BasegameHashDB(null, me3dir, false);
+                } catch (SQLException e) {
+                    while (e.getNextException() != null) {
+                        ModManager.debugLogger.writeErrorWithException("DB FAILED TO LOAD.", e);
+                        e = e.getNextException();
+                    }
+                    return true;
+                }
+                if (bghDB == null) {
+                    //cannot continue
+                    failedLoadingDB = true;
+                    JOptionPane.showMessageDialog(ModInstallWindow.this, "<html>The game repair database failed to load.<br>"
+                                    + "Only one connection to the local repair database is allowed at a time.<br>"
+                                    + "Please make sure you only have one instance of Mod Manager running.<br>Mod Manager appears as Java (TM) Platform Binary (or javaw.exe on Windows Vista/7) in Task Manager.<br><br>If the issue persists and you are sure only one instance is running, close Mod Manager and<br>delete the the data\\databases folder.<br>You will need to re-create the game repair database afterwards.<br><br>If this *STILL* does not fix your issue, please send a log to Mgamerz through the help menu.</html>",
+                            "Database Failure", JOptionPane.ERROR_MESSAGE);
+                    return true;
+                }
+
+            }
+            //check if DB exists
+            if (!bghDB.isBasegameTableCreated()) {
+                JOptionPane.showMessageDialog(ModInstallWindow.this,
+                        "The game repair database has not been created.\nMods that affect the basegame or official DLC require the game repair database to install.",
+                        "No Game Repair Database", JOptionPane.ERROR_MESSAGE);
+                continueBatchInstallation = false;
+                return true; //open DB window
+            }
+
+            for (ModJob job : jobs) {
+                if (job.getJobType() == ModJob.BALANCE_CHANGES) {
+                    ModManager.debugLogger.writeMessage("Skipping GRDB check for balance changes job");
+                    continue;
+                }
+                publish("Checking database on " + job.getJobName());
+                if (job.getJobType() == ModJob.BASEGAME && job.getFilesToReplaceTargets().size() > 0) {
+                    //BGDB files are required
+                    ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
+                    int numFilesToReplace = filesToReplace.size();
+                    for (int i = 0; i < numFilesToReplace; i++) {
+                        String fileToReplace = filesToReplace.get(i);
+                        if (FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
+                            continue; //skip PCConsoleTOC as they'll be updated outside of mod installs. Especially the basegame one.
+                        }
+                        File basegamefile = new File(me3dir + fileToReplace);
+
+                        String relative = ResourceUtils.getRelativePath(basegamefile.getAbsolutePath(), me3dir, File.separator);
+                        RepairFileInfo rfi = bghDB.getFileInfo(relative);
+                        if (rfi == null) {
+                            ModManager.debugLogger.writeMessage("File not in GameDB, showing prompt: " + relative);
+                            // file is missing. Basegame DB likely hasn't been made
+                            int reply = JOptionPane.showConfirmDialog(ModInstallWindow.this, "<html>" + relative
+                                            + " is not in the game repair database.<br>In order to restore basegame files and unpacked DLC files this database needs to be created or updated.<br>Open the database window?</html>",
+                                    "Mod Installation Warning", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                            if (reply == JOptionPane.NO_OPTION) {
+                                return false;
+                            } else {
+                                return true;
+                            }
+                        }
+                    }
+                } else {
+                    //DLC files are not required... unless all are present
+                    ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
+                    ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
+                    int numFilesToReplace = filesToReplace.size();
+                    boolean fileIsMissing = false;
+                    //Check for files to replace not being present for backup
+                    for (int i = 0; i < numFilesToReplace; i++) {
+                        String fileToReplace = filesToReplace.get(i);
+                        File unpackeddlcfile = new File(me3dir + fileToReplace);
+                        if (!unpackeddlcfile.exists()) {
+                            fileIsMissing = true;
+                            ModManager.debugLogger.writeMessage("Game DB: unpacked DLC file not present. DLC is assumed to still be in SFAR: " + job.getJobName());
+                            break;
+                        }
+                    }
+
+                    //Check for files to remove not being present for backup
+                    for (String removeFile : filesToRemove) {
+                        File unpackeddlcfile = new File(me3dir + removeFile);
+                        if (!unpackeddlcfile.exists()) {
+                            fileIsMissing = true;
+                            ModManager.debugLogger.writeMessage("Game DB: unpacked DLC file not present. DLC is assumed to still be in SFAR: " + job.getJobName());
+                            break;
+                        }
+                    }
+
+                    if (fileIsMissing) {
+                        continue;
+                    }
+
+                    //DLC appears unpacked
+                    for (int i = 0; i < numFilesToReplace; i++) {
+                        String fileToReplace = filesToReplace.get(i);
+                        if (FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
+                            continue; //skip PCConsoleTOC as they'll be updated outside of mod installs. Especially the basegame one.
+                        }
+                        File unpackeddlcfile = new File(me3dir + fileToReplace);
+
+                        //check if in GDB
+                        String relative = ResourceUtils.getRelativePath(unpackeddlcfile.getAbsolutePath(), me3dir, File.separator);
+                        RepairFileInfo rfi = bghDB.getFileInfo(relative);
+                        if (rfi == null) {
+                            // file is missing. Basegame DB likely hasn't been made
+                            int reply = JOptionPane.showConfirmDialog(ModInstallWindow.this,
+                                    "<html>One or more of the files this mod is installing is not in the game repair database.<br>In order to restore game files this database needs to be created or updated.<br>Open the database window?</html>",
+                                    "Mod Installation Warning", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                            if (reply == JOptionPane.NO_OPTION) {
+                                return false;
+                            } else {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        private boolean processBasegameJob(ModJob job) {
+            ModManager.debugLogger.writeMessage("===Processing a basegame job===");
+            completedTaskSteps = 0;
+            taskSteps = job.getFilesToReplace().size() + job.getFilesToAdd().size() + job.getFilesToRemoveTargets().size();
+            publish("Processing basegame files...");
+            File bgdir = new File(ModManager.appendSlash(bioGameDir));
+            String me3dir = ModManager.appendSlash(bgdir.getParent());
+            // Make backup folder if it doesn't exist
+            String backupfolderpath = me3dir.toString() + "cmmbackup\\";
+            File cmmbackupfolder = new File(backupfolderpath);
+            if (cmmbackupfolder.mkdirs()) {
+                ModManager.debugLogger.writeMessage("Created unpacked files backup directory.");
+            }
+            // Prep replacement job
+            {
+                ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
+                ArrayList<String> newFiles = job.getFilesToReplace();
+                int numFilesToReplace = filesToReplace.size();
+                ModManager.debugLogger.writeMessage("Number of files to replace in the basegame: " + numFilesToReplace);
+                for (int i = 0; i < numFilesToReplace; i++) {
+                    String fileToReplace = filesToReplace.get(i);
+                    String newFile = newFiles.get(i);
+
+                    boolean shouldContinue = checkBackupAndHash(me3dir, fileToReplace, job);
+                    if (!shouldContinue) {
+                        installCancelled = true;
+                        return false;
+                    }
+
+                    // install file.
+                    File unpacked = new File(me3dir + fileToReplace);
+                    Path originalpath = Paths.get(unpacked.toString());
+                    if (!unpacked.getAbsolutePath().toLowerCase().endsWith("pcconsoletoc.bin")) {
+                        try {
+                            publish(ModTypeConstants.BASEGAME + ": Installing " + FilenameUtils.getName(newFile));
+                            Path newfilepath = Paths.get(newFile);
+                            Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
+                            completedTaskSteps++;
+                            ModManager.debugLogger.writeMessage("Installed mod file: " + newFile + " => " + unpacked);
+                        } catch (IOException e) {
+                            ModManager.debugLogger.writeException(e);
+                            return false;
+                        }
+                    } else {
+                        ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Post-Install TOC indicates we should skip installing PCConsoleTOC for this job");
+                    }
+                }
+            }
+
+            //ADD TASKS
+            ArrayList<String> filesToAddTargets = job.getFilesToAddTargets();
+            ArrayList<String> filesToAdd = job.getFilesToAdd();
+            int numFilesToAdd = filesToAdd.size();
+            ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Number of files to add to the basegame: " + numFilesToAdd);
+            for (int i = 0; i < numFilesToAdd; i++) {
+                String fileToAddTarget = filesToAddTargets.get(i);
+                String fileToAdd = filesToAdd.get(i);
+                // install file.
+                File installFile = new File(me3dir + fileToAddTarget);
+                Path installPath = Paths.get(installFile.toString());
+                try {
+                    publish(ModTypeConstants.BASEGAME + ": Installing " + FilenameUtils.getName(fileToAdd));
+                    Path newfilepath = Paths.get(fileToAdd);
+                    if (installFile.exists()) {
+                        installFile.delete();
+                    }
+                    Files.copy(newfilepath, installPath, StandardCopyOption.REPLACE_EXISTING);
+                    if (job.getAddFilesReadOnlyTargets().contains(fileToAddTarget)) {
+                        installFile.setReadOnly();
+                        ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Set read only: " + installFile);
+                    }
+                    completedTaskSteps++;
+                    ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Installed mod file: " + fileToAdd + " => " + installFile);
+                } catch (IOException e) {
+                    ModManager.debugLogger.writeException(e);
+                    return false;
+                }
+            }
+
+            //REMOVAL TASKS
+            ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
+            ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Number of files to remove: " + filesToRemove.size());
+            for (String fileToRemove : filesToRemove) {
+                boolean userCanceled = checkBackupAndHash(me3dir, fileToRemove, job);
+                if (userCanceled) {
+                    installCancelled = true;
+                    return false;
+                }
+
+                // remove file.
+                File unpacked = new File(me3dir + fileToRemove);
+                ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Removing file: " + unpacked);
+                publish(job.getJobName() + ": Removing " + FilenameUtils.getName(unpacked.getAbsolutePath()));
+                FileUtils.deleteQuietly(unpacked);
+                completedTaskSteps++;
+                ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Deleted game file: " + unpacked);
+            }
+            return true;
+        }
+
+        private boolean processBalanceChangesJob(ModJob job) {
+            ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]===Processing a balance changes job===");
+            completedTaskSteps = 0;
+            taskSteps = job.getFilesToReplace().size() + job.getFilesToAdd().size() + job.getFilesToRemoveTargets().size();
+            publish("Processing balance changes files...");
+            File bgdir = new File(ModManager.appendSlash(bioGameDir));
+            String me3dir = ModManager.appendSlash(bgdir.getParent());
+
+            // Prep replacement job
+            {
+                ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
+                ArrayList<String> newFiles = job.getFilesToReplace();
+                int numFilesToReplace = filesToReplace.size();
+                ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Number of files to replace in the basegame (balance changes): " + numFilesToReplace);
+                for (int i = 0; i < numFilesToReplace; i++) {
+                    String fileToReplace = filesToReplace.get(i);
+                    String newFile = newFiles.get(i);
+
+                    // install file.
+                    File unpacked = new File(me3dir + fileToReplace);
+                    Path originalpath = Paths.get(unpacked.toString());
+                    try {
+                        publish(ModTypeConstants.BASEGAME + ": Installing " + FilenameUtils.getName(newFile));
+                        Path newfilepath = Paths.get(newFile);
+                        if (!unpacked.getParentFile().exists()) {
+                            unpacked.getParentFile().mkdirs();
+                        }
+                        Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
+                        completedTaskSteps++;
+                        ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Installed mod file: " + newFile + " => " + unpacked);
+                    } catch (IOException e) {
+                        ModManager.debugLogger.writeException(e);
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Processes a DLC job. Installs via SFAR (injection) if files in their
+         * unpacked location do not exist.
+         *
+         * @param job Job to install
+         * @return true if successful, false otherwise
+         */
+        private boolean processDLCJob(ModJob job) {
+            ModManager.debugLogger.writeMessage("===Processing a dlc job: " + job.getJobName() + "===");
+            File bgdir = new File(ModManager.appendSlash(bioGameDir));
+            String me3dir = ModManager.appendSlash(bgdir.getParent());
+
+            //Check for files to replace not being present
+            for (int i = 0; i < job.filesToReplaceTargets.size(); i++) {
+                String fileToReplace = job.filesToReplaceTargets.get(i);
+                File unpackeddlcfile = new File(me3dir + fileToReplace);
+                if (!unpackeddlcfile.exists()) {
+                    ModManager.debugLogger.writeMessage("[" + job.getJobName() + "]Game DB: unpacked DLC file not present. DLC job will use SFAR method: " + job.getJobName());
+                    return processSFARDLCJob(job);
+                }
+            }
+
+            //Check that the default.sfar file is not smaller than the normal size (typically means unpacked)
+            String sfarName = "Default.sfar";
+            if (job.TESTPATCH) {
+                sfarName = "Patch_001.sfar";
+            }
+            long knownsfarsize = ModTypeConstants.getSizesMap().get(job.getJobName());
+            String sfarPath = ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName;
+            File sfarFile = new File(sfarPath);
+            if (sfarFile.exists()) {
+                if (sfarName.equals("Patch_001.sfar") || sfarFile.length() >= knownsfarsize) {
+                    ModManager.debugLogger.writeMessage("[" + job.getJobName()
+                            + "]SFAR is same or larger in bytes than the known original. Likely is the vanilla one, or has been modified, but not unpacked. Using the SFAR method: "
+                            + job.getJobName());
+                    return processSFARDLCJob(job);
+                }
+            } else {
+                ModManager.debugLogger.writeError("[" + job.getJobName() + "]SFAR doesn't exist for unpacked DLC... interesting... " + sfarPath);
+            }
+
+            //We don't need to check for files to remove, as if it this is an unpacked DLC we can just skip the file. If it is missing in the DLC then there would be nothing we can do.
+
+            //UNPACKED DLC METHOD
+            return updateUnpackedDLC(job);
+        }
+
+        /**
+         * Processes a DLC job using the unpacked DLC method
+         *
+         * @param job job to conduct
+         * @return true is successful, false otherwise
+         */
+        private boolean updateUnpackedDLC(ModJob job) {
+            completedTaskSteps = 0;
+            taskSteps = job.getFilesToReplace().size() + job.getFilesToAdd().size() + job.getFilesToRemoveTargets().size();
+            publish(job.getJobName() + ": Installing using unpacked DLC method");
+            File bgdir = new File(ModManager.appendSlash(bioGameDir));
+            String me3dir = ModManager.appendSlash(bgdir.getParent());
+
+            // Make backup folder if it doesn't exist
+
+            //REPLACEMENT TASKS
+            ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
+            ArrayList<String> newFiles = job.getFilesToReplace();
+            int numFilesToReplace = filesToReplace.size();
+            ModManager.debugLogger.writeMessage("Number of files to replace in the DLC: " + numFilesToReplace);
+            for (int i = 0; i < numFilesToReplace; i++) {
+                String fileToReplace = filesToReplace.get(i);
+                String newFile = newFiles.get(i);
+
+                boolean shouldContinue = checkBackupAndHash(me3dir, fileToReplace, job);
+                if (!shouldContinue) {
+                    installCancelled = true;
+                    return false;
+                }
+
+                // install file.
+                File unpacked = new File(me3dir + fileToReplace);
+                Path originalpath = Paths.get(unpacked.toString());
+                if (!unpacked.getAbsolutePath().toLowerCase().endsWith("pcconsoletoc.bin")) {
+
+                    try {
+                        Path newfilepath = Paths.get(newFile);
+                        Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
+                        completedTaskSteps++;
+                        ModManager.debugLogger.writeMessage("Installed mod file: " + newFile + " => " + originalpath);
+                    } catch (IOException e) {
+                        ModManager.debugLogger.writeException(e);
+                        return false;
+                    }
+                } else {
+                    ModManager.debugLogger.writeMessage("Post-Install TOC indicates we should skip installing PCConsoleTOC for this job");
+
+                }
+            }
+
+            //ADD TASKS
+            ArrayList<String> filesToAdd = job.getFilesToAdd();
+            ArrayList<String> filesToAddTargets = job.getFilesToAddTargets();
+            int numFilesToAdd = filesToAddTargets.size();
+            ModManager.debugLogger.writeMessage("Number of files to add in the DLC: " + numFilesToAdd);
+            for (int i = 0; i < numFilesToAdd; i++) {
+                String addFile = filesToAdd.get(i);
+                String addFileTarget = filesToAddTargets.get(i);
+
+                // install file.
+                File unpacked = new File(me3dir + addFileTarget);
+                Path originalpath = Paths.get(unpacked.toString());
+                try {
+                    ModManager.debugLogger.writeMessage("Adding new mod file: " + addFile);
+                    publish(job.getJobName() + ": Adding new file " + FilenameUtils.getName(addFile));
+                    Path newfilepath = Paths.get(addFile);
+                    if (unpacked.exists()) {
+                        unpacked.delete();
+                    }
+                    Files.copy(newfilepath, originalpath, StandardCopyOption.REPLACE_EXISTING);
+                    if (job.getAddFilesReadOnlyTargets().contains(addFileTarget)) {
+                        unpacked.setReadOnly();
+                        ModManager.debugLogger.writeMessage("Set read-only: " + unpacked);
+                    }
+                    completedTaskSteps++;
+                    ModManager.debugLogger.writeMessage("Added mod file: " + addFile);
+                } catch (IOException e) {
+                    ModManager.debugLogger.writeException(e);
+                    return false;
+                }
+            }
+
+            //REMOVAL TASKS
+            ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
+            ModManager.debugLogger.writeMessage("Number of files to remove: " + filesToRemove.size());
+            for (String fileToRemove : filesToRemove) {
+                boolean shouldContinue = checkBackupAndHash(me3dir, fileToRemove, job);
+                if (!shouldContinue) {
+                    installCancelled = true;
+                    return false;
+                }
+
+                // install file.
+                File unpacked = new File(me3dir + fileToRemove);
+                Path originalpath = Paths.get(unpacked.toString());
+                if (unpacked.exists()) {
+                    try {
+                        ModManager.debugLogger.writeMessage("Removing file: " + unpacked);
+                        publish(job.getJobName() + ": Removing " + FilenameUtils.getName(unpacked.getAbsolutePath()));
+                        Files.delete(originalpath);
+                        completedTaskSteps++;
+                        ModManager.debugLogger.writeMessage("Deleted mod file: " + unpacked);
+                    } catch (IOException e) {
+                        ModManager.debugLogger.writeException(e);
+                        return false;
+                    }
+                } else {
+                    ModManager.debugLogger.writeMessage(unpacked + " was to be removed but does not exist, skipping");
+                    completedTaskSteps++;
+                    publish(job.getJobName() + ": " + FilenameUtils.getName(unpacked.getAbsolutePath()) + " not present for removal, skipping");
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Checks for a backup file and the hash of the original one in the DB
+         * to make sure they match if no backup is found.
+         *
+         * @param me3dir        ME3 DIR to use as a base
+         * @param fileToReplace file that will be replaced, as a relative path
+         * @param job           job (for outputting name)
+         * @return true if file is backed up (and hashed OK), false if it is not
+         * backed up/error/hashfail
+         */
+        private boolean checkBackupAndHash(String me3dir, String fileToReplace, ModJob job) {
+            String backupfolderpath = me3dir.toString() + "cmmbackup\\";
+            File cmmbackupfolder = new File(backupfolderpath);
+            boolean madeDir = cmmbackupfolder.mkdirs();
+            if (madeDir) {
+                ModManager.debugLogger.writeMessage("Created unpacked files backup directory.");
+            }
+
+            // Check for backup
+            File unpacked = new File(me3dir + fileToReplace);
+            File backupfile = new File(backupfolderpath + fileToReplace);
+            Path originalpath = Paths.get(unpacked.toString());
+
+            ModManager.debugLogger.writeMessage("Checking for backup file at " + backupfile);
+            if (!backupfile.exists()) {
+                // backup the file
+                if (bghDB == null) {
+                    publish(job.getJobName() + ": Loading repair database");
+                    try {
+                        bghDB = new BasegameHashDB(null, me3dir, false);
+                    } catch (SQLException e) {
+                        installCancelled = true;
+                        failedLoadingDB = true;
+                        ModManager.debugLogger.writeErrorWithException("DB FAILED TO LOAD!", e);
+                        return false;
+                    }
+                }
+                Path backuppath = Paths.get(backupfile.toString());
+                backupfile.getParentFile().mkdirs();
+
+                String relative = ResourceUtils.getRelativePath(unpacked.getAbsolutePath(), me3dir, File.separator);
+                boolean installAndUpdate = false;
+
+                if (!FilenameUtils.getName(fileToReplace).equalsIgnoreCase("PCConsoleTOC.bin")) {
+                    RepairFileInfo rfi = bghDB.getFileInfo(relative);
+                    // validate file to backup.
+                    boolean justInstall = false;
+                    if (rfi == null) {
+                        int reply = JOptionPane.showOptionDialog(ModInstallWindow.this, "<html><div style=\"width: 400px\">The file:<br>" + relative
+                                        + "<br>is not in the repair database. "
+                                        + "Installing/Removing this file may overwrite your default setup if you restore and have custom mods like texture swaps installed.</div></html>",
+                                "Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+                                new String[]{"Add to DB and install", "Install file", "Cancel mod installation"}, "default");
+                        switch (reply) {
+                            case JOptionPane.CANCEL_OPTION:
+                                installCancelled = true;
+                                return false;
+                            case JOptionPane.NO_OPTION:
+                                justInstall = true;
+                                break;
+                            case JOptionPane.YES_OPTION:
+                                installAndUpdate = true;
+                                break;
+                        }
+                    }
+
+                    // Check filesize
+                    if (!justInstall && !installAndUpdate) {
+                        if (unpacked.length() != rfi.filesize) {
+                            // MISMATCH!
+                            int reply = JOptionPane.showOptionDialog(ModInstallWindow.this,
+                                    "<html>The filesize of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>" + unpacked.length()
+                                            + " bytes (installed) vs " + rfi.filesize + " bytes (database)<br><br>"
+                                            + "This file could be corrupted or modified since the database was created.<br>"
+                                            + "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when you restore.<br></html>",
+                                    "Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+                                    new String[]{"Backup and update DB", "Backup this file", "Cancel mod installation"}, "default");
+                            switch (reply) {
+                                case JOptionPane.CANCEL_OPTION:
+                                    return false;
+                                case JOptionPane.NO_OPTION:
+                                    justInstall = true;
+                                    break;
+                                case JOptionPane.YES_OPTION:
+                                    installAndUpdate = true;
+                                    break;
+                            }
+                        }
+                    }
+
+                    // Check hash
+                    if (!justInstall && !installAndUpdate) {
+                        // this is outside of the previous if statement as the
+                        // previous one could set the restoreAnyways variable
+                        // again.
+                        try {
+                            if (!MD5Checksum.getMD5Checksum(unpacked.getAbsolutePath()).equals(rfi.md5)) {
+                                int reply = JOptionPane.showOptionDialog(ModInstallWindow.this,
+                                        "<html>The hash of the file:<br>" + relative + "<br>does not match the one stored in the repair game database.<br>"
+                                                + "This file has changed since the database was created.<br>"
+                                                + "Backing up this file may overwrite your default setup if you use custom mods like texture swaps when restoring.<br></html>",
+                                        "Backing Up Unverified File", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+                                        new String[]{"Backup and update DB", "Backup this file", "Cancel mod installation"}, "default");
+                                switch (reply) {
+                                    case JOptionPane.CANCEL_OPTION:
+                                        return false;
+                                    case JOptionPane.NO_OPTION:
+                                        justInstall = true;
+                                        break;
+                                    case JOptionPane.YES_OPTION:
+                                        installAndUpdate = true;
+                                        break;
+                                }
+                            }
+                        } catch (Exception e) {
+                            ModManager.debugLogger.writeException(e);
+                        }
+                    }
+                }
+                try {
+                    // backup and then copy file
+                    Files.copy(originalpath, backuppath);
+                    ModManager.debugLogger.writeMessage("Backed up " + fileToReplace);
+                    if (installAndUpdate) {
+                        ArrayList<File> updateFile = new ArrayList<File>();
+                        updateFile.add(unpacked);
+                        bghDB.updateDB(updateFile);
+                    }
+                } catch (IOException e) {
+                    ModManager.debugLogger.writeErrorWithException("ERROR BACKING UP FILE:", e);
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Processes a DLC job using the SFAR method
+         *
+         * @param job job to conduct
+         * @return true if success, false otherwise
+         */
+        public boolean processSFARDLCJob(ModJob job) {
+            boolean result = true;
+            completedTaskSteps = 0;
+            taskSteps = 0;
+
+            //REPLACE JOB
+            if (job.getFilesToReplaceTargets().size() > 0) {
+
+                ArrayList<String> commandBuilder = new ArrayList<String>();
+                commandBuilder.add(ModManager.getCommandLineToolsDir() + "SFARTools-Inject.exe");
+                commandBuilder.add("--sfarpath");
+                String sfarName = "Default.sfar";
+                if (job.TESTPATCH) {
+                    sfarName = "Patch_001.sfar";
+                }
+                File sfarFile = new File(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
+                if (!sfarFile.exists()) {
+                    //missing module
+                    ModManager.debugLogger.writeMessage("Missing DLC Module, skipping: " + sfarFile.getAbsolutePath());
+                    publish("DLC is missing: " + job.getDLCFilePath());
+                    return true;
+                }
+                commandBuilder.add(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
+                commandBuilder.add("--replacefiles");
+                commandBuilder.add("--files");
+
+                ArrayList<String> filesToReplace = job.getFilesToReplaceTargets();
+                ArrayList<String> newFiles = job.getFilesToReplace();
+                ModManager.debugLogger.writeMessage("Number of files to replace: " + filesToReplace.size());
+
+                publish("Updating " + filesToReplace.size() + " files in " + job.getJobName());
+                for (int i = 0; i < filesToReplace.size(); i++) {
+                    commandBuilder.add(filesToReplace.get(i));
+
+                    String newFile = newFiles.get(i);
+                    commandBuilder.add(newFile);
+                }
+                int returncode = 1;
+                ProcessBuilder pb = new ProcessBuilder(commandBuilder);
+                ModManager.debugLogger.writeMessage("Executing process for DLC Injection Job.");
+                // p = Runtime.getRuntime().exec(command);
+                ProcessResult pr = ModManager.runProcess(pb);
+                returncode = pr.getReturnCode();
+                ModManager.debugLogger.writeMessage("Return code for process was 0: " + (returncode == 0));
+                result = (returncode == 0) && result;
+            }
+
+            //ADD FILE TASK
+            if (job.getFilesToAdd().size() > 0) {
+                ArrayList<String> commandBuilder = new ArrayList<String>();
+                commandBuilder.add(ModManager.getCommandLineToolsDir() + "SFARTools-Inject.exe");
+                commandBuilder.add("--sfarpath");
+                String sfarName = "Default.sfar";
+                if (job.TESTPATCH) {
+                    sfarName = "Patch_001.sfar";
+                }
+                File sfarFile = new File(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
+                if (!sfarFile.exists()) {
+                    //missing module
+                    ModManager.debugLogger.writeMessage("Missing DLC Module, skipping: " + sfarFile.getAbsolutePath());
+                    publish("DLC is missing: " + job.getDLCFilePath());
+                    return true;
+                }
+                commandBuilder.add(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
+                commandBuilder.add("--addfiles");
+                commandBuilder.add("--files");
+                ArrayList<String> filesToAdd = job.getFilesToAdd();
+                ArrayList<String> filesToAddTargets = job.getFilesToAddTargets();
+                ModManager.debugLogger.writeMessage("Number of files to add: " + filesToAdd.size());
+
+                publish("Adding " + filesToAdd.size() + " files to " + job.getJobName());
+                for (int i = 0; i < filesToAdd.size(); i++) {
+                    commandBuilder.add(filesToAddTargets.get(i));
+                    commandBuilder.add(filesToAdd.get(i));
+                }
+
+                String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
+                StringBuilder sb = new StringBuilder();
+                for (String arg : command) {
+                    sb.append(arg + " ");
+                }
+                ModManager.debugLogger.writeMessage("[" + job.getJobName() + "] Executing injection");
+                int returncode = 1;
+                ProcessBuilder pb = new ProcessBuilder(command);
+                ModManager.debugLogger.writeMessage("Executing process for SFAR File Injection (Adding files).");
+                ProcessResult pr = ModManager.runProcess(pb, job.getJobName());
+                returncode = pr.getReturnCode();
+                ModManager.debugLogger.writeMessage("ProcessSFARJob ADD FILES returned 0: " + (returncode == 0));
+                result = (returncode == 0) && result;
+            }
+
+            //REMOVE FILE TASK
+            if (job.getFilesToRemoveTargets().size() > 0) {
+                ArrayList<String> commandBuilder = new ArrayList<String>();
+                commandBuilder.add(ModManager.getCommandLineToolsDir() + "SFARTools-Inject.exe");
+                commandBuilder.add("--sfarpath");
+                String sfarName = "Default.sfar";
+                if (job.TESTPATCH) {
+                    sfarName = "Patch_001.sfar";
+                }
+                File sfarFile = new File(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
+                if (!sfarFile.exists()) {
+                    //missing module
+                    ModManager.debugLogger.writeMessage("Missing DLC Module, skipping: " + sfarFile.getAbsolutePath());
+                    publish("DLC is missing: " + job.getDLCFilePath());
+                    return true;
+                }
+                commandBuilder.add(ModManager.appendSlash(bioGameDir) + ModManager.appendSlash(job.getDLCFilePath()) + sfarName);
+                commandBuilder.add("--deletefiles");
+                commandBuilder.add("--files");
+                ArrayList<String> filesToRemove = job.getFilesToRemoveTargets();
+                ModManager.debugLogger.writeMessage("Number of files to remove: " + filesToRemove.size());
+
+                publish("Removing " + filesToRemove.size() + " files from " + job.getJobName() + ", this may take some time...");
+                for (int i = 0; i < filesToRemove.size(); i++) {
+                    commandBuilder.add(filesToRemove.get(i));
+                }
+
+                String[] command = commandBuilder.toArray(new String[commandBuilder.size()]);
+                StringBuilder sb = new StringBuilder();
+                for (String arg : command) {
+                    sb.append(arg + " ");
+                }
+                ModManager.debugLogger.writeMessage("Executing removal command: " + sb.toString());
+                int returncode = 1;
+                ProcessBuilder pb = new ProcessBuilder(command);
+                returncode = ModManager.runProcess(pb).getReturnCode();
+                result = returncode == 0 && result;
+            }
+            return result;
+        }
+
+        /**
+         * Copies the CUSTOMDLC folder to the specified directory
+         *
+         * @param job job describing the customDLC job
+         * @return true if successful, false otherwise.
+         */
+        private boolean processCustomDLCJob(ModJob job) {
+            ModManager.debugLogger.writeMessage("===Processing a customdlc job===");
+            ArrayList<String> destfolders = job.getDestFolders();
+            File dlcdir = new File(ModManager.appendSlash(bioGameDir) + "DLC" + File.separator);
+            for (String folder : destfolders) {
+                File dlcFolder = new File(dlcdir + File.separator + folder);
+                if (dlcFolder.exists() && dlcFolder.isDirectory()) {
+                    ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Deleting existing CustomDLC folder: " + dlcFolder);
+                    FileUtils.deleteQuietly(dlcFolder);
+                }
+
+                dlcFolder = new File(dlcdir + File.separator + "x" + folder);
+                if (dlcFolder.exists() && dlcFolder.isDirectory()) {
+                    ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Deleting disabled CustomDLC folder: " + dlcFolder);
+                    FileUtils.deleteQuietly(dlcFolder);
+                }
+            }
+            taskSteps = job.getFilesToReplaceTargets().size();
+            completedTaskSteps = 0;
+            ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Number of files to install: " + taskSteps);
+            for (int i = 0; i < job.getFilesToReplaceTargets().size(); i++) {
+                String target = job.getFilesToReplaceTargets().get(i);
+                String fileDestination = dlcdir + target;
+                String fileSource = job.getFilesToReplace().get(i);
+                // install file.
+                try {
+                    publish(ModTypeConstants.CUSTOMDLC + ": Installing " + FilenameUtils.getName(fileSource));
+                    Path sourcePath = Paths.get(fileSource);
+                    Path destPath = Paths.get(fileDestination);
+                    File dest = new File(fileDestination);
+                    dest.mkdirs();
+                    Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);
+                    completedTaskSteps++;
+                    ModManager.debugLogger.writeMessage("[CUSTOMDLC JOB]Installed mod file: " + fileSource + " => " + fileDestination);
+
+                } catch (IOException e) {
+                    ModManager.debugLogger.writeErrorWithException("[CUSTOMDLC JOB]Installing custom dlc file failed:", e);
+                    return false;
+                }
+            }
+            //autotoc if necessary, create metadata file
+            Set<String> destinationFoldersUnique = new HashSet<>(job.getDestFolders());
+            for (String str : destinationFoldersUnique) {
+                if (str.contains("\\") || str.contains("/")) {
+                    continue; //skip
+                }
+                String metadatapath = dlcdir + File.separator + str + File.separator + CUSTOMDLC_METADATA_FILE;
+                MetaCMM.writeMetaCMMFile(job.getOwningMod(), metadatapath);
+            }
+            return true;
+        }
+
+        @Override
+        protected void process(List<String> updates) {
+            for (String update : updates) {
+                if (numjobs != 0) {
+                    int fullJobCompletion = (int) (((double) completed.get() / numjobs) * 100);
+                    if (taskSteps != 0) {
+                        fullJobCompletion += (int) (((completedTaskSteps / taskSteps) * 100) / numjobs);
+                    }
+                    progressBar.setValue(fullJobCompletion);
+                }
+                try {
+                    Double.parseDouble(update); // see if we got a number. if we
+                    // did that means we should
+                    // update the bar
+                } catch (NumberFormatException e) {
+                    // this is not a progress update, it's a string update
+                    addToQueue(update);
+                }
+            }
+
+        }
+
+        @Override
+        protected void done() {
+            boolean success = false;
+            boolean hasException = false;
+            try {
+                success = get();
+            } catch (InterruptedException e) {
+                ModManager.debugLogger.writeException(e);
+                hasException = true;
+            } catch (ExecutionException e) {
+                ModManager.debugLogger.writeException(e);
+                hasException = true;
+            }
+
+            if (!abortInstallation) {
+                if (outdatedinstalledfolders != null && outdatedinstalledfolders.size() > 0) {
+                    for (Map.Entry<String, String> entry : outdatedinstalledfolders.entrySet()) {
+                        String modname = entry.getKey();
+                        String outdated = entry.getValue();
+
+                        int result = JOptionPane.showConfirmDialog(ModInstallWindow.this, "<html><div style='width: 400px'>" + modname
+                                + "'s mod descriptor indicates that the currently installed CustomDLC " + outdated + "(" + ME3TweaksUtils.getThirdPartyModName(outdated, false)
+                                + ") is not compatible/no longer necessary for this mod. The mod indicates they should be deleted as they may conflict with this mod.<br><br>Delete the Custom DLC folder "
+                                + outdated + "?</div></html>", "Outdated CustomDLC detected", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                        if (result == JOptionPane.YES_OPTION) {
+                            String deleteFolder = bioGameDir + "DLC/" + outdated;
+                            ModManager.debugLogger.writeMessage("Deleting outdated custom DLC: " + deleteFolder);
+                            boolean deleted = false;//FileUtils.deleteQuietly(new File(deleteFolder));
+                            if (deleted) {
+                                ModManager.debugLogger.writeMessage("Deleted outdated custom DLC: " + deleteFolder);
+                                ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Deleted " + outdated);
+                            } else {
+                                ModManager.debugLogger.writeError("deleteQuietly() returned false when attempting to delete outdated custom DLC: " + deleteFolder);
+                                ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Failed to " + outdated);
+                                JOptionPane.showMessageDialog(ModInstallWindow.this, "Failed to delete custom DLC folder:\n" + deleteFolder, "Outdated Custom DLC deletion failed",
+                                        JOptionPane.ERROR_MESSAGE);
+                            }
+                        } else {
+                            ModManager.debugLogger.writeMessage("User declined deleting outdated DLC: " + outdated);
+                        }
+                    }
+                } else {
+                    ModManager.debugLogger.writeMessage("No outdated custom dlc to remove, continuing install...");
+                }
+
+                if (!skipTOC) {
+                    ModManager.debugLogger.writeMessage("Running Game-Wide AutoTOC after mod install");
+                    new AutoTocWindow(bioGameDir);
+                }
+
+                if (success) {
+                    if (numjobs != completed.get()) {
+                        // failed something
+                        StringBuilder sb = new StringBuilder();
+                        sb.append(
+                                "Failed to process mod installation.\nSome parts of the install may have succeeded.\nCheck the log file by copying it to the clipboard in the help menu.");
+                        ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Failed to install at least 1 part of mod");
+                        ModManager.debugLogger
+                                .writeMessage("Some mods failed to fully install. Jobs required to copmlete: " + numjobs + ", while injectioncommander only reported " + completed);
+                        JOptionPane.showMessageDialog(ModInstallWindow.this, sb.toString(), "Error", JOptionPane.ERROR_MESSAGE);
+                    } else {
+                        // we're good
+                        if (mods.size() > 1) {
+                            ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(mods.size() + " mods installed");
+                        } else {
+                            ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(mods.get(0).getModName() + " installed");
+                        }
+                        for (Mod mod : mods) {
+                            for (ModJob job : mod.jobs) {
+                                if (job.getJobType() == ModJob.BALANCE_CHANGES) {
+                                    if (ModManager.checkIfASIBinkBypassIsInstalled(bioGameDir)) {
+                                        if (!ASIModWindow.IsASIModGroupInstalled(5)) { //update group 5 = Balance Changes on ME3Tweaks
 										/*ModManager.debugLogger.writeMessage("Balance changes ASI is not installed. Advertising install");
 										int result = JOptionPane.showConfirmDialog(ModInstallWindow.this,
 												"This mod contains edits to the balance changes file.\nFor these edits to take effect you need to have the Balance Changes Replacer ASI mod installed.\nOpen the ASI management window to install this?",
@@ -1338,110 +1332,117 @@ public class ModInstallWindow extends JDialog {
 										if (result == JOptionPane.YES_OPTION) {
 											new ASIModWindow(new File(bioGameDir).getParent(), true);
 										}*/
-										try {
-											ModManager.debugLogger.writeMessage("Mod requires Balance Changes Replacer - installing");
-											File balancechangeseplacer = new File(new File(ModManagerWindow.GetBioGameDir()).getParent() + "\\Binaries\\Win32\\asi\\BalanceChangesReplacer.asi");
-											balancechangeseplacer.getParentFile().mkdirs();
-											ModManager.ExportResource("/BalanceChangesReplacer.asi", balancechangeseplacer.toString());
-											ModManager.debugLogger.writeMessage("Balance Changes Replacer - installed");
-											break;
-										} catch (Exception e) {
-											ModManager.debugLogger.writeErrorWithException("Error extracting balance changes replacer:", e);
-										}
-									}
-								} else {
-									//loader not in
-									ModManager.debugLogger.writeMessage("ASI loader not installed. Advertising install");
-									int result = JOptionPane.showConfirmDialog(ModInstallWindow.this,
-											"This mod contains edits to the balance changes file.\nFor these edits to take effect you need to have the binkw32 ASI loader installed as well as the Balance Changes Replacer ASI.\nOpen the ASI management window to install these?",
-											"ASI Loader + ASI mod required", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-									if (result == JOptionPane.YES_OPTION) {
-										new ASIModWindow(new File(bioGameDir).getParent(), true);
-									}
-								}
-							}
-						}
-					}
-					installFinished = true;
-				}
-			} else {
-				if (!hasException) {
-					ModManager.debugLogger.writeMessage("Installation canceled by user because game repair database update is required (or connection failed and auto canceled).");
-					if (bghDB != null) {
-						bghDB.shutdownDB();
-						bghDB = null;
-					}
-					System.gc();//force shutdown the old DB
+                                            try {
+                                                ModManager.debugLogger.writeMessage("Mod requires Balance Changes Replacer - installing");
+                                                File balancechangeseplacer = new File(new File(ModManagerWindow.GetBioGameDir()).getParent() + "\\Binaries\\Win32\\asi\\BalanceChangesReplacer.asi");
+                                                balancechangeseplacer.getParentFile().mkdirs();
+                                                ModManager.ExportResource("/BalanceChangesReplacer.asi", balancechangeseplacer.toString());
+                                                ModManager.debugLogger.writeMessage("Balance Changes Replacer - installed");
+                                                break;
+                                            } catch (Exception e) {
+                                                ModManager.debugLogger.writeErrorWithException("Error extracting balance changes replacer:", e);
+                                            }
+                                        }
+                                    } else {
+                                        //loader not in
+                                        ModManager.debugLogger.writeMessage("ASI loader not installed. Advertising install");
+                                        int result = JOptionPane.showConfirmDialog(ModInstallWindow.this,
+                                                "This mod contains edits to the balance changes file.\nFor these edits to take effect you need to have the binkw32 ASI loader installed as well as the Balance Changes Replacer ASI.\nOpen the ASI management window to install these?",
+                                                "ASI Loader + ASI mod required", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                                        if (result == JOptionPane.YES_OPTION) {
+                                            new ASIModWindow(new File(bioGameDir).getParent(), true);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        installFinished = true;
+                    }
+                } else {
+                    if (!hasException) {
+                        ModManager.debugLogger.writeMessage("Installation canceled by user because game repair database update is required (or connection failed and auto canceled).");
+                        if (bghDB != null) {
+                            bghDB.shutdownDB();
+                            bghDB = null;
+                        }
+                        System.gc();//force shutdown the old DB
 
-					ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Mod install canceled");
-					dispose();
-					if (!failedLoadingDB) {
-						File bgdir = new File(ModManager.appendSlash(bioGameDir));
-						String me3dir = ModManager.appendSlash(bgdir.getParent());
-						try {
-							bghDB = new BasegameHashDB(null, me3dir, true);
-						} catch (SQLException e) {
-							while (e.getNextException() != null) {
-								ModManager.debugLogger.writeErrorWithException("DB FAILED TO LOAD.", e);
-								e = e.getNextException();
-							}
-						}
-						if (bghDB == null) {
-							//cannot continue
-							JOptionPane.showMessageDialog(ModInstallWindow.this, "<html>The game repair database failed to load.<br>"
-									+ "Only one connection to the local repair database is allowed at a time.<br>"
-									+ "Please make sure you only have one instance of Mod Manager running.<br>Mod Manager appears as Java (TM) Platform Binary (or javaw.exe on Windows Vista/7) in Task Manager.<br><br>If the issue persists and you are sure only one instance is running, close Mod Manager and<br>delete the the data\\databases folder.<br>You will need to re-create the game repair database afterwards.<br><br>If this *STILL* does not fix your issue, please send a log to Mgamerz through the help menu.</html>",
-									"Database Failure", JOptionPane.ERROR_MESSAGE);
+                        ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Mod install canceled");
+                        dispose();
+                        if (!failedLoadingDB) {
+                            File bgdir = new File(ModManager.appendSlash(bioGameDir));
+                            String me3dir = ModManager.appendSlash(bgdir.getParent());
+                            try {
+                                bghDB = new BasegameHashDB(null, me3dir, true);
+                            } catch (SQLException e) {
+                                while (e.getNextException() != null) {
+                                    ModManager.debugLogger.writeErrorWithException("DB FAILED TO LOAD.", e);
+                                    e = e.getNextException();
+                                }
+                            }
+                            if (bghDB == null) {
+                                //cannot continue
+                                JOptionPane.showMessageDialog(ModInstallWindow.this, "<html>The game repair database failed to load.<br>"
+                                                + "Only one connection to the local repair database is allowed at a time.<br>"
+                                                + "Please make sure you only have one instance of Mod Manager running.<br>Mod Manager appears as Java (TM) Platform Binary (or javaw.exe on Windows Vista/7) in Task Manager.<br><br>If the issue persists and you are sure only one instance is running, close Mod Manager and<br>delete the the data\\databases folder.<br>You will need to re-create the game repair database afterwards.<br><br>If this *STILL* does not fix your issue, please send a log to Mgamerz through the help menu.</html>",
+                                        "Database Failure", JOptionPane.ERROR_MESSAGE);
 
-						}
-					}
-				} else {
-					ModManager.debugLogger.writeError("Mod Injection thread encountered an error. See the exception above.");
-				}
-			}
-			finishInstall();
-			return;
-		}
+                            }
+                        }
+                    } else {
+                        ModManager.debugLogger.writeError("Mod Injection thread encountered an error. See the exception above.");
+                    }
+                }
+            } else {
+                if (mods.size() > 1) {
+                    ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("At least one mod failed to install");
+                } else {
+                    ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText(mods.get(0).getModName() + " not installed");
+                }
+            }
+            finishInstall();
+            return;
+        }
 
-		protected void finishInstall() {
-			ModManager.debugLogger.writeMessage("=========Finished installing mod(s)==========");
-			dispose();
-		}
-	}
+        protected void finishInstall() {
+            ModManager.debugLogger.writeMessage("=========Finished installing mod(s)==========");
+            dispose();
+        }
+    }
 
-	public void addToQueue(String newLine) {
-		for (int i = consoleQueue.length - 1; i >= 1; i--) {
-			consoleQueue[i] = consoleQueue[i - 1];
-		}
-		consoleQueue[0] = newLine;
-		updateInfo();
-	}
+    public void addToQueue(String newLine) {
+        for (int i = consoleQueue.length - 1; i >= 1; i--) {
+            consoleQueue[i] = consoleQueue[i - 1];
+        }
+        consoleQueue[0] = newLine;
+        updateInfo();
+    }
 
-	public String getConsoleString() {
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < consoleQueue.length; i++) {
-			sb.append((consoleQueue[i] != null) ? consoleQueue[i] : "");
-			if (i < consoleQueue.length - 1) {
-				sb.append("\n");
-			}
-		}
-		return sb.toString();
-	}
+    public String getConsoleString() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < consoleQueue.length; i++) {
+            sb.append((consoleQueue[i] != null) ? consoleQueue[i] : "");
+            if (i < consoleQueue.length - 1) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
 
-	private void updateInfo() {
-		consoleArea.setText(getConsoleString());
-	}
+    private void updateInfo() {
+        consoleArea.setText(getConsoleString());
+    }
 
-	/**
-	 * Returns true on all non-batch installations, always. Returns true if
-	 * cancel button was not pressed in batch mode, false if it was not clicked.
-	 */
-	public boolean shouldContinueBatchInstallation() {
-		return continueBatchInstallation;
-	}
+    /**
+     * Returns true on all non-batch installations, always. Returns true if
+     * cancel button was not pressed in batch mode, false if it was not clicked.
+     */
+    public boolean shouldContinueBatchInstallation() {
+        return continueBatchInstallation;
+    }
 
-	public static class BatchPackage {
-		public int totalBatchMods;
-		public int currentBatchInstallationNumber;
-	}
+    public static class BatchPackage {
+        public int totalBatchMods;
+        public int currentBatchInstallationNumber;
+    }
 }

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -40,10 +40,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.prefs.Preferences;
 
 public class ModManager {
-    public static boolean IS_DEBUG = false;
-    public static final String VERSION = "5.1";
-    public static long BUILD_NUMBER = 88L;
-    public static final String BUILD_DATE = "10/03/2018";
+    public static boolean IS_DEBUG = true;
+    public static final String VERSION = "5.1.1";
+    public static long BUILD_NUMBER = 89L;
+    public static final String BUILD_DATE = "11/04/2018";
     public static final String SETTINGS_FILENAME = "me3cmm.ini";
     public static DebugLogger debugLogger;
     public static boolean logging = false;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -43,7 +43,7 @@ public class ModManager {
     public static boolean IS_DEBUG = false;
     public static final String VERSION = "5.1";
     public static long BUILD_NUMBER = 88L;
-    public static final String BUILD_DATE = "09/30/2018";
+    public static final String BUILD_DATE = "10/03/2018";
     public static final String SETTINGS_FILENAME = "me3cmm.ini";
     public static DebugLogger debugLogger;
     public static boolean logging = false;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -19,6 +19,7 @@ import org.ini4j.Wini;
 import org.w3c.dom.Document;
 
 import javax.swing.*;
+import javax.swing.filechooser.FileSystemView;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -40,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.prefs.Preferences;
 
 public class ModManager {
-    public static boolean IS_DEBUG = false;
+    public static boolean IS_DEBUG = true;
     public static final String VERSION = "5.1.1";
     public static long BUILD_NUMBER = 89L;
     public static final String BUILD_DATE = "11/04/2018";
@@ -2775,6 +2776,32 @@ public class ModManager {
             } catch (IOException e) {
                 ModManager.debugLogger.writeErrorWithException("Error checking if ALOT is installed.", e);
             }
+        }
+        return false;
+    }
+
+    /**
+     * Checks the gamersettings.ini file for vanilla versions of TEXTUREGROUP_Character_1024 and TEXTUREGROUP_World. If they are not the orignials a high res mod is assumed to be installed.
+     *
+     * @return true if TEXTUREGROUP_World and TEXTUREGROUP_Character_1024 are not their original versions, false otherwise
+     */
+    public static boolean areHighResGamerSettingsInstalled() {
+        File gamerSettings = new File(FileSystemView.getFileSystemView().getDefaultDirectory().getPath() + "\\BioWare\\Mass Effect 3\\BioGame\\Config\\GamerSettings.ini");
+        if (!gamerSettings.exists()) {
+            return false;
+        }
+
+        try {
+            Wini ini = new Wini(gamerSettings);
+            ini.load(gamerSettings);
+            String HRGroupCharacter1024 = "(MinLODSize=2048,MaxLODSize=4096,LODBias=0)";
+            String HRGroupWorld = "(MinLODSize=256,MaxLODSize=4096,LODBias=0)";
+            String textureGroupCharacter1024 = ini.get("SystemSettings", "TEXTUREGROUP_Character_1024");
+            String textureGroupWorld = ini.get("SystemSettings", "TEXTUREGROUP_World");
+            return textureGroupCharacter1024.equals(HRGroupCharacter1024) && textureGroupWorld.equals(HRGroupWorld);
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            ModManager.debugLogger.writeErrorWithException("Error reading game configuration file!", e);
         }
         return false;
     }

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -2798,7 +2798,7 @@ public class ModManager {
             String HRGroupWorld = "(MinLODSize=256,MaxLODSize=4096,LODBias=0)";
             String textureGroupCharacter1024 = ini.get("SystemSettings", "TEXTUREGROUP_Character_1024");
             String textureGroupWorld = ini.get("SystemSettings", "TEXTUREGROUP_World");
-            return textureGroupCharacter1024.equals(HRGroupCharacter1024) && textureGroupWorld.equals(HRGroupWorld);
+            return textureGroupCharacter1024!= null && textureGroupWorld != null && textureGroupCharacter1024.equals(HRGroupCharacter1024) && textureGroupWorld.equals(HRGroupWorld);
         } catch (IOException e) {
             // TODO Auto-generated catch block
             ModManager.debugLogger.writeErrorWithException("Error reading game configuration file!", e);

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.prefs.Preferences;
 
 public class ModManager {
-    public static boolean IS_DEBUG = true;
+    public static boolean IS_DEBUG = false;
     public static final String VERSION = "5.1.1";
     public static long BUILD_NUMBER = 89L;
     public static final String BUILD_DATE = "11/04/2018";

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -41,10 +41,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.prefs.Preferences;
 
 public class ModManager {
-    public static boolean IS_DEBUG = true;
+    public static boolean IS_DEBUG = false;
     public static final String VERSION = "5.1.1";
     public static long BUILD_NUMBER = 89L;
-    public static final String BUILD_DATE = "11/04/2018";
+    public static final String BUILD_DATE = "11/07/2018";
     public static final String SETTINGS_FILENAME = "me3cmm.ini";
     public static DebugLogger debugLogger;
     public static boolean logging = false;

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1946,6 +1946,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
             }
 
             // Populate Manual Alternate Files for Official DLC
+            boolean hasAltFiles = false;
             for (ModJob job : mod.getJobs()) {
                 if (job.getJobType() == ModJob.CUSTOMDLC) {
                     continue; // don't parse these
@@ -1970,12 +1971,15 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                             labelStatus.setText(item.getText() + " set to " + (item.isSelected() ? "enabled" : "disabled"));
                         }
                     });
+                    hasAltFiles = true;
                     modAlternatesMenu.add(item);
                 }
             }
 
             if (altdlcs.size() > 0) {
-                modAlternatesMenu.addSeparator();
+                if (hasAltFiles) {
+                    modAlternatesMenu.addSeparator();
+                }
                 for (AlternateCustomDLC altdlc : altdlcs) {
                     String friendlyname = altdlc.getOperation() + " due to " + altdlc.getCondition() + " for " + altdlc.getConditionalDLC();
                     if (altdlc.getFriendlyName() != null) {

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -3384,7 +3384,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
             Mod mod = modModel.get(index);
 
             // Precheck all required items
-            ArrayList<String> requiredHeaders = mod.getRequiredDLCHeaders();
+            ArrayList<String> requiredHeadersExplicit = mod.getRequiredDLCHeaders();
+            List<String> requiredHeaders = requiredHeadersExplicit.stream()
+                    .map(String::toUpperCase)
+                    .collect(Collectors.toList());
             if (requiredHeaders.size() > 0) {
                 ArrayList<String> installedDLC = ModManager.getInstalledDLC(GetBioGameDir());
                 if (!installedDLC.containsAll(requiredHeaders)) {
@@ -3566,7 +3569,10 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         buttonApplyMod.setEnabled(false);
                     }
 
-                    ArrayList<String> requiredHeaders = selectedMod.getRequiredDLCHeaders();
+                    ArrayList<String> requiredHeadersExplicit = selectedMod.getRequiredDLCHeaders();
+                    List<String> requiredHeaders = requiredHeadersExplicit.stream()
+                            .map(String::toUpperCase)
+                            .collect(Collectors.toList());
                     if (requiredHeaders.size() > 0) {
                         ArrayList<String> installedDLC = ModManager.getInstalledDLC(GetBioGameDir());
                         if (installedDLC.containsAll(requiredHeaders)) {

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -1365,7 +1365,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
         if (ModManager.NET_FRAMEWORK_IS_INSTALLED) {
             buttonApplyMod.setToolTipText("Select a mod on the left");
         } else {
-            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
+            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to install mods");
         }
         buttonStartGame = new JButton("Start Game");
         buttonStartGame.addActionListener(this);
@@ -1444,7 +1444,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
             }
         } else {
             buttonApplyMod.setText(".NET Missing");
-            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
+            buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to install mods");
             buttonApplyMod.setEnabled(false);
         }
     }
@@ -2099,9 +2099,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         new SingleModUpdateCheckThread(mod).execute();
                     } else {
                         updateApplyButton();
-                        labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                        labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                         ModManager.debugLogger.writeMessage("Single mode updater: Missing .NET Framework");
-                        new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" to update ModMaker mods.");
+                        new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " to update ModMaker mods.");
                     }
                 } else {
                     labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
@@ -2124,9 +2124,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         new SingleModUpdateCheckThread(cloneMod).execute();
                     } else {
                         updateApplyButton();
-                        labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                        labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                         ModManager.debugLogger.writeMessage("Single mode updater: Missing .NET Framework");
-                        new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" to update ModMaker mods.");
+                        new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " to update ModMaker mods.");
                     }
                 } else {
                     labelStatus.setText("Updating ModMaker mods requires valid BIOGame");
@@ -2148,9 +2148,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         new DeltaWindow(mod, delta, true, false);
                     }
                 } else {
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("Patch Library: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher to switch mod variants.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher to switch mod variants.");
                 }
             }
         });
@@ -2163,9 +2163,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     ModManager.debugLogger.writeMessage("Reverting a delta.");
                     new DeltaWindow(mod);
                 } else {
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("Revert Delta: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher to switch mod variants.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher to switch mod variants.");
                 }
             }
         });
@@ -2179,9 +2179,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new KeybindsInjectionWindow(ModManagerWindow.this, mod, false);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("Keybinds Injector: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use the Keybinds Injector.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to use the Keybinds Injector.");
                 }
             }
         });
@@ -2202,9 +2202,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     autoTOC(AutoTocWindow.LOCALMOD_MODE);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("AutoTOC: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use the AutoTOC feature.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to use the AutoTOC feature.");
                 }
             }
         });
@@ -2296,9 +2296,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 } else {
 
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("ModMaker: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use ModMaker.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to use ModMaker.");
                 }
             } else {
                 labelStatus.setText("ModMaker requires valid BIOGame directory to start");
@@ -2343,9 +2343,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new CustomDLCConflictWindow();
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeError("Custom DLC Conflict Window: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to fully use the conflict detection tool.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to fully use the conflict detection tool.");
                 }
             } else {
                 labelStatus.setText("Conflict detector requires valid BIOGame directory");
@@ -2620,9 +2620,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         applyMod();
                     } else {
                         updateApplyButton();
-                        labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                        labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                         ModManager.debugLogger.writeMessage("Applying selected mod: .NET is not installed");
-                        new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods.");
+                        new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to install mods.");
                     }
                 } else {
                     labelStatus.setText("Installing a mod requires valid BIOGame path");
@@ -2651,9 +2651,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 new PCCDataDumperWindow();
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                 ModManager.debugLogger.writeMessage("Run PCC Data Dumper: .NET is not installed");
-                new NetFrameworkMissingWindow("The PCC Data Dumper tool requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher to be installed.");
+                new NetFrameworkMissingWindow("The PCC Data Dumper tool requires .NET " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher to be installed.");
             }
 
         } else if (e.getSource() == toolME3Explorer) {
@@ -2725,9 +2725,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 }
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                 ModManager.debugLogger.writeMessage("Run ME3Explorer: .NET is not installed");
-                new NetFrameworkMissingWindow("ME3Explorer requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
+                new NetFrameworkMissingWindow("ME3Explorer requires .NET " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to run.");
             }
         } else if (e.getSource() == toolAlotInstaller) {
             if (ModManager.validateNETFrameworkIsInstalled()) {
@@ -2788,9 +2788,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
 
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                 ModManager.debugLogger.writeMessage("Run ALOT Installer: .NET is not installed");
-                new NetFrameworkMissingWindow("ALOT Installer requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
+                new NetFrameworkMissingWindow("ALOT Installer requires .NET " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to run.");
             }
 
         } else if (e.getSource() == modManagementOpenModsFolder)
@@ -2835,18 +2835,18 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 }
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                 ModManager.debugLogger.writeMessage("Run TLK: .NET is not installed");
-                new NetFrameworkMissingWindow("Tankmaster's TLK Tool requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
+                new NetFrameworkMissingWindow("Tankmaster's TLK Tool requires .NET " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to run.");
             }
         } else if (e.getSource() == toolTankmasterCoalUI) {
             if (ModManager.validateNETFrameworkIsInstalled()) {
                 new CoalescedWindow();
             } else {
                 updateApplyButton();
-                labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                 ModManager.debugLogger.writeMessage("Run ME3Explorer: .NET is not installed");
-                new NetFrameworkMissingWindow("ME3Explorer requires .NET "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to run.");
+                new NetFrameworkMissingWindow("ME3Explorer requires .NET " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to run.");
             }
         } else if (e.getSource() == actionOptions) {
             new OptionsWindow(this);
@@ -2894,9 +2894,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new UnpackWindow(this);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("Unpack DLC Tool: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to unpack DLC.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to unpack DLC.");
                 }
             } else {
                 labelStatus.setText("Unpacking DLC requires a valid BIOGame directory");
@@ -2922,9 +2922,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new AutoTocWindow(ModManagerWindow.GetBioGameDir());
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("AutoTOC: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use the AutoTOC feature.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to use the AutoTOC feature.");
                 }
             } else {
                 labelStatus.setText("Game AutoTOC requires a valid BIOGame directory");
@@ -2942,9 +2942,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new PatchLibraryWindow(PatchLibraryWindow.MANUAL_MODE);
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("Patch Library: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to use MixIns.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to use MixIns.");
                 }
             } else {
                 labelStatus.setText("Use of the patch library requires a valid BIOGame folder");
@@ -2960,9 +2960,9 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     new ModGroupWindow();
                 } else {
                     updateApplyButton();
-                    labelStatus.setText(".NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher is missing");
+                    labelStatus.setText(".NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher is missing");
                     ModManager.debugLogger.writeMessage("Batch Mod Installer: Missing .NET Framework");
-                    new NetFrameworkMissingWindow("You must install .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to batch install mods.");
+                    new NetFrameworkMissingWindow("You must install .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to batch install mods.");
                 }
             } else {
                 labelStatus.setText("Use of the patch library requires a valid BIOGame folder");
@@ -3359,6 +3359,28 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
         int index = modList.getSelectedIndex();
         if (index >= 0) {
             Mod mod = modModel.get(index);
+
+            // Precheck all required items
+            ArrayList<String> requiredHeaders = mod.getRequiredDLCHeaders();
+            if (requiredHeaders.size() > 0) {
+                ArrayList<String> installedDLC = ModManager.getInstalledDLC(GetBioGameDir());
+                if (!installedDLC.containsAll(requiredHeaders)) {
+                    requiredHeaders.removeAll(installedDLC);
+                    String message = "This mod is missing required DLC:";
+                    for (String str : requiredHeaders) {
+                        ModManager.debugLogger.writeMessage("Detected missing DLC: " + str);
+
+                        if (!installedDLC.contains(str)) {
+                            message += "\n - " + ME3TweaksUtils.getThirdPartyModName(str, true);
+                        }
+                    }
+                    message += "\n\n" + ((requiredHeaders.size() == 1) ? "This DLC" : "These DLCs") + " must be installed before you can\ninstall " + mod.getModName() + ".";
+                    JOptionPane.showMessageDialog(this, message, "Required DLC missing", JOptionPane.ERROR_MESSAGE);
+                    return false;
+                }
+            }
+
+
             if (ModManager.isALOTInstalled(GetBioGameDir())) {
                 boolean hasPCCInstall = false;
                 ModManager.debugLogger.writeMessage("ALOT is installed, checking for installation of non-testpatch PCC files...");
@@ -3368,7 +3390,6 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         continue; // we don't are about this
                     }
                     for (String destFile : job.getFilesToReplaceTargets()) {
-                        String extension = FilenameUtils.getExtension(destFile);
                         if (FilenameUtils.getExtension(destFile).toLowerCase().equals("pcc")) {
                             hasPCCInstall = true;
                             ModManager.debugLogger.writeMessage("Detected PCC file attempting to install over ALOT installation: " + destFile);
@@ -3387,7 +3408,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     } else {
                         ModManager.debugLogger.writeMessage("ALOT is installed, found conflicts. User has allow install check off, but we are going to warn anyways.");
                         int result = JOptionPane.showOptionDialog(this,
-                                "ALOT is installed and this mod installs PCC files.\nYou should only install this if you really know what you are doing as you WILL break the game.\nSeriously - if you don't know what you are actually doing, do not continue.\n\nInstall anyways?",
+                                "ALOT is installed and this mod installs PCC files.\nYou should only install this if you really know what you are doing as you WILL break the game.\nYou cannot install PCC files after installation of ALOT due to invalid texture pointers in the files being installed.\nSeriously - if you don't know what you are actually doing, do not continue.\n\nInstall anyways?",
                                 "Warning: ALOT is installed", JOptionPane.YES_NO_OPTION, JOptionPane.ERROR_MESSAGE, null, new String[]{"Yes", "No"}, "No");
                         if (result == JOptionPane.NO_OPTION) {
                             return false;
@@ -3489,7 +3510,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                 if (ModManager.NET_FRAMEWORK_IS_INSTALLED) {
                     buttonApplyMod.setToolTipText("Select a mod on the left");
                 } else {
-                    buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
+                    buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to install mods");
                 }
                 fieldDescription.setText(getNoSelectedModDescription());
                 modWebsiteLink.setVisible(false);
@@ -3517,7 +3538,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         buttonApplyMod.setToolTipText(
                                 "<html>Apply this mod to the game.<br>If other mods are installed, you should consider uninstalling them by<br>using the Restore Menu if they are known to not work together.</html>");
                     } else {
-                        buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework "+ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR+" or higher in order to install mods");
+                        buttonApplyMod.setToolTipText("Mod Manager requires .NET Framework " + ModManager.MIN_REQUIRED_NET_FRAMEWORK_STR + " or higher in order to install mods");
                         buttonApplyMod.setText("Missing .NET");
                         buttonApplyMod.setEnabled(false);
                     }
@@ -3529,7 +3550,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                             buttonApplyMod.setEnabled(true);
                             buttonApplyMod.setText("Apply Mod");
                         } else {
-                            buttonApplyMod.setEnabled(false);
+                            requiredHeaders.removeAll(installedDLC);
                             String toolTip = "<html>This mod is missing required DLC.<br>Missing required DLC:";
                             for (String str : requiredHeaders) {
                                 if (!installedDLC.contains(str)) {

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -3837,8 +3837,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                     ModManager.debugLogger.writeMessage("Selected path: " + selectedGamePath);
                     if (currentpath != null && !currentpath.equalsIgnoreCase(selectedGamePath)) {
                         // Update registry key.
-                        boolean is64bit = ResourceUtils.is64BitWindows();
-                        String keypath = is64bit ? "HKLM\\SOFTWARE\\Wow6432Node\\BioWare\\Mass Effect 3" : "HKLM\\SOFTWARE\\BioWare\\Mass Effect 3";
+                        String keypath = "HKLM\\SOFTWARE\\Wow6432Node\\BioWare\\Mass Effect 3";
                         ArrayList<String> command = new ArrayList<String>();
                         command.add(ModManager.getCommandLineToolsDir() + "elevate.exe");
                         command.add("-c");
@@ -3857,6 +3856,18 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
                         ProcessResult pr = ModManager.runProcess(pb);
                         if (pr.getReturnCode() == 0) {
                             ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Updated registry key to point to selected installation");
+                        }
+
+                        //Get ALOT status of this new target
+                        boolean alotInstalled = ModManager.isALOTInstalled(selectedPath);
+                        boolean highResSettings = ModManager.areHighResGamerSettingsInstalled();
+                        if (alotInstalled && !highResSettings) {
+                            //offer to upgrade
+                            int result = JOptionPane.showConfirmDialog(ModManagerWindow.this, "The current texture settings are default quality, however ALOT is detected as installed.\nUpdate your texture settings to ALOT's high quality settings?", "Upgrade texture settings", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+                        } else if (!alotInstalled && highResSettings) {
+                            //offer to revert
+                            int result = JOptionPane.showConfirmDialog(ModManagerWindow.this, "The current texture settings are high quality, however ALOT is not detected as installed.\nThis will cause black textures and potential crashes due to null mips in game files.\nDowngrading to the defaults will prevent this issue.\nDowngrade your texture settings to the defaults?", "Downgrade texture settings", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+
                         }
                     }
                 } else {

--- a/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
+++ b/src/com/me3tweaks/modmanager/PatchLibraryWindow.java
@@ -728,7 +728,7 @@ public class PatchLibraryWindow extends JDialog implements ListSelectionListener
 	}
 
 	public static String getLatestMixIns() {
-		int jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Getting latest mixins");
+		int jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("MixinUpdate","Getting latest mixins");
 		PatchLibraryWindow plw = new PatchLibraryWindow(AUTOUPDATE_MODE);
 		ModManagerWindow.ACTIVE_WINDOW.submitJobCompletion(jobCode);
 		return "Updated " + plw.numberofupdatedmixins + " MixIn" + (plw.numberofupdatedmixins != 1 ? "s" : "");

--- a/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
+++ b/src/com/me3tweaks/modmanager/RestoreFilesWindow.java
@@ -738,8 +738,6 @@ public class RestoreFilesWindow extends JDialog {
 					ModManager.debugLogger.writeErrorWithException("Failure restoring backup SFAR:", e);
 					return false;
 				}
-				completed++;
-				publish(Integer.toString(completed));
 				return true;
 			}
 

--- a/src/com/me3tweaks/modmanager/UpdateJREAvailableWindow.java
+++ b/src/com/me3tweaks/modmanager/UpdateJREAvailableWindow.java
@@ -364,7 +364,7 @@ public class UpdateJREAvailableWindow extends JDialog implements ActionListener,
             pack();
             DownloadTask task = new DownloadTask(ModManager.getTempDir());
             task.addPropertyChangeListener(this);
-            jreUpdateTask = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("JREUpdate");
+            jreUpdateTask = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("JREUpdate","Updating JRE");
             ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Updating JRE...");
 
             task.execute();

--- a/src/com/me3tweaks/modmanager/UpdateJREAvailableWindow.java
+++ b/src/com/me3tweaks/modmanager/UpdateJREAvailableWindow.java
@@ -383,7 +383,7 @@ public class UpdateJREAvailableWindow extends JDialog implements ActionListener,
         try {
 
             ModManager.debugLogger.writeMessage("Upgrading JRE.");
-            JOptionPane.showMessageDialog(null, "DEBUG: Check data folder, click OK to continue update.");
+            //JOptionPane.showMessageDialog(null, "DEBUG: Check data folder, click OK to continue update.");
             ModManager.MOD_MANAGER_UPDATE_READY = true; //do not delete temp
             File script = new File(updaterSCriptPath);
             Desktop.getDesktop().open(script);

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -119,7 +119,7 @@ public class ModMakerCompilerWindow extends JDialog {
 		this.code = code;
 		this.languages = languages;
 		setupWindow();
-		jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Compiling ModMaker Mod");
+		jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("ModMakerCompiler","Compiling ModMaker Mod");
 		ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Compiling ModMaker Mod...");
 		new ModDownloadWorker().execute();
 

--- a/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/AllModsUpdateWindow.java
@@ -113,7 +113,7 @@ public class AllModsUpdateWindow extends JDialog {
 		int jobCode;
 
 		public AllModsDownloadTask() {
-			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Checking all mods for updates");
+			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("AllModsUpdateCheck","Checking all mods for updates");
 		}
 
 		/**

--- a/src/com/me3tweaks/modmanager/modupdater/ModUpdateWindow.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModUpdateWindow.java
@@ -75,7 +75,7 @@ public class ModUpdateWindow extends JDialog implements PropertyChangeListener {
      * @param frame
      */
     public void startUpdate(JFrame frame) {
-        jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Updating singlemod");
+        jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("SingleModUpdate","Updating mod");
         ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Updating " + upackage.getMod().getModName());
         if (upackage.isModmakerupdate()) {
             //get default language
@@ -98,7 +98,7 @@ public class ModUpdateWindow extends JDialog implements PropertyChangeListener {
      * @param amuw
      */
     public boolean startAllModsUpdate(AllModsUpdateWindow amuw) {
-        jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("Updating multimod");
+        jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("MultimodUpdate","Updating mods");
         ModManagerWindow.ACTIVE_WINDOW.labelStatus.setText("Updating " + upackage.getMod().getModName());
         if (upackage.isModmakerupdate()) {
             //validate biogamedir (TLK)

--- a/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
@@ -390,30 +390,6 @@ public class ModXMLTools {
 
 	}
 
-	/**
-	 * Takes a mod and validates it against the server for latest versions (also
-	 * checks locally against hashes) This method should be run in a background
-	 * thread.
-	 * 
-	 * @param mod
-	 *            Mod to check against
-	 * @return null if up to date, otherwise updatepackage describing an
-	 *         applicable update operation
-	 */
-	public static UpdatePackage validateLatestAgainstServer(Mod mod) {
-		String updateURL = "https://me3tweaks.com/mods/getlatest";
-		ModManager.debugLogger.writeMessage("=========Checking for update of " + mod.getModName() + "=========");
-		if (mod.getModMakerCode() > 0) {
-			Document doc = getOnlineInfo(updateURL, true, mod.getModMakerCode());
-			return checkForModMakerUpdate(mod, doc);
-		}
-		if (mod.getModMakerCode() <= 0) {
-			Document doc = getOnlineInfo(updateURL, false, mod.getClassicUpdateCode());
-			return checkForClassicUpdate(mod, doc, null);
-		}
-		return null;
-	}
-
 	public static ArrayList<UpdatePackage> validateLatestAgainstServer(ArrayList<Mod> mods, AllModsDownloadTask allModsDownloadTask) {
 		String updateURL = "https://me3tweaks.com/mods/getlatest_batch";
 		ModManager.debugLogger.writeMessage("Checking for updates of the following mods:");

--- a/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
+++ b/src/com/me3tweaks/modmanager/modupdater/ModXMLTools.java
@@ -81,7 +81,7 @@ public class ModXMLTools {
 			if (changelog != null && !changelog.equals("")) {
 				this.changelog = changelog;
 			}
-			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("ManifestGenerator");
+			jobCode = ModManagerWindow.ACTIVE_WINDOW.submitBackgroundJob("ManifestGenerator", "Preparing mod for updater service");
 		}
 
 		@Override

--- a/src/com/me3tweaks/modmanager/objects/MainUIBackgroundJob.java
+++ b/src/com/me3tweaks/modmanager/objects/MainUIBackgroundJob.java
@@ -1,7 +1,15 @@
 package com.me3tweaks.modmanager.objects;
 
 public class MainUIBackgroundJob {
-	@Override
+	private String uiText;
+	private String taskName;
+
+	public MainUIBackgroundJob(String taskname, String uiText) {
+		this.taskName = taskName;
+		this.uiText = uiText;
+	}
+
+    @Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
@@ -24,12 +32,10 @@ public class MainUIBackgroundJob {
 	public String getTaskName() {
 		return taskName;
 	}
-
-	public void setTaskName(String taskName) {
-		this.taskName = taskName;
+	public String getUIText() {
+		return uiText;
 	}
 
-	private String taskName;
 
 	public MainUIBackgroundJob(String taskName) {
 		this.taskName = taskName;

--- a/src/com/me3tweaks/modmanager/objects/Mod.java
+++ b/src/com/me3tweaks/modmanager/objects/Mod.java
@@ -6,12 +6,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.StringTokenizer;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -31,2408 +26,2396 @@ import com.me3tweaks.modmanager.utilities.ResourceUtils;
 import com.me3tweaks.modmanager.valueparsers.ValueParserLib;
 
 public class Mod implements Comparable<Mod> {
-	public static final String DELTAS_FOLDER = "DELTAS";
-	public static final String ORIGINAL_FOLDER = "ORIGINAL";
-	public static final String VARIANT_FOLDER = "VARIANTS";
-	public static final String DEFAULT_SERVER_FOLDER = "PUT_SERVER_PATH_HERE";
-	File modDescFile;
-	boolean validMod = false;
-	String modName, modDisplayDescription, modDescription;
-	private String modPath;
-	String modifyString;
-	public ArrayList<ModJob> jobs;
-	private String modAuthor;
-	private int modmakerCode = 0;
-	private String modSite;
-	private String modmp;
-	private boolean emptyModIsOK;
-	private double compiledAgainstModmakerVersion;
-	private String modVersion;
-	public double modCMMVer = 1.0;
-	private int classicCode;
-	private boolean ignoreLoadErrors = false;
-	private ArrayList<Patch> requiredPatches = new ArrayList<Patch>();
-	private ArrayList<ModDelta> modDeltas = new ArrayList<ModDelta>();
-	private String failedReason;
-	private String serverModFolder = DEFAULT_SERVER_FOLDER; //only for mod devs
-	private ArrayList<AlternateFile> alternateFiles = new ArrayList<AlternateFile>();
-	private ArrayList<AlternateCustomDLC> alternateCustomDLC = new ArrayList<AlternateCustomDLC>();
-	private ArrayList<String> sideloadOnlyTargets = new ArrayList<>();
-	private String sideloadURL;
-	private ArrayList<String> blacklistedFiles = new ArrayList<>();
-	private ArrayList<String> outdatedDLCModules = new ArrayList<>();
-	private ArrayList<AlternateCustomDLC> appliedAutomaticAlternateCustomDLC = new ArrayList<AlternateCustomDLC>();
-	private boolean shouldApplyAutos = true;
-	public String rawCustomDLCSourceDirs;
-	public String rawcustomDLCDestDirs;
-	public ArrayList<MDEOfficialJob> rawOfficialJobs = new ArrayList<MDEOfficialJob>();
-	public String rawAltDlcText;
-	public String rawAltFilesText;
-	public ArrayList<String> requiredDLC = new ArrayList<>();
-	private String rawOutdatedCustomDLCText;
-	private boolean modIsUnofficial;
-
-	public ArrayList<AlternateCustomDLC> getAppliedAutomaticAlternateCustomDLC() {
-		return appliedAutomaticAlternateCustomDLC;
-	}
-
-	public void setAppliedAutomaticAlternateCustomDLC(ArrayList<AlternateCustomDLC> appliedAutomaticAlternateCustomDLC) {
-		this.appliedAutomaticAlternateCustomDLC = appliedAutomaticAlternateCustomDLC;
-	}
-
-	public boolean isModIsUnofficial() {
-		return modIsUnofficial;
-	}
-
-	public void setModIsUnofficial(boolean modIsUnofficial) {
-		this.modIsUnofficial = modIsUnofficial;
-	}
-
-	public String getServerModFolder() {
-		return serverModFolder;
-	}
-
-	public ArrayList<AlternateFile> getAlternateFiles() {
-		return alternateFiles;
-	}
-
-	public void setAlternateFiles(ArrayList<AlternateFile> alternateFiles) {
-		this.alternateFiles = alternateFiles;
-	}
-
-	public ArrayList<AlternateCustomDLC> getAlternateCustomDLC() {
-		return alternateCustomDLC;
-	}
-
-	public void setAlternateCustomDLC(ArrayList<AlternateCustomDLC> alternateCustomDLC) {
-		this.alternateCustomDLC = alternateCustomDLC;
-	}
-
-	public void setServerModFolder(String serverModFolder) {
-		this.serverModFolder = serverModFolder;
-	}
-
-	/**
-	 * Creates a new mod object from a moddesc file and loads it for use.
-	 * 
-	 * @param filepath
-	 *            Path to the moddesc.ini file.
-	 */
-	public Mod(String filepath) {
-		if (filepath == null) {
-			return;
-		}
-		loadMod(filepath);
-	}
-
-	/**
-	 * Reads moddesc and sets up the mod object. This is mainly used from the
-	 * main Mod(moddesc.ini) method. This method was externalized to allow for
-	 * setting up the the mod object before this method is processed.
-	 * 
-	 * @param filepath
-	 *            Moddesc.ini file to load
-	 */
-	public void loadMod(String filepath) {
-		modifyString = "";
-		modDescFile = new File(filepath);
-		setModPath(ModManager.appendSlash(modDescFile.getParent()));
-		jobs = new ArrayList<ModJob>();
-		try {
-			readDesc(new Wini(modDescFile));
-		} catch (Exception e) {
-			if (modName == null) {
-				modName = "Unknown mod";
-			}
-			ModManager.debugLogger.writeErrorWithException("Error reading moddesc.ini:", e);
-			setFailedReason("An exception occured reading moddesc.ini for this mod: " + ExceptionUtils.getStackTrace(e));
-			setValidMod(false);
-			return;
-		}
-	}
-
-	/**
-	 * Loads a moddesc from a stream of bytes. Typically this is from a
-	 * compressed archive.
-	 * 
-	 * @param bytes
-	 */
-	public Mod(ByteArrayInOutStream bytes) {
-		modDescFile = new File(System.getProperty("user.dir"));
-		ignoreLoadErrors = true;
-		modifyString = "";
-		jobs = new ArrayList<ModJob>();
-		try {
-			Wini wini = new Wini();
-			wini.load(bytes.getInputStream());
-			readDesc(wini);
-		} catch (Exception e) {
-			ModManager.debugLogger.writeErrorWithException("Error reading moddesc.ini from stream:", e);
-			setValidMod(false);
-			return;
-		}
-	}
-
-	/**
-	 * Loads a moddesc from a stringwriter. This is used when dynamically
-	 * generating one for import from an unsupported mod.
-	 * 
-	 * @param writer
-	 */
-	public Mod(StringWriter writer) {
-		modDescFile = new File(System.getProperty("user.dir"));
-		ignoreLoadErrors = true;
-		modifyString = "";
-		jobs = new ArrayList<ModJob>();
-		try {
-			Wini wini = new Wini();
-			wini.load(new StringReader(writer.toString()));
-			readDesc(wini);
-		} catch (Exception e) {
-			ModManager.debugLogger.writeErrorWithException("Error reading moddesc.ini from stream:", e);
-			setValidMod(false);
-			return;
-		}
-	}
-
-	/**
-	 * Empty constructor. This should not be used unless you really know what
-	 * you're doing. (manually adding jobs etc)
-	 * 
-	 * Instantiates the jobs variable and modifystring to blank and nothing
-	 * else.
-	 */
-	public Mod() {
-		jobs = new ArrayList<ModJob>();
-		modifyString = "";
-	}
-
-	/**
-	 * Copy Constructor
-	 * 
-	 * @param mod
-	 *            Mod to clone
-	 */
-	public Mod(Mod mod) {
-		modDescFile = mod.modDescFile;
-		modPath = mod.modPath;
-		modName = mod.modName;
-		modVersion = mod.modVersion;
-		modSite = mod.modSite;
-		modDisplayDescription = mod.modDisplayDescription;
-		modDescription = mod.modDescription;
-		validMod = mod.validMod;
-		jobs = new ArrayList<ModJob>();
-		modifyString = mod.modifyString;
-		modAuthor = mod.modAuthor;
-		modmakerCode = mod.modmakerCode;
-		modmp = mod.modmp;
-		compiledAgainstModmakerVersion = mod.compiledAgainstModmakerVersion;
-		modCMMVer = mod.modCMMVer;
-		classicCode = mod.classicCode;
-		ignoreLoadErrors = mod.ignoreLoadErrors;
-		failedReason = mod.failedReason;
-		serverModFolder = mod.serverModFolder;
-		sideloadOnlyTargets = new ArrayList<String>();
-		outdatedDLCModules = new ArrayList<String>();
-		sideloadURL = mod.sideloadURL;
-		alternateFiles = new ArrayList<AlternateFile>();
-		requiredPatches = new ArrayList<Patch>();
-		modDeltas = new ArrayList<ModDelta>();
-		for (ModJob job : mod.jobs) {
-			ModJob newjob = new ModJob(job);
-			newjob.setOwningMod(this);
-			jobs.add(newjob);
-		}
-		for (String str : mod.sideloadOnlyTargets) {
-			sideloadOnlyTargets.add(str);
-		}
-		for (AlternateFile str : mod.alternateFiles) {
-			alternateFiles.add(new AlternateFile(str));
-		}
-		for (Patch str : mod.requiredPatches) {
-			requiredPatches.add(new Patch(str));
-		}
-		for (ModDelta str : mod.modDeltas) {
-			modDeltas.add(new ModDelta(str));
-		}
-		for (AlternateCustomDLC dlc : mod.alternateCustomDLC) {
-			alternateCustomDLC.add(new AlternateCustomDLC(dlc));
-		}
-		for (String str : mod.outdatedDLCModules) {
-			outdatedDLCModules.add(str);
-		}
-		for (String str : mod.requiredDLC) {
-			requiredDLC.add(str);
-		}
-	}
-
-	/**
-	 * Parses the moddesc.ini file and validates it.
-	 * 
-	 * @throws InvalidFileFormatException
-	 * @throws IOException
-	 */
-	private void readDesc(Wini modini) throws InvalidFileFormatException, IOException {
-		String modFolderPath = ModManager.appendSlash(modDescFile.getParent());
-		//modDisplayDescription = modini.get("ModInfo", "moddesc");
-		modName = modini.get("ModInfo", "modname");
-		String delayedFailure = null;
-		if (modName == null) {
-			//Attempt to extract name from the folder name
-			String foldername = new File(getModPath()).getName();
-			modName = foldername;
-			ModManager.debugLogger.writeError("Mod does not have a modname descriptor - marking invalid (" + modName + ") - will delay failing until update code is parsed.");
-			delayedFailure = "This mod does not have a modname descriptor under the [ModInfo] header in its moddesc.ini file. The name displayed in this window is the extracted from the mod's foldername. All Mod Manager mods must have a moddname descriptor.";
-		}
-		ModManager.debugLogger.writeMessageConditionally("-------MOD----------------Reading " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-
-		modDescription = modini.get("ModInfo", "moddesc");
-		if (modDescription == null) {
-			ModManager.debugLogger.writeError("Mod does not have a modname descriptor - marking invalid (" + modName + ") - will delay failing until update code is parsed.");
-			delayedFailure = "This mod does not have a moddesc descriptor under the [ModInfo] header in its moddesc.ini file. All Mod Manager mods must have a moddesc descriptor, which is the description shown to users in the right pane of the main Mod Manager window.";
-		}
-
-		modIsUnofficial = modini.get("ModInfo", "unofficial") != null;
-
-		// Check if this mod has been made for Mod Manager 2.0+ or legacy mode
-		modCMMVer = 1.0f;
-		try {
-			String versionStr = modini.get("ModManager", "cmmver");
-			if (versionStr == null) {
-				ModManager.debugLogger.writeMessageConditionally("Didn't read a ModManager version of the mod. Setting modtype to legacy", ModManager.LOG_MOD_INIT);
-				modCMMVer = 1.0f;
-			} else {
-				modCMMVer = Float.parseFloat(versionStr);
-			}
-		} catch (NumberFormatException e) {
-			ModManager.debugLogger.writeMessageConditionally("Didn't read a ModManager version of the mod. Setting modtype to legacy", ModManager.LOG_MOD_INIT);
-			modCMMVer = 1.0f;
-		}
-
-		//READ NON-ESSENTIAL DATA, USEFUL FOR FAILED MODS, AS THEY WILL ABORT ON ERROR
-		if (modini.get("ModInfo", "modver") != null) {
-			modVersion = modini.get("ModInfo", "modver");
-			ModManager.debugLogger.writeMessageConditionally("Detected mod version: " + modVersion, ModManager.LOG_MOD_INIT);
-		}
-
-		// Add Devsite
-		if (modini.get("ModInfo", "modsite") != null) {
-			modSite = modini.get("ModInfo", "modsite");
-			ModManager.debugLogger.writeMessageConditionally("Detected developer site", ModManager.LOG_MOD_INIT);
-		}
-
-		// Load modmaker update code
-		if (modini.get("ModInfo", "modid") != null) {
-			try {
-				modmakerCode = Integer.parseInt(modini.get("ModInfo", "modid"));
-				ModManager.debugLogger.writeMessageConditionally("Detected modmaker code", ModManager.LOG_MOD_INIT);
-			} catch (NumberFormatException e) {
-				ModManager.debugLogger.writeError("ModMaker code failed to resolve to an integer: " + modini.get("ModInfo", "modid"));
-			}
-		}
-
-		// Load classic update code
-		if (modini.get("ModInfo", "updatecode") != null) {
-			try {
-				classicCode = Integer.parseInt(modini.get("ModInfo", "updatecode"));
-				ModManager.debugLogger.writeMessageConditionally("Detected me3tweaks update code: " + classicCode, ModManager.LOG_MOD_INIT);
-			} catch (NumberFormatException e) {
-				ModManager.debugLogger.writeError("Classic update code is not an integer. Defaulting to 0");
-			}
-		}
-
-		if (classicCode > 0 && modmakerCode > 0) {
-			//can't have both
-			ModManager.debugLogger.writeError(modName + " has both a classic update code and a ModMaker update code - this is not allowed, marking as invalid.");
-			setFailedReason(
-					"This mod has both a modid and updatecode descriptor under the [ModInfo] header. These descriptors are used for checking for updates and are mutually exclusive, so this mod has been marked as invalid. To fix this, remove one of the descriptors from moddesc.ini.");
-			return;
-		}
-
-		if (delayedFailure != null) {
-			ModManager.debugLogger.writeError("Delayed failure loading " + modName + ": " + delayedFailure);
-			setFailedReason(delayedFailure);
-			return;
-		}
-
-		// Add MP Change - DEPRECATED!
-		if (modini.get("ModInfo", "modmp") != null) {
-			modmp = modini.get("ModInfo", "modmp");
-			ModManager.debugLogger.writeMessageConditionally("Detected multiplayer modification", ModManager.LOG_MOD_INIT);
-		}
-		// Add developer
-		if (modini.get("ModInfo", "moddev") != null) {
-			modAuthor = modini.get("ModInfo", "moddev");
-			ModManager.debugLogger.writeMessageConditionally("Detected developer name", ModManager.LOG_MOD_INIT);
-		}
-
-		// Backwards compatibility for mods that are built to target older
-		// versions of mod manager (NO DLC)
-		if (modCMMVer < 2.0f) {
-			modCMMVer = 1.0f;
-			ModManager.debugLogger.writeMessageConditionally("Modcmmver is less than 2, checking for coalesced.bin in folder (legacy)", ModManager.LOG_MOD_INIT);
-			if (!ignoreLoadErrors) {
-				File file = new File(ModManager.appendSlash(getModPath()) + "Coalesced.bin");
-				if (!file.exists() && !ignoreLoadErrors) {
-					ModManager.debugLogger
-							.writeError(modName + " doesn't have Coalesced.bin and is marked as legacy (coalesced is required for this moddesc version), marking as invalid.");
-					setFailedReason("Mod is legacy (1.0), which requires a Coalesced.bin in the same folder as the moddesc.ini file. Coalesced.bin is not present.");
-					return;
-				}
-			}
-			File file = new File(ModManager.appendSlash(getModPath()) + "Coalesced.bin");
-			ModManager.debugLogger.writeMessageConditionally("Mod Manager 1.0 mod, verifying Coaleseced.bin location", ModManager.LOG_MOD_INIT);
-
-			if (!file.exists() && !ignoreLoadErrors) {
-				ModManager.debugLogger.writeMessageConditionally(modName + " doesn't have Coalesced.bin even though flag was set. Marking as invalid.", ModManager.LOG_MOD_INIT);
-				setFailedReason(
-						"Mod targets Mod Manager 1.x but the Coalesced.bin file in the mod folder doesn't exist. Place a Coalesced.bin file in the same folder as moddesc.ini or remove the modcoal descriptor.");
-
-				return;
-			} else {
-				ModManager.debugLogger.writeMessageConditionally("Coalesced.bin is OK", ModManager.LOG_MOD_INIT);
-			}
-			ModJob job = new ModJob();
-			job.setOwningMod(this);
-			job.addFileReplace(file.getAbsolutePath(), "\\BIOGame\\CookedPCConsole\\Coalesced.bin", ignoreLoadErrors, false);
-			addTask(ModTypeConstants.BASEGAME, job);
-
-			validMod = true;
-			generateModDisplayDescription();
-			ModManager.debugLogger.writeMessage("Finished reading moddesc.ini file for cmm 1.0 mod " + modName);
-			ModManager.debugLogger.writeMessageConditionally(modName + " targets CMM 1.0. Added coalesced swap job.", ModManager.LOG_MOD_INIT);
-			ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-			return;
-		}
-
-		if (modCMMVer > 3.0f && modCMMVer < 3.1f) {
-			modCMMVer = 3.0f;
-		}
-
-		//some mods shipped as 3.2
-		if (modCMMVer > 3.1f && modCMMVer < 4.0f) {
-			modCMMVer = 3.1;
-		}
-
-		modCMMVer = (double) Math.round(modCMMVer * 10) / 10;
-
-		ModManager.debugLogger.writeMessageConditionally("Mod Manager version read: " + modCMMVer, ModManager.LOG_MOD_INIT);
-		ModManager.debugLogger.writeMessageConditionally("Checking for JOB headers in the ini file.", ModManager.LOG_MOD_INIT);
-
-		// It's a 2.0 or above mod. Check for mod tags in the desc file
-		String[] modIniHeaders = ModTypeConstants.getLoadingHeaderNameArray();
-
-		for (String modHeader : modIniHeaders) {
-			// Check for each mod. If it exists, add the task
-			String iniModDir = modini.get(modHeader, "moddir");
-			if (iniModDir != null && !iniModDir.equals("")) {
-				// It's a DLC header, we should check for the files to mod, and
-				// make sure they all match properly
-				ModManager.debugLogger.writeMessageConditionally("Found INI header " + modHeader, ModManager.LOG_MOD_INIT);
-
-				//REPLACE FILES (Mod Manager 2.0+)
-				String newFileIni = modini.get(modHeader, "newfiles");
-				String oldFileIni = modini.get(modHeader, "replacefiles");
-				//NEW FILES (Mod Manager 4.1+)
-				String addFileIni = modini.get(modHeader, "addfiles");
-				String addFileTargetIni = modini.get(modHeader, "addfilestargets");
-				String addReadOnlyFileTargetIni = modini.get(modHeader, "addfilesreadonlytargets");
-
-				//REMOVE FILES (Mod Manager 4.1+)
-				String removeFileTargetIni = modini.get(modHeader, "removefilestargets");
-				String requirementText = null;
-
-				boolean taskDoesSomething = false;
-				if (newFileIni != null && oldFileIni != null && !newFileIni.equals("") && !oldFileIni.equals("")) {
-					taskDoesSomething = true;
-				}
-				if (addFileIni != null && addFileTargetIni != null && !addFileIni.equals("") && !addFileTargetIni.equals("")) {
-					taskDoesSomething = true;
-				}
-				if (removeFileTargetIni != null && !removeFileTargetIni.equals("")) {
-					taskDoesSomething = true;
-				}
-
-				if (!taskDoesSomething) {
-					setFailedReason("Mod has a header (" + modHeader + ") with tasks that effectively do nothing. Add tasks or remove the header to fix this issue.");
-					ModManager.debugLogger.writeError("This task appears to do nothing. It should be removed if this is the case. Marking mod as invalid.");
-					return;
-				}
-
-				StringTokenizer newStrok = null, oldStrok = null;
-				if (newFileIni != null && oldFileIni != null) {
-					//Parse replace files
-					newStrok = new StringTokenizer(newFileIni, ";");
-					oldStrok = new StringTokenizer(oldFileIni, ";");
-					if (newStrok.countTokens() != oldStrok.countTokens()) {
-						// Same number of tokens aren't the same
-						ModManager.debugLogger.writeError("Number of files to update/replace do not match, mod being marked as invalid.");
-						setFailedReason("Mod has a header (" + modHeader
-								+ ") that has different number of files to update/replace. The lists must be the same length (source files and destination paths).");
-						ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-						return;
-					}
-				}
-
-				//Mod Manager 4.1+ ADD/REMOVE/JOBDESCRIPTIONS
-				StringTokenizer addStrok = null;
-				StringTokenizer addTargetStrok = null;
-				StringTokenizer addTargetReadOnlyStrok = null;
-				StringTokenizer removeStrok = null;
-				if (modCMMVer >= 4.1) {
-					//check for add/remove pairs
-					if ((addFileIni != null && addFileTargetIni == null) || (addFileIni == null && addFileTargetIni != null)) {
-						ModManager.debugLogger.writeError("addfiles/addtargetfiles is missing, but one is present, but both are required. Mod marked as invalid");
-						setFailedReason("Mod has a header (" + modHeader + ") that has an addfiles or addtargetfiles task, but the corresponding task is not present.");
-						ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-						return;
-					}
-
-					//Parse add files
-					if (addFileIni != null && addFileTargetIni != null && !addFileIni.equals("") && !addFileTargetIni.equals("")) {
-						addStrok = new StringTokenizer(addFileIni, ";");
-						addTargetStrok = new StringTokenizer(addFileTargetIni, ";");
-						if (addStrok.countTokens() != addTargetStrok.countTokens()) {
-							// Same number of tokens aren't the same
-							ModManager.debugLogger.writeError("Number of files to add and number of target files do not match, mod being marked as invalid.");
-							setFailedReason(
-									"Mod has a header (" + modHeader + ") that has an addfiles task, but the number of source files and the number of targets do not match.");
-							ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-							return;
-						}
-						if (modCMMVer >= 4.3 && addReadOnlyFileTargetIni != null) {
-							//READ ONLY DESIGNATION
-							addTargetReadOnlyStrok = new StringTokenizer(addReadOnlyFileTargetIni, ";");
-						}
-					}
-
-					//remove files doesn't need a token match, but create the tokenizer for later
-					if (removeFileTargetIni != null && !removeFileTargetIni.equals("")) {
-						removeStrok = new StringTokenizer(removeFileTargetIni, ";");
-					}
-					requirementText = modini.get(modHeader, "jobdescription");
-					ModManager.debugLogger.writeMessageConditionally(modHeader + " job description: " + requirementText, ModManager.LOG_MOD_INIT);
-				}
-
-				//For ModDesc Editor
-				MDEOfficialJob mdeJob = new MDEOfficialJob(modHeader, iniModDir, newFileIni, oldFileIni, addFileIni, addFileTargetIni, addReadOnlyFileTargetIni,
-						removeFileTargetIni, requirementText);
-				rawOfficialJobs.add(mdeJob);
-
-				// Check to make sure the filenames are the same, and if they
-				// are, then the mod is going to be valid.
-				// Start building the mod job.
-				// modCMMVer = 3.0;
-				ModJob newJob;
-				if (modCMMVer >= 3 && modHeader.equals(ModTypeConstants.BASEGAME)) {
-					newJob = new ModJob();
-				} else if (modCMMVer >= 4.3 && modHeader.equals(ModTypeConstants.BINI)) {
-					newJob = new ModJob();
-					newJob.setJobName(ModTypeConstants.BINI);
-					newJob.setJobType(ModJob.BALANCE_CHANGES);
-				} else {
-					// DLC Job
-					newJob = new ModJob(ModTypeConstants.getDLCPath(modHeader), modHeader, requirementText);
-					if (modCMMVer >= 3 && modHeader.equals(ModTypeConstants.TESTPATCH)) {
-						newJob.TESTPATCH = true;
-					}
-				}
-				newJob.setOwningMod(this);
-				newJob.setSourceDir(iniModDir);
-				if (newStrok != null && oldStrok != null) {
-					while (newStrok.hasMoreTokens()) {
-						String newFile = newStrok.nextToken();
-						String oldFile = oldStrok.nextToken();
-						// ModManager.debugLogger.writeMessageConditionally("Validating tokens: "+newFile+" vs
-						// "+oldFile);
-						if (!newFile.equals(getSfarFilename(oldFile))) {
-							setFailedReason("Mod has a newfiles/replacefiles task in a header (" + modHeader + ") that has different filenames in the source vs target paths: "
-									+ newFile + " vs " + getSfarFilename(oldFile) + ". These filenames currently must be the same. This restriction may be lifted in the future.");
-							ModManager.debugLogger.writeError("[REPLACEFILE]Filenames failed to match, mod marked as invalid: " + newFile + " vs " + getSfarFilename(oldFile));
-							return; // The names of the files don't match
-						}
-
-						if (oldFile.contains("..")) {
-							setFailedReason("Mod has a task in a header (" + modHeader
-									+ ") that attempts to replace files using a parent directory indicator (\\..\\). This is a security risk to the system. Mods will not load with these paths.");
-							ModManager.debugLogger
-									.writeError("[REPLACEFILE]SECURITY RISK! Task is attempting to replacing file using parent directory indicator .. . Mod has been disabled");
-							return; // Security mitigation
-						}
-
-						// Add the file swap to task job - if this method returns
-						// false it means a file doesn't exist somewhere
-						if (!(newJob.addFileReplace(modFolderPath + ModManager.appendSlash(iniModDir) + newFile, oldFile, ignoreLoadErrors, false)) && !ignoreLoadErrors) {
-							ModManager.debugLogger.writeError("Failed to add file to replace (File likely does not exist), marking as invalid.");
-							setFailedReason("Mod has a newfiles/replacefiles task in a header (" + modHeader
-									+ ") that encountered an error while building the list of source/targets. This likely means the source file does not exist: " + modFolderPath
-									+ ModManager.appendSlash(iniModDir) + newFile);
-							ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-							return;
-						}
-					}
-				}
-				if (addStrok != null) {
-					while (addStrok.hasMoreTokens()) {
-						String addFile = addStrok.nextToken();
-						String targetFile = addTargetStrok.nextToken();
-						if (!addFile.equals(getSfarFilename(targetFile))) {
-							ModManager.debugLogger.writeError("[ADDFILE]Filenames failed to match, mod marked as invalid: " + addFile + " vs " + getSfarFilename(targetFile));
-							setFailedReason("Mod specifies an addfile/addfiles target task in (" + modHeader + "), but the filenames for source vs targets doesn't match: "
-									+ addFile + " vs " + getSfarFilename(targetFile));
-							ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-							return; // The names of the files don't match
-						}
-
-						// Add the file swap to task job - if this method returns
-						// false it means a file doesn't exist somewhere
-						if (!(newJob.addNewFileTask(modFolderPath + ModManager.appendSlash(iniModDir) + addFile, targetFile, ignoreLoadErrors)) && !ignoreLoadErrors) {
-							ModManager.debugLogger.writeError("[ADDFILE]Failed to add task for file addition (File likely does not exist), marking as invalid.");
-							setFailedReason("Mod has an addfiles/addfilestargets task in a header (" + modHeader
-									+ ") that encountered an error while building the list of source/targets. This likely means the source file does not exist: " + modFolderPath
-									+ ModManager.appendSlash(iniModDir) + addFile);
-							ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-							return;
-						}
-					}
-					if (modCMMVer >= 4.3 && addTargetReadOnlyStrok != null) {
-						//READ ONLY DESIGNATION
-						while (addTargetReadOnlyStrok.hasMoreTokens()) {
-							String readonlytarget = addTargetReadOnlyStrok.nextToken();
-							if (!readonlytarget.startsWith("\\")) {
-								//prepend \ so it matches the one stored in modjob
-								readonlytarget = "\\" + readonlytarget;
-							}
-							if (!newJob.getFilesToAddTargets().contains(readonlytarget)) {
-								ModManager.debugLogger.writeError(
-										"[ADDFILE-READONLY]Failed to set a file to be marked as read only on install - Cannot mark file read-only if its not in the addfiles list: "
-												+ readonlytarget);
-								setFailedReason(
-										"Mod has designated files to install should be marked read-only (so end user won't modify them). A designation does not match any files in the addfilestargets list: "
-												+ readonlytarget);
-								ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-								return;
-							}
-							newJob.addNewFileReadOnlyTask(readonlytarget);
-						}
-					}
-				}
-				if (removeStrok != null) {
-					while (removeStrok.hasMoreTokens()) {
-						String removeFilePath = removeStrok.nextToken();
-						//add remove file to job
-						if (!newJob.addRemoveFileTask(removeFilePath)) {
-							ModManager.debugLogger.writeError("[REMOVE]Failed to add task for file removal.");
-							setFailedReason("Mod failed to add file for removal as part of header (" + modHeader
-									+ "), his shouldn't be able to happen! The file target that failed: " + removeFilePath);
-							ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
-							return;
-						}
-					}
-				}
-
-				if (modCMMVer >= 4.5 && !newJob.getJobName().equals(ModTypeConstants.BINI)) {
-					String altText = modini.get(modHeader, "altfiles");
-					if (altText != null && !altText.equals("")) {
-						ArrayList<String> alts = ValueParserLib.getSplitValues(altText);
-						if (alts == null) {
-							//error
-							ModManager.debugLogger.writeError(
-									"ALTERNATES altfiles was specified, but the value couldn't be parsed. This error is from the OFFICIAL headers, so it only applies to official BioWare DLC or the basegame. The definition is likely invalid: "
-											+ altText);
-							setFailedReason("The moddesc indicates there should be files installed differently depending on certain conditions, but it failed to parse. The ["
-									+ modHeader + "] altfiles text that failed to parse was :" + altText
-									+ "\n\nThis may not affect your specific ME3 environment, but the mod has been marked as invalid to avoid possible issues.");
-							return;
-						}
-						for (String alt : alts) {
-							AlternateFile af = new AlternateFile(alt, modCMMVer);
-							af.setAssociatedJobName(newJob.getJobName());
-							af.setModFile(ResourceUtils.normalizeFilePath(af.getModFile(), false));
-							ModManager.debugLogger.writeMessageConditionally("Alternate file specified: " + af.toString(), ModManager.LOG_MOD_INIT);
-
-							String subPath = (modCMMVer == 4.5 && af.getOperation() == AlternateFile.OPERATION_SUBSTITUTE) ? af.getSubstituteFile() : af.getAltFile();
-							if (subPath != null) {
-								//check location
-								String subfile = ModManager.appendSlash(getModPath()) + subPath;
-								File f = new File(subfile);
-								if (!f.exists() && !ignoreLoadErrors) {
-									ModManager.debugLogger.writeError(
-											"This error is from the OFFICIAL headers, so it only applies to official BioWare DLC or the Basegame. Substitute file doesn't exist: "
-													+ f.getAbsolutePath());
-									setFailedReason(
-											"The moddesc indicates there should be files installed differently depending on certain conditions, but a listed substitute file doesn't exist. The error occurs in the ["
-													+ modHeader + "] header altfiles text. The missing file is :" + f.getAbsolutePath()
-													+ "\n\nThis may not affect your specific ME3 enviroment, but the mod has been marked as invalid to avoid possible issues.");
-									return;
-								}
-
-								//Validate substition for moddesc 4.5 -> 5.0
-								if (af.getOperation().equals(AlternateFile.OPERATION_SUBSTITUTE)) {
-									if (!af.getAssociatedJobName().equals(ModTypeConstants.CUSTOMDLC) && modCMMVer == 4.5 && af.getSubstituteFile() == null) {
-										//missing substitute file on 4.5
-										ModManager.debugLogger
-												.writeError("Automatic alternate file targets Mod Manager 4.5 but does not have a listed SubstituteFile: " + af.getModFile());
-										setFailedReason("This mod specifies automatic conditional changes for the following but has no SubstituteFile item in its altfile struct: "
-												+ af.getModFile()
-												+ "\n\nThis is specific to mods targeting ModDesc 4.5. ModDesc 5.0+ mods use the same ModFile/AltModFile format for all operations.");
-										return;
-									}
-									if (modCMMVer > 4.5 && af.getSubstituteFile() != null) {
-										//Using substitute operation on > 4.5 is not allowed
-										ModManager.debugLogger
-												.writeError("Automatic alternate file targets Mod Manager > 4.5 but contains 4.5 only SubstituteFile: " + af.getModFile());
-										setFailedReason("This mod specifies automatic conditional changes for the following but has a SubstituteFile item in its altfile struct: "
-												+ af.getModFile()
-												+ "\n\nMods targeting ModDesc 5.0 and higher don't support the SubstituteFile item for altfiles - did you upgrade 4.5 -> 5.0 and forget to change this to AltFile?");
-										return;
-									}
-								}
-							} else {
-								//auto alts cannot apply to the same thing
-								ModManager.debugLogger.writeError("Automatic alternate file is missing AltFile attribute: " + af.getModFile());
-								setFailedReason(
-										"This mod specifies automatic conditional changes for the following but is missing the AltFile item in the struct: " + af.getModFile());
-								return;
-							}
-							ModManager.debugLogger.writeMessageConditionally("AltFile is OK: " + af.getFriendlyName(), ModManager.LOG_MOD_INIT);
-							newJob.getAlternateFiles().add(af);
-						}
-					}
-				}
-
-				ModManager.debugLogger.writeMessageConditionally(modName + ": Successfully made a new Mod Job for: " + modHeader, ModManager.LOG_MOD_INIT);
-				addTask(modHeader, newJob);
-			}
-		}
-
-		// CHECK FOR CUSTOMDLC HEADER (3.1+)
-		if (modCMMVer >= 3.1)
-
-		{
-			ModManager.debugLogger.writeMessageConditionally("Mod built for ModManager 3.1+, checking for CUSTOMDLC header", ModManager.LOG_MOD_INIT);
-			String iniModDir = modini.get(ModTypeConstants.CUSTOMDLC, "sourcedirs");
-			if (iniModDir != null && !iniModDir.equals("")) {
-				ModManager.debugLogger.writeMessageConditionally("Found CUSTOMDLC header", ModManager.LOG_MOD_INIT);
-
-				//customDLC flag is set
-				String sourceFolderIni = modini.get(ModTypeConstants.CUSTOMDLC, "sourcedirs");
-				String destFolderIni = modini.get(ModTypeConstants.CUSTOMDLC, "destdirs");
-				rawCustomDLCSourceDirs = sourceFolderIni;
-				rawcustomDLCDestDirs = destFolderIni;
-				// ModManager.debugLogger.writeMessageConditionally("New files: "+newFileIni);
-				// ModManager.debugLogger.writeMessageConditionally("Old Files: "+oldFileIni);
-				if (sourceFolderIni == null || destFolderIni == null || sourceFolderIni.equals("") || destFolderIni.equals("")) {
-					setFailedReason("Mod specifies a CUSTOMDLC header, but one or both of the lists was empty.");
-					ModManager.debugLogger.writeError("sourcedirs/destdirs files was null or empty, mod marked as invalid.");
-					return;
-				}
-
-				StringTokenizer srcStrok = new StringTokenizer(sourceFolderIni, ";");
-				StringTokenizer destStrok = new StringTokenizer(sourceFolderIni, ";");
-				if (srcStrok.countTokens() != destStrok.countTokens()) {
-					// Same number of tokens aren't the same
-					setFailedReason("Mod specifies a CUSTOMDLC header, but the list of source directories and target directories didn't match.");
-					ModManager.debugLogger.writeError("Number of source and destination directories for custom DLC job do not match, mod being marked as invalid.");
-					return;
-				}
-
-				ModJob newJob = new ModJob();
-				newJob.setOwningMod(this);
-				newJob.setJobName(ModTypeConstants.CUSTOMDLC); //backwards, it appears...
-				newJob.setJobType(ModJob.CUSTOMDLC);
-				newJob.setSourceFolders(new ArrayList<String>());
-				newJob.setDestFolders(new ArrayList<String>());
-
-				while (srcStrok.hasMoreTokens()) {
-					String sourceFolder = srcStrok.nextToken();
-					String destFolder = destStrok.nextToken();
-
-					File sf = new File(modFolderPath + sourceFolder);
-					if (!sf.exists() && !ignoreLoadErrors) {
-						setFailedReason("Mod specifies a CUSTOMDLC header, but one of the source directories doesn't list: " + sf.getAbsolutePath());
-						ModManager.debugLogger.writeError("Custom DLC Source folder does not exist: " + sf.getAbsolutePath() + ", mod marked as invalid");
-						return;
-					}
-					if (ModTypeConstants.isKnownDLCFolder(destFolder)) {
-						// Same number of tokens aren't the same
-						setFailedReason(
-								"Mod specifies a CUSTOMDLC header, but one of the target directories isn't allowed as it is a known official DLC foldername: " + destFolder);
-						ModManager.debugLogger.writeError("Custom DLC folder is not allowed as it is a default game one: " + destFolder);
-						return;
-					}
-
-					if (!destFolder.startsWith("DLC_")) {
-						setFailedReason(
-								"Mod specifies a CUSTOMDLC destination folder that doesn't start with DLC_. When installing this mod, this will do nothing because Mass Effect 3 will not load any DLC that does not start with DLC_."
-										+ destFolder);
-						ModManager.debugLogger.writeError("Custom DLC target folder doesn't start with DLC_: " + destFolder);
-						return;
-					}
-
-					if (sf.exists()) { //ignore errors is not present here.
-						List<File> sourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
-						for (File file : sourceFiles) {
-							String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
-							String destFilePath = ModManager.appendSlash(destFolder) + relativePath;
-							if (!(newJob.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath(), false), ResourceUtils.normalizeFilePath(destFilePath, false),
-									ignoreLoadErrors, false) && !ignoreLoadErrors)) {
-								setFailedReason("Mod specifies a CUSTOMDLC header, but a file in one of the source directories (" + sf
-										+ ") had a file that was unable to be added. This error should not be encountered.");
-								ModManager.debugLogger.writeError("Failed to add file to replace (File likely does not exist), marking as invalid.");
-								return;
-							}
-						}
-					}
-					newJob.getSourceFolders().add(sourceFolder);
-					newJob.getDestFolders().add(destFolder);
-				}
-				ModManager.debugLogger.writeMessageConditionally(modName + ": Successfully made a new Mod Job for: " + ModTypeConstants.CUSTOMDLC, ModManager.LOG_MOD_INIT);
-				addTask(ModTypeConstants.CUSTOMDLC, newJob);
-			}
-
-			//In 3.1+, we can check for 4.2+ since this won't trigger on lower
-			//MOD MANAGER 4.2.3: Support [CUSTOMDLC]>altfiles, Support [UPDATES]
-			if (modCMMVer >= 4.2) {
-				String altText = modini.get("CUSTOMDLC", "altfiles");
-				if (altText != null && !altText.equals("")) {
-					rawAltFilesText = altText;
-					ArrayList<String> alts = ValueParserLib.getSplitValues(altText);
-					if (alts == null) {
-						//error
-						ModManager.debugLogger.writeError("ALTERNATES altfiles was specified, but the value couldn't be parsed. It's likely invalid: " + altText);
-						setFailedReason(
-								"The moddesc indicates there should be files installed differently depending on certain conditions, but it failed to parse. The [ALTERNATES] altfiles text that failed to parse was :"
-										+ altText + "\n\nThis may not affect your specific ME3 enviroment, but the mod has been marked as invalid to avoid possible issues.");
-						return;
-					}
-					for (String alt : alts) {
-						AlternateFile af = new AlternateFile(alt, modCMMVer);
-						af.setAssociatedJobName(ModTypeConstants.CUSTOMDLC);
-						ModManager.debugLogger.writeMessageConditionally("Alternate file specified: " + af.toString(), ModManager.LOG_MOD_INIT);
-						alternateFiles.add(af);
-					}
-				}
-				if (modini.get("UPDATES", "serverfolder") != null) {
-					serverModFolder = modini.get("UPDATES", "serverfolder");
-					ModManager.debugLogger.writeMessageConditionally("Detected me3tweaks server folder: " + classicCode, ModManager.LOG_MOD_INIT);
-				}
-				sideloadURL = modini.get("UPDATES", "sideloadurl");
-				String sideloadonly = modini.get("UPDATES", "sideloadonly");
-				if (sideloadURL == null && sideloadonly != null) {
-					ModManager.debugLogger.writeError("Mod specifies sideload only files but does not specify sideloading link");
-					setFailedReason(
-							"This mod specifies a list of files that can only be updated via sideloading but does not specify a sideload URL. This can lead to a state where users will be unable to update the mod. Provide a (valid) sideload URL to fix this by adding 'sideloadurl=<URL>' under [UPDATES] in moddesc.ini.");
-					return;
-				}
-				if (sideloadonly != null) {
-					StringTokenizer sideloadTok = new StringTokenizer(sideloadonly, ";");
-					while (sideloadTok.hasMoreTokens()) {
-						String sideloadonlyfile = sideloadTok.nextToken();
-						sideloadonlyfile = sideloadonlyfile.replaceAll("\\\\", "/");
-						ModManager.debugLogger.writeMessageConditionally("Sideload only file for manifest: " + sideloadonlyfile, ModManager.LOG_MOD_INIT);
-						sideloadOnlyTargets.add(sideloadonlyfile);
-					}
-				}
-				String blacklisted = modini.get("UPDATES", "blacklistedfiles");
-				if (blacklisted != null) {
-					StringTokenizer blacklistedTok = new StringTokenizer(blacklisted, ";");
-					while (blacklistedTok.hasMoreTokens()) {
-						String blacklistedfile = blacklistedTok.nextToken();
-						blacklistedfile = blacklistedfile.replaceAll("\\\\", "/");
-						ModManager.debugLogger.writeMessageConditionally("Blacklisted file for manifests: " + blacklistedfile, ModManager.LOG_MOD_INIT);
-						getBlacklistedFiles().add(blacklistedfile);
-					}
-				}
-			}
-			if (modCMMVer >= 4.4) {
-				ModManager.debugLogger.writeMessageConditionally("Targetting Mod Manager Version >= 4.4, looking for altdlc descriptor in CUSTOMDLC", ModManager.LOG_MOD_INIT);
-				String altText = modini.get("CUSTOMDLC", "altdlc");
-				if (altText != null && !altText.equals("")) {
-					rawAltDlcText = altText;
-					ArrayList<String> alts = ValueParserLib.getSplitValues(altText);
-					if (alts == null) {
-						//error
-						ModManager.debugLogger.writeError("Alternate CustomDLC was specified, but the value couldn't be parsed. It's likely invalid: " + altText);
-						setFailedReason(
-								"The moddesc indicates there should Custom DLC added, removed, or modified depending on certain game conditions, but it failed to parse. The [CUSTOMDLC] altdlc text that failed to parse was :"
-										+ altText + "\n\nThis may not affect your specific ME3 enviroment, but the mod has been marked as invalid to avoid possible issues.");
-						return;
-					}
-					for (String alt : alts) {
-						AlternateCustomDLC altdlc = new AlternateCustomDLC(alt);
-						ModManager.debugLogger.writeMessageConditionally("Alternate CustomDLC specified: " + alt.toString(), ModManager.LOG_MOD_INIT);
-						alternateCustomDLC.add(altdlc);
-					}
-				}
-
-				String outdatedDLC = modini.get("CUSTOMDLC", "outdatedcustomdlc");
-				if (outdatedDLC != null && !outdatedDLC.equals("")) {
-					rawOutdatedCustomDLCText = outdatedDLC;
-					StringTokenizer outdatedDLCTok = new StringTokenizer(outdatedDLC, ";");
-					ArrayList<String> official = ModTypeConstants.getStandardDLCFolders();
-					while (outdatedDLCTok.hasMoreTokens()) {
-						String outdateddlcmodule = outdatedDLCTok.nextToken();
-						for (String officialdlc : official) {
-							officialdlc = officialdlc.toUpperCase();
-							if (officialdlc.equals(outdateddlcmodule)) {
-								ModManager.debugLogger.writeError("This mod lists an outdated DLC that should be deleted that is an official Mass Effect 3 DLC: " + officialdlc
-										+ ". This is not allowed as it can lead to users deleting officially purchased DLC. Marking mod as invalid.");
-								setFailedReason("This mod lists an outdated DLC that should be deleted that is an official Mass Effect 3 DLC: " + officialdlc
-										+ ". This is not allowed as it can lead to users deleting officially purchased DLC.");
-								return;
-							}
-						}
-						ModManager.debugLogger.writeMessageConditionally(
-								"Mod lists outdated DLC module that will be deleted on installation if the user says OK: " + outdateddlcmodule, ModManager.LOG_MOD_INIT);
-						getOutdatedDLCModules().add(outdateddlcmodule);
-					}
-				} else {
-					ModManager.debugLogger.writeMessageConditionally("Mod has no outdated custom dlc listed to remove on install", ModManager.LOG_MOD_INIT);
-				}
-			}
-		}
-
-		//Read required DLC
-		if (modCMMVer >= 5.0) {
-			ModManager.debugLogger.writeMessageConditionally("Targetting Mod Manager Version >= 5.0, looking for requireddlc descriptor", ModManager.LOG_MOD_INIT);
-			String requiredDLCText = modini.get("ModInfo", "requireddlc");
-			if (requiredDLCText != null && !requiredDLCText.equals("")) {
-				//get list of installed DLC
-				StringTokenizer tok = new StringTokenizer(requiredDLCText, ";");
-				ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
-				HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
-				while (tok.hasMoreTokens()) {
-					String header = tok.nextToken();
-					//check if its an official dlc header...
-					if (officialDLCHeaders.contains(header)) {
-						//convert to dlc folder name
-						String fname = headerFolderMap.get(header);
-						if (fname != null) {
-							ModManager.debugLogger.writeMessageConditionally("Mod requires DLC " + ME3TweaksUtils.getThirdPartyModName(fname, true), ModManager.LOG_MOD_INIT);
-							requiredDLC.add(fname.toUpperCase()); //Remap CITADEL To DLC_EXP_Pack003, etc.
-						}
-					} else {
-						requiredDLC.add(header); //Custom DLC
-					}
-				}
-			}
-		}
-
-		// Backwards compatibility for Mod Manager 2's modcoal flag (has now
-		// moved to [BASEGAME] as of 3.0)
-		if (modCMMVer < 3.0f && modCMMVer >= 2.0f)
-
-		{
-			modCMMVer = 2.0;
-			ModManager.debugLogger.writeMessageConditionally(modName + ": Targets CMM2.0. Checking for modcoal flag", ModManager.LOG_MOD_INIT);
-
-			int modCoalFlag = 0;
-			try {
-				modCoalFlag = Integer.parseInt(modini.get("ModInfo", "modcoal"));
-				ModManager.debugLogger.writeMessageConditionally("Coalesced flag: " + modCoalFlag, ModManager.LOG_MOD_INIT);
-
-				if (modCoalFlag != 0) {
-					File file = new File(ModManager.appendSlash(getModPath()) + "Coalesced.bin");
-					ModManager.debugLogger.writeMessageConditionally("Coalesced flag was set, verifying its location", ModManager.LOG_MOD_INIT);
-
-					if (!file.exists() && !ignoreLoadErrors) {
-						ModManager.debugLogger.writeMessageConditionally(modName + " doesn't have Coalesced.bin even though flag was set. Marking as invalid.",
-								ModManager.LOG_MOD_INIT);
-						setFailedReason(
-								"Mod targets Mod Manager 2.0 and specifies a Coalesced file should be present, but one doesn't exist. Place a Coalesced.bin file in the same folder as moddesc.ini or remove the modcoal descriptor.");
-
-						return;
-					} else {
-						ModManager.debugLogger.writeMessageConditionally("Coalesced.bin is OK", ModManager.LOG_MOD_INIT);
-					}
-					ModJob job = new ModJob();
-					job.setOwningMod(this);
-					job.addFileReplace(file.getAbsolutePath(), "\\BIOGame\\CookedPCConsole\\Coalesced.bin", ignoreLoadErrors, false);
-					addTask(ModTypeConstants.BASEGAME, job);
-				}
-			} catch (NumberFormatException e) {
-				ModManager.debugLogger.writeMessageConditionally("Was not able to read the coalesced mod value. Coal flag was not set/not entered, skipping setting coal",
-						ModManager.LOG_MOD_INIT);
-			}
-		}
-
-		ModManager.debugLogger.writeMessageConditionally("Number of Mod Jobs: " + jobs.size(), ModManager.LOG_MOD_INIT);
-		if (jobs.size() > 0) {
-			ModManager.debugLogger.writeMessageConditionally("Verified source files, mod should be OK to install", ModManager.LOG_MOD_INIT);
-			validMod = true;
-		} else if (jobs.size() == 0 && emptyModIsOK) {
-			ModManager.debugLogger.writeMessage("Mod is empty, but we said it was OK to load.");
-			validMod = true;
-		} else {
-			ModManager.debugLogger.writeError("Mod has no tasks. This mod does nothing. Marking as invalid");
-			setFailedReason("This mod has no installation tasks and does nothing. Add some tasks or delete this mod.");
-		}
-
-		//modmaker compiledagainst flag (1.5+)
-		if (modini.get("ModInfo", "compiledagainst") != null) {
-			try {
-				compiledAgainstModmakerVersion = Double.parseDouble(modini.get("ModInfo", "compiledagainst"));
-				ModManager.debugLogger.writeMessageConditionally("Server version compiled against: " + compiledAgainstModmakerVersion, ModManager.LOG_MOD_INIT);
-				if (compiledAgainstModmakerVersion < 1.5) {
-					try {
-						int ver = Integer.parseInt(modVersion);
-						ver++;
-						modVersion = Integer.toString(ver);
-						ModManager.debugLogger.writeMessageConditionally("ModMaker mod (<1.5), +1 to revision.", ModManager.LOG_MOD_INIT);
-					} catch (NumberFormatException e) {
-						ModManager.debugLogger.writeError("ModMaker version failed to resolve to an integer.");
-						modVersion = Integer.toString(1);
-					}
-				}
-			} catch (NumberFormatException e) {
-				ModManager.debugLogger.writeError("ModMaker code failed to resolve to an integer.");
-			}
-		} else {
-			if (modmakerCode > 0) {
-				//modmaker mod
-				compiledAgainstModmakerVersion = 1.4;
-				ModManager.debugLogger.writeMessageConditionally("Unknown server version, assuming 1.4 compilation target: " + compiledAgainstModmakerVersion,
-						ModManager.LOG_MOD_INIT);
-				try {
-					int ver = Integer.parseInt(modVersion);
-					ver++;
-					modVersion = Integer.toString(ver);
-					ModManager.debugLogger.writeMessageConditionally("ModMaker mod (<1.5), +1 to revision.", ModManager.LOG_MOD_INIT);
-				} catch (NumberFormatException e) {
-					ModManager.debugLogger.writeError("ModMaker version failed to resolve to an integer.");
-					modVersion = Integer.toString(1);
-				}
-			}
-		}
-
-		if (modCMMVer > ModManager.MODDESC_VERSION_SUPPORT) {
-			ModManager.debugLogger.writeError("Mod is for newer version of Mod Manager, may have issues with this version.");
-		}
-
-		//Read deltas
-		File dir = new File(modFolderPath + DELTAS_FOLDER);
-		File[] deltas = dir.listFiles(new FilenameFilter() {
-			public boolean accept(File dir, String filename) {
-				return filename.endsWith(".xml");
-			}
-		});
-		if (deltas != null) {
-			for (File delta : deltas) {
-				ModDelta md = new ModDelta(delta.getAbsolutePath());
-				if (md.isValidDelta()) {
-					modDeltas.add(md);
-				}
-			}
-			if (modDeltas.size() > 0) {
-				ModManager.debugLogger.writeMessageConditionally("This mod has " + modDeltas.size() + " deltas.", ModManager.LOG_MOD_INIT);
-			}
-		}
-
-		//Apply Alternate CustomDLC
-		if (alternateCustomDLC.size() > 0 && !ignoreLoadErrors) {
-			if (ModManagerWindow.validateBIOGameDir()) {
-				if (shouldApplyAutos) {
-					addCustomDLCAlternates(ModManagerWindow.GetBioGameDir());
-				}
-			} else {
-				ModManager.debugLogger.writeError(
-						"Alternate Custom DLC cannot be applied to this mod as the biogame directory is not currently valid. User needs to set it and reload mod manager");
-				setFailedReason(
-						"This mod requires a valid biogame directory due to using alternate custom dlc. Without a valid biogame directory, this mod will not know what parts are required on install. Fix the biogame directory and reload mod manager.");
-				return;
-			}
-		}
-
-		//Verify alternates and apply automatic ones
-		if (alternateFiles != null && alternateFiles.size() > 0 && !ignoreLoadErrors) {
-			ModManager.debugLogger.writeMessageConditionally("Verifying automatic alternate files are valid for this mod", ModManager.LOG_MOD_INIT);
-			HashMap<String, ArrayList<String>> autoOriginalFiles = new HashMap<String, ArrayList<String>>(); //header to altfiles map
-			for (AlternateFile af : alternateFiles) {
-				ModManager.debugLogger.writeMessageConditionally("Verifying " + af.getAltFile() + " on " + af.getCondition() + " of " + af.getConditionalDLC(),
-						ModManager.LOG_MOD_INIT);
-				if (af.isValidLocally(modPath)) {
-					//Verify pass
-					String condition = af.getCondition();
-					String modfile = af.getModFile();
-					String task = af.getConditionalDLC();
-
-					if (!condition.equals(AlternateFile.CONDITION_MANUAL)) {
-						ArrayList<String> headerAlternates = autoOriginalFiles.get(task);
-						if (headerAlternates != null) {
-							if (headerAlternates.contains(modfile.toLowerCase())) {
-								//auto alts cannot apply to the same thing
-								ModManager.debugLogger.writeError("Automatic alternate files contains duplicate for same file: " + modfile);
-								setFailedReason("This mod specifies automatic conditional changes for the following file in more than 1 instance: " + modfile
-										+ "\n\nEach file in Mod Manager mods can only have 1 automatically applied conditional operation attached to it.");
-								return;
-							} else {
-								headerAlternates.add(modfile.toLowerCase());
-							}
-						} else {
-							ArrayList<String> alts = new ArrayList<>();
-							alts.add(modfile.toLowerCase());
-							autoOriginalFiles.put(task, alts);
-						}
-					}
-					ModManager.debugLogger.writeMessageConditionally("Offical Task Alternate file specified: " + af.toString(), ModManager.LOG_MOD_INIT);
-				} else {
-					ModManager.debugLogger.writeError("Invalid alternate file specified: " + af + ". Some pieces of required information may be missing.");
-					setFailedReason("This mod contains an invalid alternate file specification:\n" + af);
-					return;
-				}
-			}
-		}
-
-		//Resolve Official Alternates
-		if (modCMMVer >= 4.5 && !ignoreLoadErrors) { //modpath will be null if we are inspecting a compressed mod. So just ignore this step.
-			for (ModJob job : jobs) {
-				if (job.getJobType() == ModJob.CUSTOMDLC) {
-					continue;
-				}
-				for (AlternateFile af : job.getAlternateFiles()) {
-					String replacementFilePath = getModTaskPath(af.getModFile(), job.getJobName());
-					String relativePath = ResourceUtils.getRelativePath(replacementFilePath, modPath, File.separator);
-					relativePath = ResourceUtils.normalizeFilePath(relativePath, false);
-					//af.setAltFile(relativePath);
-				}
-			}
-		}
-
-		generateModDisplayDescription();
-		ModManager.debugLogger.writeMessage("Finished loading moddesc.ini for " + getModName());
-		ModManager.debugLogger.writeMessageConditionally("-------MOD----------------END OF " + modName + "--------------------------", ModManager.LOG_MOD_INIT);
-	}
-
-	public ArrayList<ModDelta> getModDeltas() {
-		return modDeltas;
-	}
-
-	/**
-	 * Gets the filepath's internal filename
-	 * 
-	 * @param sfarFilePath
-	 *            path in sfar (or unpacked DLC)
-	 * @return filename of passed in string
-	 */
-	private String getSfarFilename(String sfarFilePath) {
-		StringTokenizer strok = new StringTokenizer(sfarFilePath, "/|\\");
-		String str = null;
-		while (strok.hasMoreTokens()) {
-			str = strok.nextToken();
-		}
-		// ModManager.debugLogger.writeMessage("SFAR Shortened filename: "+str);
-		return str;
-	}
-
-	/**
-	 * Adds a task to this mod for when the mod is deployed.
-	 * 
-	 * @param name
-	 * @param newJob
-	 */
-	public void addTask(String name, ModJob newJob) {
-		/*
-		 * if (name.equals(ModType.COAL)) { modCoal = true;
-		 * updateModifyString(ModType.COAL); return; }
-		 */
-		if (!name.equals(ModTypeConstants.CUSTOMDLC)) {
-			updateModifyString(name);
-		}
-		jobs.add(newJob);
-
-	}
-
-	/**
-	 * Updates the string showing what this mod edits in terms of files
-	 * 
-	 * @param taskName
-	 *            name of task to modify (EARTH, Coalesced, etc)
-	 */
-	private void updateModifyString(String taskName) {
-		if (modifyString.equals("")) {
-			modifyString = "\nModifies: " + taskName;
-		} else {
-			modifyString += ", " + taskName;
-		}
-	}
-
-	/**
-	 * Returns mod's folder, with a / on the end
-	 * 
-	 * @return
-	 */
-	public String getModPath() {
-		return ModManager.appendSlash(modPath);
-	}
-
-	public String getModName() {
-		return modName;
-	}
-
-	/**
-	 * Sets this mod description. It should be run through breakfixer() first.
-	 * 
-	 * @param desc
-	 */
-	public void setModDescription(String desc) {
-		this.modDescription = desc;
-	}
-
-	public void generateModDisplayDescription() {
-		modDisplayDescription = "This mod has no description in it's moddesc.ini file or there was an error reading the description of this mod.";
-		if (modDescFile == null) {
-			ModManager.debugLogger.writeMessage("Mod Desc file is null, unable to read description");
-			return;
-		}
-		modDisplayDescription = ResourceUtils.convertBrToNewline(modDescription);
-
-		modDisplayDescription += "\n=============================\n";
-
-		//Available deltas
-		if (modDeltas.size() > 0) {
-			modDisplayDescription += "Included Variants:\n";
-			for (ModDelta delta : modDeltas) {
-				modDisplayDescription += " - " + delta.getDeltaName();
-				modDisplayDescription += "\n";
-			}
-		}
-
-		if (hasAutomaticConfiguration()) {
-			modDisplayDescription += "This mod has been automatically configured for your game's current configuration.\n";
-		}
-
-		if (hasOptionalManualCustomDLC()) {
-			modDisplayDescription += "This mod contains alternate installation options. Access them through the mod utils menu.\n";
-		}
-
-		// Add modversion
-		if (modVersion != null) {
-			modDisplayDescription += "\nMod Version: " + modVersion;
-		}
-
-		// Add developer
-		if (modAuthor != null) {
-			modDisplayDescription += "\nMod Developer: " + modAuthor;
-		}
-
-		// Add developer
-		if (modIsUnofficial) {
-			modDisplayDescription += "\nThis mod was imported by Mod Manager using the ME3Tweaks Third Party Mod Identification Service.";
-		}
-
-		// Add mod manager build version
-		modDisplayDescription += "\nTargets Mod Manager " + modCMMVer;
-		if (modCMMVer > ModManager.MODDESC_VERSION_SUPPORT) {
-			modDisplayDescription += ", which is not fully supported by this version of Mod Manager. Update Mod Manager for full support.";
-		}
-		if (classicCode > 0) {
-			modDisplayDescription += "\nUpdate code: " + classicCode;
-		}
-
-		if (getSideloadOnlyTargets().size() > 0) {
-			modDisplayDescription += "\nFuture updates may require sideloading an update package";
-		}
-
-		// Add MP Changer
-		if (modmp != null) {
-			modDisplayDescription += "\nModifies Multiplayer: " + modmp;
-		}
-
-		// Add Modmaker
-		if (modmakerCode > 0) {
-			modDisplayDescription += "\nModMaker code: " + modmakerCode;
-		}
-
-		// Add modifier
-		modDisplayDescription += getModifyString();
-
-		//add required
-		if (requiredDLC.size() > 0) {
-			modDisplayDescription += "\nRequires DLC/Mods: ";
-
-			for (String str : requiredDLC) {
-				String dlcName = ME3TweaksUtils.getThirdPartyModName(str, true);
-				if (!dlcName.equals(str)) {
-					dlcName += " (" + str + ")";
-				}
-				modDisplayDescription += "\n - " + dlcName;
-			}
-		}
-	}
-
-	private boolean hasAutomaticConfiguration() {
-		if (alternateCustomDLC.size() > 0) {
-			for (AlternateCustomDLC dlc : alternateCustomDLC) {
-				if (!dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL)) {
-					return true;
-				}
-			}
-		}
-
-		if (alternateFiles.size() > 0) {
-			for (AlternateFile altfile : alternateFiles) {
-				if (!altfile.getCondition().equals(AlternateFile.CONDITION_MANUAL)) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	private boolean hasOptionalManualCustomDLC() {
-		if (alternateCustomDLC.size() > 0) {
-			for (AlternateCustomDLC dlc : alternateCustomDLC) {
-				if (dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL)) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	public String getModDisplayDescription() {
-		return modDisplayDescription;
-	}
-
-	public String getModDescription() {
-		return modDescription;
-	}
-
-	@Override
-	public String toString() {
-		return getModName();
-	}
-
-	public ModJob[] getJobs() {
-		return jobs.toArray(new ModJob[jobs.size()]);
-	}
-
-	public String getModifyString() {
-		for (ModJob job : jobs) {
-			if (job.getJobName().equals(ModTypeConstants.CUSTOMDLC)) {
-				String appendStr = " CUSTOMDLC (";
-				if (modifyString.equals("")) {
-					appendStr = "\nModifies:" + appendStr;
-				} else {
-					appendStr = "," + appendStr;
-				}
-				boolean first = true;
-				TreeSet<String> ss = new TreeSet<String>(job.getDestFolders());
-				for (String destFolder : ss) {
-					if (destFolder.endsWith("CookedPCConsole")) {
-						continue; //do not show this
-					}
-					if (first) {
-						first = false;
-					} else {
-						appendStr += ", ";
-					}
-					appendStr += destFolder;
-				}
-				appendStr += ")";
-				modifyString += appendStr;
-				break;
-			}
-		}
-		return modifyString;
-	}
-
-	public boolean canMergeWith(Mod other) {
-		ModManager.debugLogger.writeMessage("Checking if mods can cleanly merge. Will report only first failure.");
-		for (ModJob job : jobs) {
-			ModJob otherCorrespondingJob = null;
-			for (ModJob otherjob : other.jobs) {
-				if (otherjob.equals(job)) {
-					otherCorrespondingJob = otherjob;
-					break;
-				}
-			}
-			if (otherCorrespondingJob == null) {
-				continue;
-			}
-			// scanned for matching job. Found it. Iterate over files...
-
-			//Compare my replace files to others replace/remove 
-			for (String file : job.getFilesToReplaceTargets()) {
-				if (FilenameUtils.getName(file).equalsIgnoreCase("PCConsoleTOC.bin")) {
-					continue;
-				}
-				ModManager.debugLogger.writeMessage("==Checking file for conflicts " + file + "==");
-
-				for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
-					ModManager.debugLogger.writeMessage("Comparing replace files: " + file + " vs " + otherfile);
-					if (file.equalsIgnoreCase(otherfile)) {
-						ModManager.debugLogger.writeMessage("Merge conflicts with file to update " + file);
-						return false;
-					}
-				}
-				for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
-					if (file.equalsIgnoreCase(otherfile)) {
-						ModManager.debugLogger.writeMessage("Merge conflicts with file to update " + file);
-						return false;
-					}
-				}
-			}
-
-			//Compare my replace files to others replace/remove 
-			for (String file : job.getFilesToRemoveTargets()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
-					if (file.equalsIgnoreCase(otherfile)) {
-						ModManager.debugLogger.writeMessage("Merge would add a task to remove a file requiring replace: " + file);
-						return false;
-					}
-				}
-			}
-
-			//compare files to add
-			for (String file : job.getFilesToAdd()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToAdd()) {
-					if (file.equalsIgnoreCase(otherfile)) {
-						ModManager.debugLogger.writeMessage("Merge conflicts with file to add " + file);
-						return false;
-					}
-				}
-			}
-
-			//Compare my add files to others remove
-			for (String file : job.getFilesToAddTargets()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
-					if (file.equalsIgnoreCase(otherfile)) {
-						ModManager.debugLogger.writeMessage("Merge conflicts with file to add/remove " + file);
-						return false;
-					}
-				}
-			}
-			for (String file : job.getFilesToRemoveTargets()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToAddTargets()) {
-					if (file.equalsIgnoreCase(otherfile)) {
-						ModManager.debugLogger.writeMessage("Merge conflicts with file to add/remove " + file);
-						return false;
-					}
-				}
-			}
-
-			//don't care about files to remove. I think...
-
-		}
-		ModManager.debugLogger.writeMessage("No conflicted detected.");
-		return true;
-	}
-
-	/**
-	 * Gets the list of files that conflict with the specified mod, in terms of
-	 * files to replace.
-	 * 
-	 * @param other
-	 *            Other mod to compare against
-	 * @return hashmap of job names mapped to a list of strings of conflicting
-	 *         file names
-	 */
-	public HashMap<String, ArrayList<String>> getReplaceConflictsWithMod(Mod other) {
-		HashMap<String, ArrayList<String>> conflicts = new HashMap<String, ArrayList<String>>();
-		for (ModJob job : jobs) {
-			ModJob otherCorrespondingJob = null;
-			for (ModJob otherjob : other.jobs) {
-				if (otherjob.equals(job)) {
-					otherCorrespondingJob = otherjob;
-					break;
-				}
-			}
-			if (otherCorrespondingJob == null) {
-				continue;
-			}
-			// scanned for matching job. Found it. Iterate over files...
-			for (String file : job.getFilesToReplaceTargets()) {
-				if (FilenameUtils.getName(file).equalsIgnoreCase("PCConsoleTOC.bin")) {
-					continue;
-				}
-				for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
-					if (file.equals(otherfile)) {
-						if (conflicts.containsKey(job.getJobName())) {
-							conflicts.get(job.getJobName()).add(file);
-							ModManager.debugLogger.writeMessage("ADDING TO CONFLICT LIST: " + file);
-						} else {
-							ArrayList<String> conflictFiles = new ArrayList<String>();
-							conflictFiles.add(file);
-							conflicts.put(job.getJobName(), conflictFiles);
-						}
-					}
-				}
-			}
-		}
-		if (conflicts.size() <= 0) {
-			return null;
-		}
-		return conflicts;
-	}
-
-	/**
-	 * Creates a moddesc.ini string that should be written to a file that
-	 * describes this mod object.
-	 * 
-	 * @param keepUpdaterCode Keeps the classic update code
-	 * @param cmmVersion Version of moddesc to write to file
-	 *
-	 * @return moddesc.ini file as a string
-	 */
-	public String createModDescIni(boolean keepUpdaterCode, double cmmVersion) {
-		// Write mod descriptor file
-		try {
-			Wini ini = new Wini();
-
-			// put modmanager, modinfo
-			ini.put("ModManager", "cmmver", cmmVersion);
-			ini.put("ModInfo", "modname", modName);
-			ini.put("ModInfo", "moddev", modAuthor);
-			if (modDescription != null) {
-				ini.put("ModInfo", "moddesc", ResourceUtils.convertNewlineToBr(modDescription));
-			}
-			if (modVersion != null) {
-				ini.put("ModInfo", "modver", modVersion);
-			}
-			if (modmp != null) {
-				ini.put("ModInfo", "modmp", modmp);
-			}
-			if (modSite != null) {
-				ini.put("ModInfo", "modsite", modSite);
-			}
-			if (modmakerCode > 0) {
-				ini.put("ModInfo", "modid", Integer.toString(modmakerCode));
-			}
-			if (compiledAgainstModmakerVersion > 0) {
-				ini.put("ModInfo", "compiledagainst", Double.toString(compiledAgainstModmakerVersion));
-			}
-			if (keepUpdaterCode && isME3TweaksUpdatable()) {
-				if (getClassicUpdateCode() > 0) {
-					ini.put("ModInfo", "updatecode", getClassicUpdateCode());
-				} else {
-					ini.put("ModInfo", "me3tweaksid", getModMakerCode());
-				}
-			}
-
-			for (ModJob job : jobs) {
-				boolean isFirst = true;
-				if (job.getRequirementText() != null && !job.getRequirementText().equals("")) {
-					ini.put(job.getJobName(), "jobdescription", job.getRequirementText());
-				}
-
-				if (job.getJobType() == ModJob.CUSTOMDLC) {
-					StringBuilder sfsb = new StringBuilder();
-					StringBuilder dfsb = new StringBuilder();
-
-					//source dirs
-					for (String file : job.getSourceFolders()) {
-						if (isFirst) {
-							isFirst = false;
-						} else {
-							sfsb.append(";");
-						}
-						sfsb.append(FilenameUtils.getName(file));
-					}
-					isFirst = true;
-					//dest dirs
-					for (String file : job.getDestFolders()) {
-						if (isFirst) {
-							isFirst = false;
-						} else {
-							dfsb.append(";");
-						}
-						dfsb.append(FilenameUtils.getName(file));
-					}
-
-					ini.put(job.getJobName(), "sourcedirs", sfsb.toString());
-					ini.put(job.getJobName(), "destdirs", dfsb.toString());
-					continue; //skip dlc,basegame on this pass
-				}
-
-				ini.put(job.getJobName(), "moddir", getStandardFolderName(job.getJobName()));
-				StringBuilder nfsb = new StringBuilder();
-				//new files list
-				isFirst = true;
-				for (String file : job.getFilesToReplace()) {
-					if (isFirst) {
-						isFirst = false;
-					} else {
-						nfsb.append(";");
-					}
-					nfsb.append(FilenameUtils.getName(file));
-				}
-
-				//replace files list
-				isFirst = true;
-				StringBuilder rfsb = new StringBuilder();
-				for (String file : job.getFilesToReplaceTargets()) {
-					if (isFirst) {
-						isFirst = false;
-					} else {
-						rfsb.append(";");
-					}
-					rfsb.append(file);
-				}
-
-				//add files list
-				isFirst = true;
-				StringBuilder afsb = new StringBuilder();
-				for (String file : job.getFilesToAdd()) {
-					if (isFirst) {
-						isFirst = false;
-					} else {
-						afsb.append(";");
-					}
-					afsb.append(FilenameUtils.getName(file));
-				}
-
-				//addfilestargets files list
-				isFirst = true;
-				StringBuilder aftsb = new StringBuilder();
-				for (String file : job.getFilesToAddTargets()) {
-					if (isFirst) {
-						isFirst = false;
-					} else {
-						aftsb.append(";");
-					}
-					aftsb.append(file);
-				}
-
-				//removefiles list
-				isFirst = true;
-				StringBuilder rftsb = new StringBuilder();
-				for (String file : job.getFilesToRemoveTargets()) {
-					if (isFirst) {
-						isFirst = false;
-					} else {
-						rftsb.append(";");
-					}
-					rftsb.append(file);
-				}
-
-				//DLC, basegame
-				ini.put(job.getJobName(), "newfiles", nfsb.toString());
-				ini.put(job.getJobName(), "replacefiles", rfsb.toString());
-
-				if (job.getFilesToAdd().size() > 0) {
-					ini.put(job.getJobName(), "addfiles", afsb.toString());
-				}
-
-				if (job.getFilesToAddTargets().size() > 0) {
-					ini.put(job.getJobName(), "addfilestargets", aftsb.toString());
-				}
-
-				if (job.getFilesToRemoveTargets().size() > 0) {
-					ini.put(job.getJobName(), "removefilestargets", rftsb.toString());
-				}
-			}
-			ByteArrayOutputStream os = new ByteArrayOutputStream();
-			ini.store(os);
-			return new String(os.toByteArray(), "ASCII");
-		} catch (Exception e) {
-			ModManager.debugLogger.writeError("Error saving message!");
-			ModManager.debugLogger.writeException(e);
-		}
-		return "Failed to write new moddesc.ini file";
-	}
-
-	/**
-	 * Gets the standard folder name a mod uses for a module. Essentially is a
-	 * Header => Internal converter
-	 * 
-	 * @param header
-	 * @return
-	 */
-	public static String getStandardFolderName(String header) {
-		switch (header) {
-		case "BASEGAME":
-			return "BASEGAME";
-		case "RESURGENCE":
-			return "MP1";
-		case "REBELLION":
-			return "MP2";
-		case "EARTH":
-			return "MP3";
-		case "RETALIATION":
-			return "MP4";
-		case "RECKONING":
-			return "MP5";
-		case "PATCH1":
-			return "PATCH1";
-		case "PATCH2":
-			return "PATCH2";
-		case "TESTPATCH":
-			return "TESTPATCH";
-		case "FROM_ASHES":
-			return "FROM_ASHES";
-		case "EXTENDED_CUT":
-			return "EXTENDED_CUT";
-		case "LEVIATHAN":
-			return "LEVIATHAN";
-		case "OMEGA":
-			return "OMEGA";
-		case "CITADEL":
-			return "CITADEL";
-		case "CITADEL_BASE":
-			return "CITADEL_BASE";
-		case "APPEARANCE":
-			return "APPEARANCE";
-		case "FIREFIGHT":
-			return "FIREFIGHT";
-		case "GROUNDSIDE":
-			return "GROUNDSIDE";
-		case "GENESIS2":
-			return "GENESIS2";
-		case "CUSTOMDLC":
-			return "CUSTOMDLC";
-		case "BALANCE_CHANGES":
-			return "BALANCE_CHANGES";
-		default:
-			return "UNKNOWN_DEFAULT_FOLDER";
-		}
-	}
-
-	/**
-	 * Creates a new mod package in a folder with the same name as this mod.
-	 * Copies files to the new directory based on the name of this mod. Creates
-	 * a moddesc.ini file based on jobs in this mod.
-	 * 
-	 * @param otherMergingMod
-	 *            Other mod this one is merging with. This can be null. This is
-	 *            used to find the Custom DLC directory to copy to the new mod
-	 *            if one isn't present for this mod.
-	 */
-	public Mod createNewMod(Mod otherMergingMod) {
-		printModContents();
-		File modFolder = new File(ModManager.getModsDir() + modName);
-		modFolder.mkdirs();
-		for (ModJob job : jobs) {
-			if (job.getJobType() == ModJob.CUSTOMDLC) {
-				for (String sourceFolder : job.getSourceFolders()) {
-					try {
-						File srcFolder = new File(ModManager.appendSlash(modDescFile.getParentFile().getAbsolutePath()) + sourceFolder);
-						if (!srcFolder.exists() && otherMergingMod != null) {
-							//may be in other mod as we haven't copied it yet and we don't use file pointers here (folder names)
-							srcFolder = new File(ModManager.appendSlash(otherMergingMod.modDescFile.getParentFile().getAbsolutePath()) + sourceFolder);
-						}
-						File destFolder = new File(modFolder + File.separator + sourceFolder); //source folder is a string
-						ModManager.debugLogger.writeMessage("Copying custom DLC folder: " + srcFolder.getAbsolutePath() + " to " + destFolder.getAbsolutePath());
-						FileUtils.copyDirectory(srcFolder, destFolder);
-					} catch (IOException e) {
-						ModManager.debugLogger.writeMessage("IOException while merging mods (custom DLC).");
-						ModManager.debugLogger.writeException(e);
-					}
-				}
-				continue;
-			}
-
-			File moduleDir = new File(modFolder + File.separator + getStandardFolderName(job.getJobName()));
-			moduleDir.mkdirs();
-			// scanned for matching job. Found it. Iterate over files...
-			//Copy files to replace
-			for (String mergefile : job.getFilesToReplace()) {
-				File file = new File(mergefile);
-				String baseName = FilenameUtils.getName(mergefile);
-				try {
-					File destinationFile = new File(moduleDir + File.separator + baseName);
-					ModManager.debugLogger.writeMessage("Copying to new mod folder: " + file.getAbsolutePath() + " to " + destinationFile.getAbsolutePath());
-					FileUtils.copyFile(file, destinationFile);
-				} catch (IOException e) {
-					ModManager.debugLogger.writeMessage("IOException while merging mods.");
-					ModManager.debugLogger.writeException(e);
-				}
-				ModManager.debugLogger.writeMessage(job.getJobName() + ": " + file);
-			}
-			//copy files to add
-			for (String mergefile : job.getFilesToAdd()) {
-				File file = new File(mergefile);
-				String baseName = FilenameUtils.getName(mergefile);
-				try {
-					File destinationFile = new File(moduleDir + File.separator + baseName);
-					ModManager.debugLogger.writeMessage("Copying to new mod folder: " + file.getAbsolutePath() + " to " + destinationFile.getAbsolutePath());
-					FileUtils.copyFile(file, destinationFile);
-				} catch (IOException e) {
-					ModManager.debugLogger.writeMessage("IOException while merging mods.");
-					ModManager.debugLogger.writeException(e);
-				}
-				ModManager.debugLogger.writeMessage(job.getJobName() + ": " + file);
-			}
-		}
-
-		//COPY DELTAS
-		if (modDeltas.size() > 0) {
-			File dir = new File(modFolder + File.separator + DELTAS_FOLDER);
-			dir.mkdirs();
-			for (ModDelta delta : modDeltas) {
-				try {
-					FileUtils.copyFile(new File(delta.getDeltaFilepath()), new File(dir + File.separator + FilenameUtils.getName(delta.getDeltaFilepath())));
-				} catch (IOException e) {
-					ModManager.debugLogger.writeErrorWithException("Unable to copy delta:", e);
-				}
-			}
-		}
-
-		try {
-			ModManager.debugLogger.writeMessage("Creating moddesc.ini...");
-			FileUtils.writeStringToFile(new File(modFolder + File.separator + "moddesc.ini"), createModDescIni(false, modCMMVer));
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			ModManager.debugLogger.writeMessage("IOException while merging mods.");
-			ModManager.debugLogger.writeException(e);
-			e.printStackTrace();
-		}
-		Mod newMod = new Mod(modFolder + File.separator + "moddesc.ini");
-		for (ModDelta delta : newMod.getModDeltas()) {
-			new DeltaWindow(newMod, delta, true, true);
-		}
-		if (newMod.isValidMod()) {
-			new AutoTocWindow(newMod, AutoTocWindow.LOCALMOD_MODE, ModManagerWindow.GetBioGameDir());
-		} else {
-			return null;
-		}
-		return newMod;
-	}
-
-	private void printModContents() {
-		ModManager.debugLogger.writeMessage("========" + modName + "========");
-		for (ModJob job : jobs) {
-			if (job.getJobType() == ModJob.CUSTOMDLC) {
-				for (String sourceFolder : job.getSourceFolders()) {
-					ModManager.debugLogger.writeMessage(job.getJobName() + ": " + sourceFolder);
-				}
-				continue;
-			}
-			for (String sourceFile : job.getFilesToAdd()) {
-				ModManager.debugLogger.writeMessage(job.getJobName() + ": " + sourceFile);
-			}
-		}
-	}
-
-	public void setModName(String modName) {
-		this.modName = modName;
-	}
-
-	@Override
-	public int compareTo(Mod other) {
-		if (!validMod) {
-			return -1;
-		}
-		return getModName().toLowerCase().compareTo(other.getModName().toLowerCase());
-	}
-
-	/**
-	 * Checks if this mod has a job for custom DLC
-	 * 
-	 * @return true if contains custom DLC job, false otherwise
-	 */
-	public boolean containsCustomDLCJob() {
-		if (modCMMVer < 3.1) {
-			return false;
-		}
-		for (ModJob job : jobs) {
-			if (job.getJobType() == ModJob.CUSTOMDLC) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Attempts to parse the mod version from the CMM string If it fails it
-	 * returns a 0
-	 * 
-	 * @return
-	 */
-	public double getVersion() {
-		if (modVersion == null) {
-			return 0;
-		}
-		try {
-			return Double.parseDouble(modVersion);
-		} catch (NumberFormatException e) {
-			return 0;
-		}
-	}
-
-	public int getClassicUpdateCode() {
-		if (classicCode <= 0) {
-			return 0;
-		}
-
-		return classicCode;
-	}
-
-	public int getModMakerCode() {
-		return modmakerCode;
-	}
-
-	public String getDescFile() {
-		return getModPath() + "moddesc.ini";
-	}
-
-	public double getCMMVer() {
-		return modCMMVer;
-	}
-
-	/**
-	 * Returns if this mod is able to check for updates on ME3Tweaks
-	 * 
-	 * @return true if classic and has update code, or has modmaker code and
-	 *         version > 0
-	 */
-	public boolean isME3TweaksUpdatable() {
-		if ((getClassicUpdateCode() > 0 || getModMakerCode() > 0) && getVersion() > 0) {
-			return true;
-		}
-		return false;
-	}
-
-	public String getAuthor() {
-		return modAuthor;
-	}
-
-	public void setModUpdateCode(int i) {
-		classicCode = i;
-	}
-
-	public void setVersion(double i) {
-		modVersion = Double.toString(i);
-	}
-
-	/**
-	 * Returns true if this mod has a job that modifies the basegame coalesced
-	 * 
-	 * @return true if basegame coal is swapped, false otherwise
-	 */
-	public boolean modifiesBasegameCoalesced() {
-		for (ModJob job : jobs) {
-			if (job.getJobName() == ModTypeConstants.COAL) {
-				return true;
-			}
-			for (String file : job.filesToReplaceTargets) {
-				file = file.replaceAll("\\\\", "/"); //make sure all are the same (since the yall work)
-				if (file.toLowerCase().equals("/BIOGame/CookedPCConsole/Coalesced.bin".toLowerCase())) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Gets this mods basegame coalesced file it will install.
-	 * 
-	 * @return new basegame coalesced file, or null if this mod does not specify
-	 *         one
-	 */
-	public String getBasegameCoalesced() {
-		return getModTaskPath("\\BIOGame\\CookedPCConsole\\Coalesced.bin", ModTypeConstants.BASEGAME);
-	}
-
-	/**
-	 * Searches through all jobs for the specified path. Uses a module ID
-	 * (header) to find a job.
-	 * 
-	 * @return path to new file if found, null if it does't exist.
-	 */
-	public String getModTaskPath(String modulePath, String header) {
-		if (header.equals(ModTypeConstants.COAL)) {
-			header = ModTypeConstants.BASEGAME;
-			modulePath = "\\BIOGame\\CookedPCConsole\\Coalesced.bin";
-		}
-		modulePath = modulePath.replaceAll("\\\\", "/");
-		if (!modulePath.startsWith("/")) {
-			modulePath = "/" + modulePath;
-		}
-		for (ModJob job : jobs) {
-			if (!job.getJobName().equals(header)) {
-				continue;
-			}
-			for (int i = 0; i < job.filesToReplaceTargets.size(); i++) {
-				String file = job.filesToReplaceTargets.get(i);
-				file = file.replaceAll("\\\\", "/"); //make sure all are the same (since the yall work)
-				if (!file.startsWith("/")) {
-					file = "/" + file;
-				}
-				if (file.toLowerCase().equals(modulePath.toLowerCase())) {
-					return job.filesToReplace.get(i);
-				}
-			}
-		}
-		return null;
-	}
-
-	public ArrayList<Patch> getRequiredPatches() {
-		return requiredPatches;
-	}
-
-	public void setRequiredPatches(ArrayList<Patch> requiredPatches) {
-		this.requiredPatches = requiredPatches;
-	}
-
-	public boolean isValidMod() {
-		return validMod;
-	}
-
-	private void setValidMod(boolean validMod) {
-		this.validMod = validMod;
-	}
-
-	/**
-	 * Checks for conflicts with the other mod pertaining to add/replace.
-	 * 
-	 * @param other
-	 * @return Hashmap of job names mapping to a list of targets that conflict
-	 */
-	public HashMap<String, ArrayList<String>> getAddRemoveConflictsWithMod(Mod other) {
-		HashMap<String, ArrayList<String>> conflicts = new HashMap<String, ArrayList<String>>();
-		for (ModJob job : jobs) {
-			ModJob otherCorrespondingJob = null;
-			for (ModJob otherjob : other.jobs) {
-				if (otherjob.equals(job)) {
-					otherCorrespondingJob = otherjob;
-					break;
-				}
-			}
-			if (otherCorrespondingJob == null) {
-				continue;
-			}
-
-			// scanned for matching job. Found it. Iterate over files...
-			for (String file : job.getFilesToAddTargets()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
-					if (file.equals(otherfile)) {
-						if (conflicts.containsKey(job.getJobName())) {
-							conflicts.get(job.getJobName()).add(file);
-							ModManager.debugLogger.writeMessage("ADDING TO ADDREMOVE CONFLICT LIST: " + file);
-						} else {
-							ArrayList<String> conflictFiles = new ArrayList<String>();
-							conflictFiles.add(file);
-							conflicts.put(job.getJobName(), conflictFiles);
-							ModManager.debugLogger.writeMessage("ADDING TO ADDREMOVE CONFLICT LIST: " + file);
-						}
-					}
-				}
-			}
-
-			//versa
-			for (String file : job.getFilesToRemoveTargets()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToAddTargets()) {
-					if (file.equals(otherfile)) {
-						if (conflicts.containsKey(job.getJobName())) {
-							conflicts.get(job.getJobName()).add(file);
-							ModManager.debugLogger.writeMessage("ADDING TO ADDREMOVE CONFLICT LIST: " + file);
-						} else {
-							ArrayList<String> conflictFiles = new ArrayList<String>();
-							conflictFiles.add(file);
-							conflicts.put(job.getJobName(), conflictFiles);
-						}
-					}
-				}
-			}
-		}
-		if (conflicts.size() <= 0) {
-			return null;
-		}
-		return conflicts;
-	}
-
-	/**
-	 * Checks for conflicts with the other mod pertaining to remove/replace.
-	 * 
-	 * @param other
-	 * @return Hashmap of job names mapping to a list of targets that conflict
-	 */
-	public HashMap<String, ArrayList<String>> getReplaceRemoveConflictsWithMod(Mod other) {
-		HashMap<String, ArrayList<String>> conflicts = new HashMap<String, ArrayList<String>>();
-		for (ModJob job : jobs) {
-			ModJob otherCorrespondingJob = null;
-			for (ModJob otherjob : other.jobs) {
-				if (otherjob.equals(job)) {
-					otherCorrespondingJob = otherjob;
-					break;
-				}
-			}
-			if (otherCorrespondingJob == null) {
-				continue;
-			}
-			// scanned for matching job. Found it. Iterate over files...
-			for (String file : job.getFilesToReplaceTargets()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
-					if (file.equals(otherfile)) {
-						if (conflicts.containsKey(job.getJobName())) {
-							conflicts.get(job.getJobName()).add(file);
-							ModManager.debugLogger.writeMessage("ADDING TO REPLACEREMOVE CONFLICT LIST: " + file);
-						} else {
-							ArrayList<String> conflictFiles = new ArrayList<String>();
-							conflictFiles.add(file);
-							conflicts.put(job.getJobName(), conflictFiles);
-						}
-					}
-				}
-			}
-
-			//versa
-			for (String file : job.getFilesToRemoveTargets()) {
-				for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
-					if (file.equals(otherfile)) {
-						if (conflicts.containsKey(job.getJobName())) {
-							conflicts.get(job.getJobName()).add(file);
-							ModManager.debugLogger.writeMessage("ADDING TO REPLACEREMOVE CONFLICT LIST: " + file);
-						} else {
-							ArrayList<String> conflictFiles = new ArrayList<String>();
-							conflictFiles.add(file);
-							conflicts.put(job.getJobName(), conflictFiles);
-						}
-					}
-				}
-			}
-		}
-		if (conflicts.size() <= 0) {
-			return null;
-		}
-		return conflicts;
-	}
-
-	/**
-	 * Finds a source file using the specified target file
-	 * 
-	 * @param targetFile
-	 *            target to find match
-	 * @param useReplace
-	 *            search replacements. Otherwise search adds
-	 * @return null if not found (should not occur!) or the string source path
-	 */
-	public String findTargetSourceFileFromJob(boolean useReplace, ModJob job, String targetFile) {
-		ArrayList<String> sourceList = useReplace ? job.getFilesToReplace() : job.getFilesToAdd();
-		ArrayList<String> targetList = useReplace ? job.getFilesToReplaceTargets() : job.getFilesToAddTargets();
-
-		for (int i = 0; i < sourceList.size(); i++) {
-			if (targetList.get(i).equals(targetFile)) {
-				return sourceList.get(i);
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * Gets a modjob from this mod by the name (ModType)
-	 * 
-	 * @param moduleName
-	 *            module job to return
-	 * @return null if not found, job otherwise
-	 */
-	public ModJob getJobByModuleName(String moduleName) {
-		for (ModJob job : jobs) {
-			if (job.getJobName().equals(moduleName)) {
-				return job;
-			}
-		}
-		return null;
-	}
-
-	public void setAuthor(String modAuthor) {
-		this.modAuthor = modAuthor;
-	}
-
-	public void setSite(String modSite) {
-		this.modSite = modSite;
-	}
-
-	public String getModSite() {
-		return modSite;
-	}
-
-	public String getFailedReason() {
-		return failedReason;
-	}
-
-	public void setFailedReason(String failedReason) {
-		setValidMod(false);
-		this.failedReason = failedReason;
-	}
-
-	public void setModPath(String modPath) {
-		this.modPath = modPath;
-	}
-
-	public ArrayList<String> getSideloadOnlyTargets() {
-		return sideloadOnlyTargets;
-	}
-
-	public void setSideloadOnlyTargets(ArrayList<String> sideloadOnlyTargets) {
-		this.sideloadOnlyTargets = sideloadOnlyTargets;
-	}
-
-	public String getSideloadURL() {
-		return sideloadURL;
-	}
-
-	public void setSideloadURL(String sideloadURL) {
-		this.sideloadURL = sideloadURL;
-	}
-
-	/**
-	 * Processes alternate DLC specifications and will add them into this mod as
-	 * necessary
-	 * 
-	 * @return true if all were added OK. False if any failed.
-	 */
-	public boolean addCustomDLCAlternates(String biogamedir) {
-		if (alternateFiles.size() > 0 && ModManagerWindow.validateBIOGameDir()) {
-			boolean altApplied = false;
-			ModManager.debugLogger.writeMessageConditionally(
-					getModName() + ": Checking automatic alternate custom dlc list to see if applicable and will apply if conditions are right", ModManager.LOG_MOD_INIT);
-			//get list of installed DLC
-			ArrayList<String> installedDLC = ModManager.getInstalledDLC(biogamedir);
-			HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
-			ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
-
-			for (AlternateCustomDLC altdlc : alternateCustomDLC) {
-				ModManager.debugLogger.writeMessageConditionally("Checking if Alternate DLC applies: " + altdlc, ModManager.LOG_MOD_INIT);
-				String condition = altdlc.getCondition();
-				String conditionaldlc = altdlc.getConditionalDLC();
-				ArrayList<String> conditionaldlcs = altdlc.getConditionalDLCList();
-				if (conditionaldlcs != null && conditionaldlcs.size() > 0) {
-					//MULTI DLC
-					ArrayList<String> remappedHeaders = new ArrayList<String>();
-					for (String dlcpart : conditionaldlcs) { //for all dlc in the list
-						if (!installedDLC.contains(dlcpart)) { //if installed dlc does not contain this (e.g. CITADEL vs DLC_EXP_Pack003)
-							//check if its an official dlc header...
-							if (officialDLCHeaders.contains(dlcpart)) {
-								//convert to dlc folder name
-								String fname = headerFolderMap.get(dlcpart);
-								if (fname != null) {
-									remappedHeaders.add(fname.toUpperCase()); //Remap CITADEL To DLC_EXP_Pack003, etc.
-								} else {
-									//remappedHeaders.add(dlcpart);
-									ModManager.debugLogger
-											.writeError("[alt dlc application] Alt dlc specifies non-existent Custom DLC/Mod Manager Header, this shouldn't really be possible. "
-													+ conditionaldlc);
-								}
-							}
-						} else {
-							remappedHeaders.add(dlcpart.toUpperCase());
-						}
-					}
-
-					switch (condition) {
-					case AlternateCustomDLC.CONDITION_ALL_DLC_PRESENT:
-						if (installedDLC.containsAll(remappedHeaders)) {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as all DLC in condition is present: " + altdlc,
-									ModManager.LOG_MOD_INIT);
-							ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
-							applyAlternateDLCOperation(job, altdlc);
-							altApplied = true;
-
-						} else {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable at least one DLC in condition is not present: " + altdlc,
-									ModManager.LOG_MOD_INIT);
-						}
-						break;
-					case AlternateCustomDLC.CONDITION_ANY_DLC_NOT_PRESENT:
-						if (!installedDLC.containsAll(remappedHeaders)) {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as at least one DLC in condition are not present: " + altdlc,
-									ModManager.LOG_MOD_INIT);
-							ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
-							applyAlternateDLCOperation(job, altdlc);
-							altApplied = true;
-						} else {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable as all DLC in condition are present: " + altdlc,
-									ModManager.LOG_MOD_INIT);
-						}
-						break;
-					default:
-						ModManager.debugLogger.writeError("Unknown CustomDLC condition: " + condition);
-						break;
-					}
-				} else {
-					//SINGLE DLC
-					if (!installedDLC.contains(conditionaldlc)) {
-						//check if its an official dlc header...
-						if (officialDLCHeaders.contains(conditionaldlc)) {
-							//convert to dlc folder name
-							String fname = headerFolderMap.get(conditionaldlc);
-							if (fname != null) {
-								conditionaldlc = fname;
-							} else {
-								ModManager.debugLogger.writeError("[alt dlc application] Alt dlc specifies non-existent Custom DLC/Mod Manager Header: " + conditionaldlc);
-								continue;
-							}
-						}
-					}
-					switch (condition) {
-					case AlternateCustomDLC.CONDITION_DLC_NOT_PRESENT:
-						if (!installedDLC.contains(conditionaldlc.toUpperCase())) {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as " + conditionaldlc + " is not present",
-									ModManager.LOG_MOD_INIT);
-							ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
-							applyAlternateDLCOperation(job, altdlc);
-							altApplied = true;
-						} else {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable as " + conditionaldlc + " is present",
-									ModManager.LOG_MOD_INIT);
-						}
-						break;
-					case AlternateCustomDLC.CONDITION_DLC_PRESENT:
-						if (installedDLC.contains(conditionaldlc.toUpperCase())) {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as " + conditionaldlc + " is present", ModManager.LOG_MOD_INIT);
-							ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
-							applyAlternateDLCOperation(job, altdlc);
-							altApplied = true;
-						} else {
-							ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable as " + conditionaldlc + " is not present",
-									ModManager.LOG_MOD_INIT);
-						}
-						break;
-					}
-				}
-			}
-			return altApplied;
-		} else {
-			return false; //no operations performed
-		}
-	}
-
-	private void applyAlternateDLCOperation(ModJob job, AlternateCustomDLC altdlc) {
-		File sf = new File(getModPath() + altdlc.getAltDLC());
-		String destdlc = altdlc.getDestDLC();
-		switch (altdlc.getOperation()) {
-		case AlternateCustomDLC.OPERATION_ADD_FILES_TO_CUSTOMDLC_FOLDER:
-			ModManager.debugLogger.writeMessageConditionally("Condition match, adding additional layer for DLC folder: " + altdlc.getDestDLC(), ModManager.LOG_MOD_INIT);
-			job.getSourceFolders().add(altdlc.getAltDLC());
-			job.getDestFolders().add(altdlc.getDestDLC());
-			List<File> sourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
-			for (File file : sourceFiles) {
-				String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
-				String destFilePath = ModManager.appendSlash(destdlc) + relativePath;
-				if (!(job.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath(), false), ResourceUtils.normalizeFilePath(destFilePath, false), ignoreLoadErrors, true)
-						&& !ignoreLoadErrors)) {
-					setFailedReason("Mod specifies a CUSTOMDLC header, but an Alternate DLC operation failed to apply: " + altdlc
-							+ ". The issue occurred when attempting to add the file " + file + " to the mod.");
-					ModManager.debugLogger.writeError("Failed to add file to replace with ALTERNATE CUSTOM DLC (File likely does not exist), marking as invalid.");
-					return;
-				} else {
-					appliedAutomaticAlternateCustomDLC.add(altdlc);
-				}
-			}
-			break;
-		case AlternateCustomDLC.OPERATION_ADD_CUSTOMDLC_JOB:
-			ModManager.debugLogger.writeMessageConditionally("Condition match, adding custom DLC folder: " + altdlc.getDestDLC(), ModManager.LOG_MOD_INIT);
-			job.getSourceFolders().add(altdlc.getAltDLC());
-			job.getDestFolders().add(altdlc.getDestDLC());
-			List<File> addsourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
-			for (File file : addsourceFiles) {
-				String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
-				String destFilePath = ModManager.appendSlash(destdlc) + relativePath;
-				if (!(job.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath(), false), ResourceUtils.normalizeFilePath(destFilePath, false), ignoreLoadErrors, false)
-						&& !ignoreLoadErrors)) {
-					setFailedReason("Mod specifies a CUSTOMDLC header, but an Alternate DLC operation failed to apply: " + altdlc
-							+ ". The issue occured when attempting to add the file in an additional DLC to the mod: " + file + ".");
-					ModManager.debugLogger.writeError("Failed to add file to replace with ADD ALTERNATE CUSTOM DLC (File likely does not exist), marking as invalid.");
-					return;
-				} else {
-					appliedAutomaticAlternateCustomDLC.add(altdlc);
-				}
-			}
-			break;
-		}
-	}
-
-	/**
-	 * Applies automatic alternate files to this mod
-	 * 
-	 * @param biogamedir
-	 *            biogame directory
-	 */
-	public boolean applyAutomaticAlternates(String biogamedir) {
-		if (alternateFiles.size() > 0) {
-			boolean altApplied = false;
-			ModManager.debugLogger.writeMessageConditionally(getModName() + ": Checking automatic alternate files list to see if applicable and will apply if conditions are right",
-					ModManager.LOG_MOD_INIT);
-			//get list of installed DLC
-			ArrayList<String> installedDLC = ModManager.getInstalledDLC(biogamedir);
-			ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
-
-			for (AlternateFile af : alternateFiles) {
-				ModManager.debugLogger.writeMessageConditionally("Checking if Alt file applies: " + af, ModManager.LOG_MOD_INIT);
-				String condition = af.getCondition();
-				String conditionaldlc = af.getConditionalDLC();
-				if (!installedDLC.contains(conditionaldlc)) {
-					//check if its a header...
-					if (officialDLCHeaders.contains(conditionaldlc)) {
-						//convert to dlc name
-						HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
-						String fname = headerFolderMap.get(conditionaldlc);
-						if (fname != null) {
-							conditionaldlc = fname;
-						} else {
-							ModManager.debugLogger.writeError("[alt file application] Alt file specifies non-existent Custom DLC/Mod Manager Header: " + conditionaldlc);
-							continue;
-						}
-					}
-				}
-
-				switch (condition) {
-				case AlternateFile.CONDITION_DLC_NOT_PRESENT:
-					if (!installedDLC.contains(conditionaldlc.toUpperCase())) {
-						ModJob job = null;
-						if (officialDLCHeaders.contains(conditionaldlc)) {
-							//official DLC task
-							job = getJobByModuleName(conditionaldlc);
-						} else {
-							//custom dlc task
-							job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
-						}
-						applyAlternateFileOperation(job, af);
-						altApplied = true;
-					}
-					break;
-				case AlternateFile.CONDITION_DLC_PRESENT:
-					if (installedDLC.contains(conditionaldlc.toUpperCase())) {
-						ModJob job = null;
-						if (officialDLCHeaders.contains(conditionaldlc)) {
-							//official DLC task
-							job = getJobByModuleName(conditionaldlc);
-						} else {
-							//custom dlc task
-							job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
-						}
-						applyAlternateFileOperation(job, af);
-						altApplied = true;
-					}
-					break;
-				}
-			}
-			return altApplied;
-		} else {
-			return false; //no operations performed
-		}
-	}
-
-	private void applyAlternateFileOperation(ModJob job, AlternateFile af) {
-		switch (af.getOperation()) {
-		case AlternateFile.OPERATION_INSTALL:
-			//add file to task
-			if (job.getFilesToReplace().contains(getModPath() + af.getAltFile())) {
-				return; //file to replace already exists, user may have already applied mod in session.
-			}
-			ModManager.debugLogger.writeMessage("Condition match, " + af.getModFile() + " will now install new file " + af.getAltFile());
-			job.getFilesToReplace().add(getModPath() + af.getAltFile());
-			job.getFilesToReplaceTargets().add(af.getModFile());
-			break;
-		case AlternateFile.OPERATION_NOINSTALL:
-			ModManager.debugLogger.writeMessage("Condition match, will no longer modify " + af.getModFile());
-			String fileToRemovePath = af.getModFile();
-			if (fileToRemovePath.charAt(0) == '/' || fileToRemovePath.charAt(0) == '\\') {
-				fileToRemovePath = fileToRemovePath.substring(1);
-			}
-
-			String fileToRemoveTarget = ResourceUtils.normalizeFilePath(af.getModFile(), false);
-			int indexToRemove = job.getFilesToReplaceTargets().indexOf(fileToRemoveTarget);
-
-			job.getFilesToReplaceTargets().remove(indexToRemove);
-			job.getFilesToReplace().remove(indexToRemove);
+    public static final String DELTAS_FOLDER = "DELTAS";
+    public static final String ORIGINAL_FOLDER = "ORIGINAL";
+    public static final String VARIANT_FOLDER = "VARIANTS";
+    public static final String DEFAULT_SERVER_FOLDER = "PUT_SERVER_PATH_HERE";
+    File modDescFile;
+    boolean validMod = false;
+    String modName, modDisplayDescription, modDescription;
+    private String modPath;
+    String modifyString;
+    public ArrayList<ModJob> jobs;
+    private String modAuthor;
+    private int modmakerCode = 0;
+    private String modSite;
+    private String modmp;
+    private boolean emptyModIsOK;
+    private double compiledAgainstModmakerVersion;
+    private String modVersion;
+    public double modCMMVer = 1.0;
+    private int classicCode;
+    private boolean ignoreLoadErrors = false;
+    private ArrayList<Patch> requiredPatches = new ArrayList<Patch>();
+    private ArrayList<ModDelta> modDeltas = new ArrayList<ModDelta>();
+    private String failedReason;
+    private String serverModFolder = DEFAULT_SERVER_FOLDER; //only for mod devs
+    private ArrayList<AlternateFile> alternateFiles = new ArrayList<AlternateFile>();
+    private ArrayList<AlternateCustomDLC> alternateCustomDLC = new ArrayList<AlternateCustomDLC>();
+    private ArrayList<String> sideloadOnlyTargets = new ArrayList<>();
+    private String sideloadURL;
+    private ArrayList<String> blacklistedFiles = new ArrayList<>();
+    private ArrayList<String> outdatedDLCModules = new ArrayList<>();
+    private ArrayList<AlternateCustomDLC> appliedAutomaticAlternateCustomDLC = new ArrayList<AlternateCustomDLC>();
+    private boolean shouldApplyAutos = true;
+    public String rawCustomDLCSourceDirs;
+    public String rawcustomDLCDestDirs;
+    public ArrayList<MDEOfficialJob> rawOfficialJobs = new ArrayList<MDEOfficialJob>();
+    public String rawAltDlcText;
+    public String rawAltFilesText;
+    public ArrayList<String> requiredDLC = new ArrayList<>();
+    private String rawOutdatedCustomDLCText;
+    private boolean modIsUnofficial;
+
+    public ArrayList<AlternateCustomDLC> getAppliedAutomaticAlternateCustomDLC() {
+        return appliedAutomaticAlternateCustomDLC;
+    }
+
+    public void setAppliedAutomaticAlternateCustomDLC(ArrayList<AlternateCustomDLC> appliedAutomaticAlternateCustomDLC) {
+        this.appliedAutomaticAlternateCustomDLC = appliedAutomaticAlternateCustomDLC;
+    }
+
+    public boolean isModIsUnofficial() {
+        return modIsUnofficial;
+    }
+
+    public void setModIsUnofficial(boolean modIsUnofficial) {
+        this.modIsUnofficial = modIsUnofficial;
+    }
+
+    public String getServerModFolder() {
+        return serverModFolder;
+    }
+
+    public ArrayList<AlternateFile> getAlternateFiles() {
+        return alternateFiles;
+    }
+
+    public void setAlternateFiles(ArrayList<AlternateFile> alternateFiles) {
+        this.alternateFiles = alternateFiles;
+    }
+
+    public ArrayList<AlternateCustomDLC> getAlternateCustomDLC() {
+        return alternateCustomDLC;
+    }
+
+    public void setAlternateCustomDLC(ArrayList<AlternateCustomDLC> alternateCustomDLC) {
+        this.alternateCustomDLC = alternateCustomDLC;
+    }
+
+    public void setServerModFolder(String serverModFolder) {
+        this.serverModFolder = serverModFolder;
+    }
+
+    /**
+     * Creates a new mod object from a moddesc file and loads it for use.
+     *
+     * @param filepath Path to the moddesc.ini file.
+     */
+    public Mod(String filepath) {
+        if (filepath == null) {
+            return;
+        }
+        loadMod(filepath);
+    }
+
+    /**
+     * Reads moddesc and sets up the mod object. This is mainly used from the
+     * main Mod(moddesc.ini) method. This method was externalized to allow for
+     * setting up the the mod object before this method is processed.
+     *
+     * @param filepath Moddesc.ini file to load
+     */
+    public void loadMod(String filepath) {
+        modifyString = "";
+        modDescFile = new File(filepath);
+        setModPath(ModManager.appendSlash(modDescFile.getParent()));
+        jobs = new ArrayList<ModJob>();
+        try {
+            readDesc(new Wini(modDescFile));
+        } catch (Exception e) {
+            if (modName == null) {
+                modName = "Unknown mod";
+            }
+            ModManager.debugLogger.writeErrorWithException("Error reading moddesc.ini:", e);
+            setFailedReason("An exception occured reading moddesc.ini for this mod: " + ExceptionUtils.getStackTrace(e));
+            setValidMod(false);
+            return;
+        }
+    }
+
+    /**
+     * Loads a moddesc from a stream of bytes. Typically this is from a
+     * compressed archive.
+     *
+     * @param bytes
+     */
+    public Mod(ByteArrayInOutStream bytes) {
+        modDescFile = new File(System.getProperty("user.dir"));
+        ignoreLoadErrors = true;
+        modifyString = "";
+        jobs = new ArrayList<ModJob>();
+        try {
+            Wini wini = new Wini();
+            wini.load(bytes.getInputStream());
+            readDesc(wini);
+        } catch (Exception e) {
+            ModManager.debugLogger.writeErrorWithException("Error reading moddesc.ini from stream:", e);
+            setValidMod(false);
+            return;
+        }
+    }
+
+    /**
+     * Loads a moddesc from a stringwriter. This is used when dynamically
+     * generating one for import from an unsupported mod.
+     *
+     * @param writer
+     */
+    public Mod(StringWriter writer) {
+        modDescFile = new File(System.getProperty("user.dir"));
+        ignoreLoadErrors = true;
+        modifyString = "";
+        jobs = new ArrayList<ModJob>();
+        try {
+            Wini wini = new Wini();
+            wini.load(new StringReader(writer.toString()));
+            readDesc(wini);
+        } catch (Exception e) {
+            ModManager.debugLogger.writeErrorWithException("Error reading moddesc.ini from stream:", e);
+            setValidMod(false);
+            return;
+        }
+    }
+
+    /**
+     * Empty constructor. This should not be used unless you really know what
+     * you're doing. (manually adding jobs etc)
+     * <p>
+     * Instantiates the jobs variable and modifystring to blank and nothing
+     * else.
+     */
+    public Mod() {
+        jobs = new ArrayList<ModJob>();
+        modifyString = "";
+    }
+
+    /**
+     * Copy Constructor
+     *
+     * @param mod Mod to clone
+     */
+    public Mod(Mod mod) {
+        modDescFile = mod.modDescFile;
+        modPath = mod.modPath;
+        modName = mod.modName;
+        modVersion = mod.modVersion;
+        modSite = mod.modSite;
+        modDisplayDescription = mod.modDisplayDescription;
+        modDescription = mod.modDescription;
+        validMod = mod.validMod;
+        jobs = new ArrayList<ModJob>();
+        modifyString = mod.modifyString;
+        modAuthor = mod.modAuthor;
+        modmakerCode = mod.modmakerCode;
+        modmp = mod.modmp;
+        compiledAgainstModmakerVersion = mod.compiledAgainstModmakerVersion;
+        modCMMVer = mod.modCMMVer;
+        classicCode = mod.classicCode;
+        ignoreLoadErrors = mod.ignoreLoadErrors;
+        failedReason = mod.failedReason;
+        serverModFolder = mod.serverModFolder;
+        sideloadOnlyTargets = new ArrayList<String>();
+        outdatedDLCModules = new ArrayList<String>();
+        sideloadURL = mod.sideloadURL;
+        alternateFiles = new ArrayList<AlternateFile>();
+        requiredPatches = new ArrayList<Patch>();
+        modDeltas = new ArrayList<ModDelta>();
+        for (ModJob job : mod.jobs) {
+            ModJob newjob = new ModJob(job);
+            newjob.setOwningMod(this);
+            jobs.add(newjob);
+        }
+        for (String str : mod.sideloadOnlyTargets) {
+            sideloadOnlyTargets.add(str);
+        }
+        for (AlternateFile str : mod.alternateFiles) {
+            alternateFiles.add(new AlternateFile(str));
+        }
+        for (Patch str : mod.requiredPatches) {
+            requiredPatches.add(new Patch(str));
+        }
+        for (ModDelta str : mod.modDeltas) {
+            modDeltas.add(new ModDelta(str));
+        }
+        for (AlternateCustomDLC dlc : mod.alternateCustomDLC) {
+            alternateCustomDLC.add(new AlternateCustomDLC(dlc));
+        }
+        for (String str : mod.outdatedDLCModules) {
+            outdatedDLCModules.add(str);
+        }
+        for (String str : mod.requiredDLC) {
+            requiredDLC.add(str);
+        }
+    }
+
+    /**
+     * Parses the moddesc.ini file and validates it.
+     *
+     * @throws InvalidFileFormatException
+     * @throws IOException
+     */
+    private void readDesc(Wini modini) throws InvalidFileFormatException, IOException {
+        String modFolderPath = ModManager.appendSlash(modDescFile.getParent());
+        //modDisplayDescription = modini.get("ModInfo", "moddesc");
+        modName = modini.get("ModInfo", "modname");
+        String delayedFailure = null;
+        if (modName == null) {
+            //Attempt to extract name from the folder name
+            String foldername = new File(getModPath()).getName();
+            modName = foldername;
+            ModManager.debugLogger.writeError("Mod does not have a modname descriptor - marking invalid (" + modName + ") - will delay failing until update code is parsed.");
+            delayedFailure = "This mod does not have a modname descriptor under the [ModInfo] header in its moddesc.ini file. The name displayed in this window is the extracted from the mod's foldername. All Mod Manager mods must have a moddname descriptor.";
+        }
+        ModManager.debugLogger.writeMessageConditionally("-------MOD----------------Reading " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+
+        modDescription = modini.get("ModInfo", "moddesc");
+        if (modDescription == null) {
+            ModManager.debugLogger.writeError("Mod does not have a modname descriptor - marking invalid (" + modName + ") - will delay failing until update code is parsed.");
+            delayedFailure = "This mod does not have a moddesc descriptor under the [ModInfo] header in its moddesc.ini file. All Mod Manager mods must have a moddesc descriptor, which is the description shown to users in the right pane of the main Mod Manager window.";
+        }
+
+        modIsUnofficial = modini.get("ModInfo", "unofficial") != null;
+
+        // Check if this mod has been made for Mod Manager 2.0+ or legacy mode
+        modCMMVer = 1.0f;
+        try {
+            String versionStr = modini.get("ModManager", "cmmver");
+            if (versionStr == null) {
+                ModManager.debugLogger.writeMessageConditionally("Didn't read a ModManager version of the mod. Setting modtype to legacy", ModManager.LOG_MOD_INIT);
+                modCMMVer = 1.0f;
+            } else {
+                modCMMVer = Float.parseFloat(versionStr);
+            }
+        } catch (NumberFormatException e) {
+            ModManager.debugLogger.writeMessageConditionally("Didn't read a ModManager version of the mod. Setting modtype to legacy", ModManager.LOG_MOD_INIT);
+            modCMMVer = 1.0f;
+        }
+
+        //READ NON-ESSENTIAL DATA, USEFUL FOR FAILED MODS, AS THEY WILL ABORT ON ERROR
+        if (modini.get("ModInfo", "modver") != null) {
+            modVersion = modini.get("ModInfo", "modver");
+            ModManager.debugLogger.writeMessageConditionally("Detected mod version: " + modVersion, ModManager.LOG_MOD_INIT);
+        }
+
+        // Add Devsite
+        if (modini.get("ModInfo", "modsite") != null) {
+            modSite = modini.get("ModInfo", "modsite");
+            ModManager.debugLogger.writeMessageConditionally("Detected developer site", ModManager.LOG_MOD_INIT);
+        }
+
+        // Load modmaker update code
+        if (modini.get("ModInfo", "modid") != null) {
+            try {
+                modmakerCode = Integer.parseInt(modini.get("ModInfo", "modid"));
+                ModManager.debugLogger.writeMessageConditionally("Detected modmaker code", ModManager.LOG_MOD_INIT);
+            } catch (NumberFormatException e) {
+                ModManager.debugLogger.writeError("ModMaker code failed to resolve to an integer: " + modini.get("ModInfo", "modid"));
+            }
+        }
+
+        // Load classic update code
+        if (modini.get("ModInfo", "updatecode") != null) {
+            try {
+                classicCode = Integer.parseInt(modini.get("ModInfo", "updatecode"));
+                ModManager.debugLogger.writeMessageConditionally("Detected me3tweaks update code: " + classicCode, ModManager.LOG_MOD_INIT);
+            } catch (NumberFormatException e) {
+                ModManager.debugLogger.writeError("Classic update code is not an integer. Defaulting to 0");
+            }
+        }
+
+        if (classicCode > 0 && modmakerCode > 0) {
+            //can't have both
+            ModManager.debugLogger.writeError(modName + " has both a classic update code and a ModMaker update code - this is not allowed, marking as invalid.");
+            setFailedReason(
+                    "This mod has both a modid and updatecode descriptor under the [ModInfo] header. These descriptors are used for checking for updates and are mutually exclusive, so this mod has been marked as invalid. To fix this, remove one of the descriptors from moddesc.ini.");
+            return;
+        }
+
+        if (delayedFailure != null) {
+            ModManager.debugLogger.writeError("Delayed failure loading " + modName + ": " + delayedFailure);
+            setFailedReason(delayedFailure);
+            return;
+        }
+
+        // Add MP Change - DEPRECATED!
+        if (modini.get("ModInfo", "modmp") != null) {
+            modmp = modini.get("ModInfo", "modmp");
+            ModManager.debugLogger.writeMessageConditionally("Detected multiplayer modification", ModManager.LOG_MOD_INIT);
+        }
+        // Add developer
+        if (modini.get("ModInfo", "moddev") != null) {
+            modAuthor = modini.get("ModInfo", "moddev");
+            ModManager.debugLogger.writeMessageConditionally("Detected developer name", ModManager.LOG_MOD_INIT);
+        }
+
+        // Backwards compatibility for mods that are built to target older
+        // versions of mod manager (NO DLC)
+        if (modCMMVer < 2.0f) {
+            modCMMVer = 1.0f;
+            ModManager.debugLogger.writeMessageConditionally("Modcmmver is less than 2, checking for coalesced.bin in folder (legacy)", ModManager.LOG_MOD_INIT);
+            if (!ignoreLoadErrors) {
+                File file = new File(ModManager.appendSlash(getModPath()) + "Coalesced.bin");
+                if (!file.exists() && !ignoreLoadErrors) {
+                    ModManager.debugLogger
+                            .writeError(modName + " doesn't have Coalesced.bin and is marked as legacy (coalesced is required for this moddesc version), marking as invalid.");
+                    setFailedReason("Mod is legacy (1.0), which requires a Coalesced.bin in the same folder as the moddesc.ini file. Coalesced.bin is not present.");
+                    return;
+                }
+            }
+            File file = new File(ModManager.appendSlash(getModPath()) + "Coalesced.bin");
+            ModManager.debugLogger.writeMessageConditionally("Mod Manager 1.0 mod, verifying Coaleseced.bin location", ModManager.LOG_MOD_INIT);
+
+            if (!file.exists() && !ignoreLoadErrors) {
+                ModManager.debugLogger.writeMessageConditionally(modName + " doesn't have Coalesced.bin even though flag was set. Marking as invalid.", ModManager.LOG_MOD_INIT);
+                setFailedReason(
+                        "Mod targets Mod Manager 1.x but the Coalesced.bin file in the mod folder doesn't exist. Place a Coalesced.bin file in the same folder as moddesc.ini or remove the modcoal descriptor.");
+
+                return;
+            } else {
+                ModManager.debugLogger.writeMessageConditionally("Coalesced.bin is OK", ModManager.LOG_MOD_INIT);
+            }
+            ModJob job = new ModJob();
+            job.setOwningMod(this);
+            job.addFileReplace(file.getAbsolutePath(), "\\BIOGame\\CookedPCConsole\\Coalesced.bin", ignoreLoadErrors, false);
+            addTask(ModTypeConstants.BASEGAME, job);
+
+            validMod = true;
+            generateModDisplayDescription();
+            ModManager.debugLogger.writeMessage("Finished reading moddesc.ini file for cmm 1.0 mod " + modName);
+            ModManager.debugLogger.writeMessageConditionally(modName + " targets CMM 1.0. Added coalesced swap job.", ModManager.LOG_MOD_INIT);
+            ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+            return;
+        }
+
+        if (modCMMVer > 3.0f && modCMMVer < 3.1f) {
+            modCMMVer = 3.0f;
+        }
+
+        //some mods shipped as 3.2
+        if (modCMMVer > 3.1f && modCMMVer < 4.0f) {
+            modCMMVer = 3.1;
+        }
+
+        modCMMVer = (double) Math.round(modCMMVer * 10) / 10;
+
+        ModManager.debugLogger.writeMessageConditionally("Mod Manager version read: " + modCMMVer, ModManager.LOG_MOD_INIT);
+        ModManager.debugLogger.writeMessageConditionally("Checking for JOB headers in the ini file.", ModManager.LOG_MOD_INIT);
+
+        // It's a 2.0 or above mod. Check for mod tags in the desc file
+        String[] modIniHeaders = ModTypeConstants.getLoadingHeaderNameArray();
+
+        for (String modHeader : modIniHeaders) {
+            // Check for each mod. If it exists, add the task
+            String iniModDir = modini.get(modHeader, "moddir");
+            if (iniModDir != null && !iniModDir.equals("")) {
+                // It's a DLC header, we should check for the files to mod, and
+                // make sure they all match properly
+                ModManager.debugLogger.writeMessageConditionally("Found INI header " + modHeader, ModManager.LOG_MOD_INIT);
+
+                //REPLACE FILES (Mod Manager 2.0+)
+                String newFileIni = modini.get(modHeader, "newfiles");
+                String oldFileIni = modini.get(modHeader, "replacefiles");
+                //NEW FILES (Mod Manager 4.1+)
+                String addFileIni = modini.get(modHeader, "addfiles");
+                String addFileTargetIni = modini.get(modHeader, "addfilestargets");
+                String addReadOnlyFileTargetIni = modini.get(modHeader, "addfilesreadonlytargets");
+
+                //REMOVE FILES (Mod Manager 4.1+)
+                String removeFileTargetIni = modini.get(modHeader, "removefilestargets");
+                String requirementText = null;
+
+                boolean taskDoesSomething = false;
+                if (newFileIni != null && oldFileIni != null && !newFileIni.equals("") && !oldFileIni.equals("")) {
+                    taskDoesSomething = true;
+                }
+                if (addFileIni != null && addFileTargetIni != null && !addFileIni.equals("") && !addFileTargetIni.equals("")) {
+                    taskDoesSomething = true;
+                }
+                if (removeFileTargetIni != null && !removeFileTargetIni.equals("")) {
+                    taskDoesSomething = true;
+                }
+
+                if (!taskDoesSomething) {
+                    setFailedReason("Mod has a header (" + modHeader + ") with tasks that effectively do nothing. Add tasks or remove the header to fix this issue.");
+                    ModManager.debugLogger.writeError("This task appears to do nothing. It should be removed if this is the case. Marking mod as invalid.");
+                    return;
+                }
+
+                StringTokenizer newStrok = null, oldStrok = null;
+                if (newFileIni != null && oldFileIni != null) {
+                    //Parse replace files
+                    newStrok = new StringTokenizer(newFileIni, ";");
+                    oldStrok = new StringTokenizer(oldFileIni, ";");
+                    if (newStrok.countTokens() != oldStrok.countTokens()) {
+                        // Same number of tokens aren't the same
+                        ModManager.debugLogger.writeError("Number of files to update/replace do not match, mod being marked as invalid.");
+                        setFailedReason("Mod has a header (" + modHeader
+                                + ") that has different number of files to update/replace. The lists must be the same length (source files and destination paths).");
+                        ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                        return;
+                    }
+                }
+
+                //Mod Manager 4.1+ ADD/REMOVE/JOBDESCRIPTIONS
+                StringTokenizer addStrok = null;
+                StringTokenizer addTargetStrok = null;
+                StringTokenizer addTargetReadOnlyStrok = null;
+                StringTokenizer removeStrok = null;
+                if (modCMMVer >= 4.1) {
+                    //check for add/remove pairs
+                    if ((addFileIni != null && addFileTargetIni == null) || (addFileIni == null && addFileTargetIni != null)) {
+                        ModManager.debugLogger.writeError("addfiles/addtargetfiles is missing, but one is present, but both are required. Mod marked as invalid");
+                        setFailedReason("Mod has a header (" + modHeader + ") that has an addfiles or addtargetfiles task, but the corresponding task is not present.");
+                        ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                        return;
+                    }
+
+                    //Parse add files
+                    if (addFileIni != null && addFileTargetIni != null && !addFileIni.equals("") && !addFileTargetIni.equals("")) {
+                        addStrok = new StringTokenizer(addFileIni, ";");
+                        addTargetStrok = new StringTokenizer(addFileTargetIni, ";");
+                        if (addStrok.countTokens() != addTargetStrok.countTokens()) {
+                            // Same number of tokens aren't the same
+                            ModManager.debugLogger.writeError("Number of files to add and number of target files do not match, mod being marked as invalid.");
+                            setFailedReason(
+                                    "Mod has a header (" + modHeader + ") that has an addfiles task, but the number of source files and the number of targets do not match.");
+                            ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                            return;
+                        }
+                        if (modCMMVer >= 4.3 && addReadOnlyFileTargetIni != null) {
+                            //READ ONLY DESIGNATION
+                            addTargetReadOnlyStrok = new StringTokenizer(addReadOnlyFileTargetIni, ";");
+                        }
+                    }
+
+                    //remove files doesn't need a token match, but create the tokenizer for later
+                    if (removeFileTargetIni != null && !removeFileTargetIni.equals("")) {
+                        removeStrok = new StringTokenizer(removeFileTargetIni, ";");
+                    }
+                    requirementText = modini.get(modHeader, "jobdescription");
+                    ModManager.debugLogger.writeMessageConditionally(modHeader + " job description: " + requirementText, ModManager.LOG_MOD_INIT);
+                }
+
+                //For ModDesc Editor
+                MDEOfficialJob mdeJob = new MDEOfficialJob(modHeader, iniModDir, newFileIni, oldFileIni, addFileIni, addFileTargetIni, addReadOnlyFileTargetIni,
+                        removeFileTargetIni, requirementText);
+                rawOfficialJobs.add(mdeJob);
+
+                // Check to make sure the filenames are the same, and if they
+                // are, then the mod is going to be valid.
+                // Start building the mod job.
+                // modCMMVer = 3.0;
+                ModJob newJob;
+                if (modCMMVer >= 3 && modHeader.equals(ModTypeConstants.BASEGAME)) {
+                    newJob = new ModJob();
+                } else if (modCMMVer >= 4.3 && modHeader.equals(ModTypeConstants.BINI)) {
+                    newJob = new ModJob();
+                    newJob.setJobName(ModTypeConstants.BINI);
+                    newJob.setJobType(ModJob.BALANCE_CHANGES);
+                } else {
+                    // DLC Job
+                    newJob = new ModJob(ModTypeConstants.getDLCPath(modHeader), modHeader, requirementText);
+                    if (modCMMVer >= 3 && modHeader.equals(ModTypeConstants.TESTPATCH)) {
+                        newJob.TESTPATCH = true;
+                    }
+                }
+                newJob.setOwningMod(this);
+                newJob.setSourceDir(iniModDir);
+                if (newStrok != null && oldStrok != null) {
+                    while (newStrok.hasMoreTokens()) {
+                        String newFile = newStrok.nextToken();
+                        String oldFile = oldStrok.nextToken();
+                        // ModManager.debugLogger.writeMessageConditionally("Validating tokens: "+newFile+" vs
+                        // "+oldFile);
+                        if (!newFile.equals(getSfarFilename(oldFile))) {
+                            setFailedReason("Mod has a newfiles/replacefiles task in a header (" + modHeader + ") that has different filenames in the source vs target paths: "
+                                    + newFile + " vs " + getSfarFilename(oldFile) + ". These filenames currently must be the same. This restriction may be lifted in the future.");
+                            ModManager.debugLogger.writeError("[REPLACEFILE]Filenames failed to match, mod marked as invalid: " + newFile + " vs " + getSfarFilename(oldFile));
+                            return; // The names of the files don't match
+                        }
+
+                        if (oldFile.contains("..")) {
+                            setFailedReason("Mod has a task in a header (" + modHeader
+                                    + ") that attempts to replace files using a parent directory indicator (\\..\\). This is a security risk to the system. Mods will not load with these paths.");
+                            ModManager.debugLogger
+                                    .writeError("[REPLACEFILE]SECURITY RISK! Task is attempting to replacing file using parent directory indicator .. . Mod has been disabled");
+                            return; // Security mitigation
+                        }
+
+                        // Add the file swap to task job - if this method returns
+                        // false it means a file doesn't exist somewhere
+                        if (!(newJob.addFileReplace(modFolderPath + ModManager.appendSlash(iniModDir) + newFile, oldFile, ignoreLoadErrors, false)) && !ignoreLoadErrors) {
+                            ModManager.debugLogger.writeError("Failed to add file to replace (File likely does not exist), marking as invalid.");
+                            setFailedReason("Mod has a newfiles/replacefiles task in a header (" + modHeader
+                                    + ") that encountered an error while building the list of source/targets. This likely means the source file does not exist: " + modFolderPath
+                                    + ModManager.appendSlash(iniModDir) + newFile);
+                            ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                            return;
+                        }
+                    }
+                }
+                if (addStrok != null) {
+                    while (addStrok.hasMoreTokens()) {
+                        String addFile = addStrok.nextToken();
+                        String targetFile = addTargetStrok.nextToken();
+                        if (!addFile.equals(getSfarFilename(targetFile))) {
+                            ModManager.debugLogger.writeError("[ADDFILE]Filenames failed to match, mod marked as invalid: " + addFile + " vs " + getSfarFilename(targetFile));
+                            setFailedReason("Mod specifies an addfile/addfiles target task in (" + modHeader + "), but the filenames for source vs targets doesn't match: "
+                                    + addFile + " vs " + getSfarFilename(targetFile));
+                            ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                            return; // The names of the files don't match
+                        }
+
+                        // Add the file swap to task job - if this method returns
+                        // false it means a file doesn't exist somewhere
+                        if (!(newJob.addNewFileTask(modFolderPath + ModManager.appendSlash(iniModDir) + addFile, targetFile, ignoreLoadErrors)) && !ignoreLoadErrors) {
+                            ModManager.debugLogger.writeError("[ADDFILE]Failed to add task for file addition (File likely does not exist), marking as invalid.");
+                            setFailedReason("Mod has an addfiles/addfilestargets task in a header (" + modHeader
+                                    + ") that encountered an error while building the list of source/targets. This likely means the source file does not exist: " + modFolderPath
+                                    + ModManager.appendSlash(iniModDir) + addFile);
+                            ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                            return;
+                        }
+                    }
+                    if (modCMMVer >= 4.3 && addTargetReadOnlyStrok != null) {
+                        //READ ONLY DESIGNATION
+                        while (addTargetReadOnlyStrok.hasMoreTokens()) {
+                            String readonlytarget = addTargetReadOnlyStrok.nextToken();
+                            if (!readonlytarget.startsWith("\\")) {
+                                //prepend \ so it matches the one stored in modjob
+                                readonlytarget = "\\" + readonlytarget;
+                            }
+                            if (!newJob.getFilesToAddTargets().contains(readonlytarget)) {
+                                ModManager.debugLogger.writeError(
+                                        "[ADDFILE-READONLY]Failed to set a file to be marked as read only on install - Cannot mark file read-only if its not in the addfiles list: "
+                                                + readonlytarget);
+                                setFailedReason(
+                                        "Mod has designated files to install should be marked read-only (so end user won't modify them). A designation does not match any files in the addfilestargets list: "
+                                                + readonlytarget);
+                                ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                                return;
+                            }
+                            newJob.addNewFileReadOnlyTask(readonlytarget);
+                        }
+                    }
+                }
+                if (removeStrok != null) {
+                    while (removeStrok.hasMoreTokens()) {
+                        String removeFilePath = removeStrok.nextToken();
+                        //add remove file to job
+                        if (!newJob.addRemoveFileTask(removeFilePath)) {
+                            ModManager.debugLogger.writeError("[REMOVE]Failed to add task for file removal.");
+                            setFailedReason("Mod failed to add file for removal as part of header (" + modHeader
+                                    + "), his shouldn't be able to happen! The file target that failed: " + removeFilePath);
+                            ModManager.debugLogger.writeMessageConditionally("-----MOD------------END OF " + modName + "--------------------", ModManager.LOG_MOD_INIT);
+                            return;
+                        }
+                    }
+                }
+
+                if (modCMMVer >= 4.5 && !newJob.getJobName().equals(ModTypeConstants.BINI)) {
+                    String altText = modini.get(modHeader, "altfiles");
+                    if (altText != null && !altText.equals("")) {
+                        ArrayList<String> alts = ValueParserLib.getSplitValues(altText);
+                        if (alts == null) {
+                            //error
+                            ModManager.debugLogger.writeError(
+                                    "ALTERNATES altfiles was specified, but the value couldn't be parsed. This error is from the OFFICIAL headers, so it only applies to official BioWare DLC or the basegame. The definition is likely invalid: "
+                                            + altText);
+                            setFailedReason("The moddesc indicates there should be files installed differently depending on certain conditions, but it failed to parse. The ["
+                                    + modHeader + "] altfiles text that failed to parse was :" + altText
+                                    + "\n\nThis may not affect your specific ME3 environment, but the mod has been marked as invalid to avoid possible issues.");
+                            return;
+                        }
+                        for (String alt : alts) {
+                            AlternateFile af = new AlternateFile(alt, modCMMVer);
+                            af.setAssociatedJobName(newJob.getJobName());
+                            af.setModFile(ResourceUtils.normalizeFilePath(af.getModFile(), false));
+                            ModManager.debugLogger.writeMessageConditionally("Alternate file specified: " + af.toString(), ModManager.LOG_MOD_INIT);
+
+                            String subPath = (modCMMVer == 4.5 && af.getOperation() == AlternateFile.OPERATION_SUBSTITUTE) ? af.getSubstituteFile() : af.getAltFile();
+                            if (subPath != null) {
+                                //check location
+                                String subfile = ModManager.appendSlash(getModPath()) + subPath;
+                                File f = new File(subfile);
+                                if (!f.exists() && !ignoreLoadErrors) {
+                                    ModManager.debugLogger.writeError(
+                                            "This error is from the OFFICIAL headers, so it only applies to official BioWare DLC or the Basegame. Substitute file doesn't exist: "
+                                                    + f.getAbsolutePath());
+                                    setFailedReason(
+                                            "The moddesc indicates there should be files installed differently depending on certain conditions, but a listed substitute file doesn't exist. The error occurs in the ["
+                                                    + modHeader + "] header altfiles text. The missing file is :" + f.getAbsolutePath()
+                                                    + "\n\nThis may not affect your specific ME3 enviroment, but the mod has been marked as invalid to avoid possible issues.");
+                                    return;
+                                }
+
+                                //Validate substition for moddesc 4.5 -> 5.0
+                                if (af.getOperation().equals(AlternateFile.OPERATION_SUBSTITUTE)) {
+                                    if (!af.getAssociatedJobName().equals(ModTypeConstants.CUSTOMDLC) && modCMMVer == 4.5 && af.getSubstituteFile() == null) {
+                                        //missing substitute file on 4.5
+                                        ModManager.debugLogger
+                                                .writeError("Automatic alternate file targets Mod Manager 4.5 but does not have a listed SubstituteFile: " + af.getModFile());
+                                        setFailedReason("This mod specifies automatic conditional changes for the following but has no SubstituteFile item in its altfile struct: "
+                                                + af.getModFile()
+                                                + "\n\nThis is specific to mods targeting ModDesc 4.5. ModDesc 5.0+ mods use the same ModFile/AltModFile format for all operations.");
+                                        return;
+                                    }
+                                    if (modCMMVer > 4.5 && af.getSubstituteFile() != null) {
+                                        //Using substitute operation on > 4.5 is not allowed
+                                        ModManager.debugLogger
+                                                .writeError("Automatic alternate file targets Mod Manager > 4.5 but contains 4.5 only SubstituteFile: " + af.getModFile());
+                                        setFailedReason("This mod specifies automatic conditional changes for the following but has a SubstituteFile item in its altfile struct: "
+                                                + af.getModFile()
+                                                + "\n\nMods targeting ModDesc 5.0 and higher don't support the SubstituteFile item for altfiles - did you upgrade 4.5 -> 5.0 and forget to change this to AltFile?");
+                                        return;
+                                    }
+                                }
+                            } else {
+                                //auto alts cannot apply to the same thing
+                                ModManager.debugLogger.writeError("Automatic alternate file is missing AltFile attribute: " + af.getModFile());
+                                setFailedReason(
+                                        "This mod specifies automatic conditional changes for the following but is missing the AltFile item in the struct: " + af.getModFile());
+                                return;
+                            }
+                            ModManager.debugLogger.writeMessageConditionally("AltFile is OK: " + af.getFriendlyName(), ModManager.LOG_MOD_INIT);
+                            newJob.getAlternateFiles().add(af);
+                        }
+                    }
+                }
+
+                ModManager.debugLogger.writeMessageConditionally(modName + ": Successfully made a new Mod Job for: " + modHeader, ModManager.LOG_MOD_INIT);
+                addTask(modHeader, newJob);
+            }
+        }
+
+        // CHECK FOR CUSTOMDLC HEADER (3.1+)
+        if (modCMMVer >= 3.1)
+
+        {
+            ModManager.debugLogger.writeMessageConditionally("Mod built for ModManager 3.1+, checking for CUSTOMDLC header", ModManager.LOG_MOD_INIT);
+            String iniModDir = modini.get(ModTypeConstants.CUSTOMDLC, "sourcedirs");
+            if (iniModDir != null && !iniModDir.equals("")) {
+                ModManager.debugLogger.writeMessageConditionally("Found CUSTOMDLC header", ModManager.LOG_MOD_INIT);
+
+                //customDLC flag is set
+                String sourceFolderIni = modini.get(ModTypeConstants.CUSTOMDLC, "sourcedirs");
+                String destFolderIni = modini.get(ModTypeConstants.CUSTOMDLC, "destdirs");
+                rawCustomDLCSourceDirs = sourceFolderIni;
+                rawcustomDLCDestDirs = destFolderIni;
+                // ModManager.debugLogger.writeMessageConditionally("New files: "+newFileIni);
+                // ModManager.debugLogger.writeMessageConditionally("Old Files: "+oldFileIni);
+                if (sourceFolderIni == null || destFolderIni == null || sourceFolderIni.equals("") || destFolderIni.equals("")) {
+                    setFailedReason("Mod specifies a CUSTOMDLC header, but one or both of the lists was empty.");
+                    ModManager.debugLogger.writeError("sourcedirs/destdirs files was null or empty, mod marked as invalid.");
+                    return;
+                }
+
+                StringTokenizer srcStrok = new StringTokenizer(sourceFolderIni, ";");
+                StringTokenizer destStrok = new StringTokenizer(sourceFolderIni, ";");
+                if (srcStrok.countTokens() != destStrok.countTokens()) {
+                    // Same number of tokens aren't the same
+                    setFailedReason("Mod specifies a CUSTOMDLC header, but the list of source directories and target directories didn't match.");
+                    ModManager.debugLogger.writeError("Number of source and destination directories for custom DLC job do not match, mod being marked as invalid.");
+                    return;
+                }
+
+                ModJob newJob = new ModJob();
+                newJob.setOwningMod(this);
+                newJob.setJobName(ModTypeConstants.CUSTOMDLC); //backwards, it appears...
+                newJob.setJobType(ModJob.CUSTOMDLC);
+                newJob.setSourceFolders(new ArrayList<String>());
+                newJob.setDestFolders(new ArrayList<String>());
+
+                while (srcStrok.hasMoreTokens()) {
+                    String sourceFolder = srcStrok.nextToken();
+                    String destFolder = destStrok.nextToken();
+
+                    File sf = new File(modFolderPath + sourceFolder);
+                    if (!sf.exists() && !ignoreLoadErrors) {
+                        setFailedReason("Mod specifies a CUSTOMDLC header, but one of the source directories doesn't list: " + sf.getAbsolutePath());
+                        ModManager.debugLogger.writeError("Custom DLC Source folder does not exist: " + sf.getAbsolutePath() + ", mod marked as invalid");
+                        return;
+                    }
+                    if (ModTypeConstants.isKnownDLCFolder(destFolder)) {
+                        // Same number of tokens aren't the same
+                        setFailedReason(
+                                "Mod specifies a CUSTOMDLC header, but one of the target directories isn't allowed as it is a known official DLC foldername: " + destFolder);
+                        ModManager.debugLogger.writeError("Custom DLC folder is not allowed as it is a default game one: " + destFolder);
+                        return;
+                    }
+
+                    if (!destFolder.startsWith("DLC_")) {
+                        setFailedReason(
+                                "Mod specifies a CUSTOMDLC destination folder that doesn't start with DLC_. When installing this mod, this will do nothing because Mass Effect 3 will not load any DLC that does not start with DLC_."
+                                        + destFolder);
+                        ModManager.debugLogger.writeError("Custom DLC target folder doesn't start with DLC_: " + destFolder);
+                        return;
+                    }
+
+                    if (sf.exists()) { //ignore errors is not present here.
+                        List<File> sourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+                        for (File file : sourceFiles) {
+                            String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
+                            String destFilePath = ModManager.appendSlash(destFolder) + relativePath;
+                            if (!(newJob.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath(), false), ResourceUtils.normalizeFilePath(destFilePath, false),
+                                    ignoreLoadErrors, false) && !ignoreLoadErrors)) {
+                                setFailedReason("Mod specifies a CUSTOMDLC header, but a file in one of the source directories (" + sf
+                                        + ") had a file that was unable to be added. This error should not be encountered.");
+                                ModManager.debugLogger.writeError("Failed to add file to replace (File likely does not exist), marking as invalid.");
+                                return;
+                            }
+                        }
+                    }
+                    newJob.getSourceFolders().add(sourceFolder);
+                    newJob.getDestFolders().add(destFolder);
+                }
+                ModManager.debugLogger.writeMessageConditionally(modName + ": Successfully made a new Mod Job for: " + ModTypeConstants.CUSTOMDLC, ModManager.LOG_MOD_INIT);
+                addTask(ModTypeConstants.CUSTOMDLC, newJob);
+            }
+
+            //In 3.1+, we can check for 4.2+ since this won't trigger on lower
+            //MOD MANAGER 4.2.3: Support [CUSTOMDLC]>altfiles, Support [UPDATES]
+            if (modCMMVer >= 4.2) {
+                String altText = modini.get("CUSTOMDLC", "altfiles");
+                if (altText != null && !altText.equals("")) {
+                    rawAltFilesText = altText;
+                    ArrayList<String> alts = ValueParserLib.getSplitValues(altText);
+                    if (alts == null) {
+                        //error
+                        ModManager.debugLogger.writeError("ALTERNATES altfiles was specified, but the value couldn't be parsed. It's likely invalid: " + altText);
+                        setFailedReason(
+                                "The moddesc indicates there should be files installed differently depending on certain conditions, but it failed to parse. The [ALTERNATES] altfiles text that failed to parse was :"
+                                        + altText + "\n\nThis may not affect your specific ME3 enviroment, but the mod has been marked as invalid to avoid possible issues.");
+                        return;
+                    }
+                    for (String alt : alts) {
+                        AlternateFile af = new AlternateFile(alt, modCMMVer);
+                        af.setAssociatedJobName(ModTypeConstants.CUSTOMDLC);
+                        ModManager.debugLogger.writeMessageConditionally("Alternate file specified: " + af.toString(), ModManager.LOG_MOD_INIT);
+                        alternateFiles.add(af);
+                    }
+                }
+                if (modini.get("UPDATES", "serverfolder") != null) {
+                    serverModFolder = modini.get("UPDATES", "serverfolder");
+                    ModManager.debugLogger.writeMessageConditionally("Detected me3tweaks server folder: " + classicCode, ModManager.LOG_MOD_INIT);
+                }
+                sideloadURL = modini.get("UPDATES", "sideloadurl");
+                String sideloadonly = modini.get("UPDATES", "sideloadonly");
+                if (sideloadURL == null && sideloadonly != null) {
+                    ModManager.debugLogger.writeError("Mod specifies sideload only files but does not specify sideloading link");
+                    setFailedReason(
+                            "This mod specifies a list of files that can only be updated via sideloading but does not specify a sideload URL. This can lead to a state where users will be unable to update the mod. Provide a (valid) sideload URL to fix this by adding 'sideloadurl=<URL>' under [UPDATES] in moddesc.ini.");
+                    return;
+                }
+                if (sideloadonly != null) {
+                    StringTokenizer sideloadTok = new StringTokenizer(sideloadonly, ";");
+                    while (sideloadTok.hasMoreTokens()) {
+                        String sideloadonlyfile = sideloadTok.nextToken();
+                        sideloadonlyfile = sideloadonlyfile.replaceAll("\\\\", "/");
+                        ModManager.debugLogger.writeMessageConditionally("Sideload only file for manifest: " + sideloadonlyfile, ModManager.LOG_MOD_INIT);
+                        sideloadOnlyTargets.add(sideloadonlyfile);
+                    }
+                }
+                String blacklisted = modini.get("UPDATES", "blacklistedfiles");
+                if (blacklisted != null) {
+                    StringTokenizer blacklistedTok = new StringTokenizer(blacklisted, ";");
+                    while (blacklistedTok.hasMoreTokens()) {
+                        String blacklistedfile = blacklistedTok.nextToken();
+                        blacklistedfile = blacklistedfile.replaceAll("\\\\", "/");
+                        ModManager.debugLogger.writeMessageConditionally("Blacklisted file for manifests: " + blacklistedfile, ModManager.LOG_MOD_INIT);
+                        getBlacklistedFiles().add(blacklistedfile);
+                    }
+                }
+            }
+            if (modCMMVer >= 4.4) {
+                ModManager.debugLogger.writeMessageConditionally("Targetting Mod Manager Version >= 4.4, looking for altdlc descriptor in CUSTOMDLC", ModManager.LOG_MOD_INIT);
+                String altText = modini.get("CUSTOMDLC", "altdlc");
+                if (altText != null && !altText.equals("")) {
+                    rawAltDlcText = altText;
+                    ArrayList<String> alts = ValueParserLib.getSplitValues(altText);
+                    if (alts == null) {
+                        //error
+                        ModManager.debugLogger.writeError("Alternate CustomDLC was specified, but the value couldn't be parsed. It's likely invalid: " + altText);
+                        setFailedReason(
+                                "The moddesc indicates there should Custom DLC added, removed, or modified depending on certain game conditions, but it failed to parse. The [CUSTOMDLC] altdlc text that failed to parse was :"
+                                        + altText + "\n\nThis may not affect your specific ME3 enviroment, but the mod has been marked as invalid to avoid possible issues.");
+                        return;
+                    }
+                    for (String alt : alts) {
+                        AlternateCustomDLC altdlc = new AlternateCustomDLC(alt);
+                        ModManager.debugLogger.writeMessageConditionally("Alternate CustomDLC specified: " + alt.toString(), ModManager.LOG_MOD_INIT);
+                        alternateCustomDLC.add(altdlc);
+                    }
+                }
+
+                String outdatedDLC = modini.get("CUSTOMDLC", "outdatedcustomdlc");
+                if (outdatedDLC != null && !outdatedDLC.equals("")) {
+                    rawOutdatedCustomDLCText = outdatedDLC;
+                    StringTokenizer outdatedDLCTok = new StringTokenizer(outdatedDLC, ";");
+                    ArrayList<String> official = ModTypeConstants.getStandardDLCFolders();
+                    while (outdatedDLCTok.hasMoreTokens()) {
+                        String outdateddlcmodule = outdatedDLCTok.nextToken();
+                        for (String officialdlc : official) {
+                            officialdlc = officialdlc.toUpperCase();
+                            if (officialdlc.equals(outdateddlcmodule)) {
+                                ModManager.debugLogger.writeError("This mod lists an outdated DLC that should be deleted that is an official Mass Effect 3 DLC: " + officialdlc
+                                        + ". This is not allowed as it can lead to users deleting officially purchased DLC. Marking mod as invalid.");
+                                setFailedReason("This mod lists an outdated DLC that should be deleted that is an official Mass Effect 3 DLC: " + officialdlc
+                                        + ". This is not allowed as it can lead to users deleting officially purchased DLC.");
+                                return;
+                            }
+                        }
+                        ModManager.debugLogger.writeMessageConditionally(
+                                "Mod lists outdated DLC module that will be deleted on installation if the user says OK: " + outdateddlcmodule, ModManager.LOG_MOD_INIT);
+                        getOutdatedDLCModules().add(outdateddlcmodule);
+                    }
+                } else {
+                    ModManager.debugLogger.writeMessageConditionally("Mod has no outdated custom dlc listed to remove on install", ModManager.LOG_MOD_INIT);
+                }
+            }
+        }
+
+        //Read required DLC
+        if (modCMMVer >= 5.0) {
+            ModManager.debugLogger.writeMessageConditionally("Targetting Mod Manager Version >= 5.0, looking for requireddlc descriptor", ModManager.LOG_MOD_INIT);
+            String requiredDLCText = modini.get("ModInfo", "requireddlc");
+            if (requiredDLCText != null && !requiredDLCText.equals("")) {
+                //get list of installed DLC
+                StringTokenizer tok = new StringTokenizer(requiredDLCText, ";");
+                ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
+                HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
+                while (tok.hasMoreTokens()) {
+                    String header = tok.nextToken();
+                    //check if its an official dlc header...
+                    if (officialDLCHeaders.contains(header)) {
+                        //convert to dlc folder name
+                        String fname = headerFolderMap.get(header);
+                        if (fname != null) {
+                            ModManager.debugLogger.writeMessageConditionally("Mod requires DLC " + ME3TweaksUtils.getThirdPartyModName(fname, true), ModManager.LOG_MOD_INIT);
+                            requiredDLC.add(fname.toUpperCase()); //Remap CITADEL To DLC_EXP_Pack003, etc.
+                        }
+                    } else {
+                        requiredDLC.add(header); //Custom DLC
+                    }
+                }
+            }
+        }
+
+        // Backwards compatibility for Mod Manager 2's modcoal flag (has now
+        // moved to [BASEGAME] as of 3.0)
+        if (modCMMVer < 3.0f && modCMMVer >= 2.0f)
+
+        {
+            modCMMVer = 2.0;
+            ModManager.debugLogger.writeMessageConditionally(modName + ": Targets CMM2.0. Checking for modcoal flag", ModManager.LOG_MOD_INIT);
+
+            int modCoalFlag = 0;
+            try {
+                modCoalFlag = Integer.parseInt(modini.get("ModInfo", "modcoal"));
+                ModManager.debugLogger.writeMessageConditionally("Coalesced flag: " + modCoalFlag, ModManager.LOG_MOD_INIT);
+
+                if (modCoalFlag != 0) {
+                    File file = new File(ModManager.appendSlash(getModPath()) + "Coalesced.bin");
+                    ModManager.debugLogger.writeMessageConditionally("Coalesced flag was set, verifying its location", ModManager.LOG_MOD_INIT);
+
+                    if (!file.exists() && !ignoreLoadErrors) {
+                        ModManager.debugLogger.writeMessageConditionally(modName + " doesn't have Coalesced.bin even though flag was set. Marking as invalid.",
+                                ModManager.LOG_MOD_INIT);
+                        setFailedReason(
+                                "Mod targets Mod Manager 2.0 and specifies a Coalesced file should be present, but one doesn't exist. Place a Coalesced.bin file in the same folder as moddesc.ini or remove the modcoal descriptor.");
+
+                        return;
+                    } else {
+                        ModManager.debugLogger.writeMessageConditionally("Coalesced.bin is OK", ModManager.LOG_MOD_INIT);
+                    }
+                    ModJob job = new ModJob();
+                    job.setOwningMod(this);
+                    job.addFileReplace(file.getAbsolutePath(), "\\BIOGame\\CookedPCConsole\\Coalesced.bin", ignoreLoadErrors, false);
+                    addTask(ModTypeConstants.BASEGAME, job);
+                }
+            } catch (NumberFormatException e) {
+                ModManager.debugLogger.writeMessageConditionally("Was not able to read the coalesced mod value. Coal flag was not set/not entered, skipping setting coal",
+                        ModManager.LOG_MOD_INIT);
+            }
+        }
+
+        ModManager.debugLogger.writeMessageConditionally("Number of Mod Jobs: " + jobs.size(), ModManager.LOG_MOD_INIT);
+        if (jobs.size() > 0) {
+            ModManager.debugLogger.writeMessageConditionally("Verified source files, mod should be OK to install", ModManager.LOG_MOD_INIT);
+            validMod = true;
+        } else if (jobs.size() == 0 && emptyModIsOK) {
+            ModManager.debugLogger.writeMessage("Mod is empty, but we said it was OK to load.");
+            validMod = true;
+        } else {
+            ModManager.debugLogger.writeError("Mod has no tasks. This mod does nothing. Marking as invalid");
+            setFailedReason("This mod has no installation tasks and does nothing. Add some tasks or delete this mod.");
+        }
+
+        //modmaker compiledagainst flag (1.5+)
+        if (modini.get("ModInfo", "compiledagainst") != null) {
+            try {
+                compiledAgainstModmakerVersion = Double.parseDouble(modini.get("ModInfo", "compiledagainst"));
+                ModManager.debugLogger.writeMessageConditionally("Server version compiled against: " + compiledAgainstModmakerVersion, ModManager.LOG_MOD_INIT);
+                if (compiledAgainstModmakerVersion < 1.5) {
+                    try {
+                        int ver = Integer.parseInt(modVersion);
+                        ver++;
+                        modVersion = Integer.toString(ver);
+                        ModManager.debugLogger.writeMessageConditionally("ModMaker mod (<1.5), +1 to revision.", ModManager.LOG_MOD_INIT);
+                    } catch (NumberFormatException e) {
+                        ModManager.debugLogger.writeError("ModMaker version failed to resolve to an integer.");
+                        modVersion = Integer.toString(1);
+                    }
+                }
+            } catch (NumberFormatException e) {
+                ModManager.debugLogger.writeError("ModMaker code failed to resolve to an integer.");
+            }
+        } else {
+            if (modmakerCode > 0) {
+                //modmaker mod
+                compiledAgainstModmakerVersion = 1.4;
+                ModManager.debugLogger.writeMessageConditionally("Unknown server version, assuming 1.4 compilation target: " + compiledAgainstModmakerVersion,
+                        ModManager.LOG_MOD_INIT);
+                try {
+                    int ver = Integer.parseInt(modVersion);
+                    ver++;
+                    modVersion = Integer.toString(ver);
+                    ModManager.debugLogger.writeMessageConditionally("ModMaker mod (<1.5), +1 to revision.", ModManager.LOG_MOD_INIT);
+                } catch (NumberFormatException e) {
+                    ModManager.debugLogger.writeError("ModMaker version failed to resolve to an integer.");
+                    modVersion = Integer.toString(1);
+                }
+            }
+        }
+
+        if (modCMMVer > ModManager.MODDESC_VERSION_SUPPORT) {
+            ModManager.debugLogger.writeError("Mod is for newer version of Mod Manager, may have issues with this version.");
+        }
+
+        //Read deltas
+        File dir = new File(modFolderPath + DELTAS_FOLDER);
+        File[] deltas = dir.listFiles(new FilenameFilter() {
+            public boolean accept(File dir, String filename) {
+                return filename.endsWith(".xml");
+            }
+        });
+        if (deltas != null) {
+            for (File delta : deltas) {
+                ModDelta md = new ModDelta(delta.getAbsolutePath());
+                if (md.isValidDelta()) {
+                    modDeltas.add(md);
+                }
+            }
+            if (modDeltas.size() > 0) {
+                ModManager.debugLogger.writeMessageConditionally("This mod has " + modDeltas.size() + " deltas.", ModManager.LOG_MOD_INIT);
+            }
+        }
+
+        //Apply Alternate CustomDLC
+        if (alternateCustomDLC.size() > 0 && !ignoreLoadErrors) {
+            if (ModManagerWindow.validateBIOGameDir()) {
+                if (shouldApplyAutos) {
+                    addCustomDLCAlternates(ModManagerWindow.GetBioGameDir());
+                }
+            } else {
+                ModManager.debugLogger.writeError(
+                        "Alternate Custom DLC cannot be applied to this mod as the biogame directory is not currently valid. User needs to set it and reload mod manager");
+                setFailedReason(
+                        "This mod requires a valid biogame directory due to using alternate custom dlc. Without a valid biogame directory, this mod will not know what parts are required on install. Fix the biogame directory and reload mod manager.");
+                return;
+            }
+        }
+
+        //Verify alternates and apply automatic ones
+        if (alternateFiles != null && alternateFiles.size() > 0 && !ignoreLoadErrors) {
+            ModManager.debugLogger.writeMessageConditionally("Verifying automatic alternate files are valid for this mod", ModManager.LOG_MOD_INIT);
+            HashMap<String, ArrayList<String>> autoOriginalFiles = new HashMap<String, ArrayList<String>>(); //header to altfiles map
+            for (AlternateFile af : alternateFiles) {
+                ModManager.debugLogger.writeMessageConditionally("Verifying " + af.getAltFile() + " on " + af.getCondition() + " of " + af.getConditionalDLC(),
+                        ModManager.LOG_MOD_INIT);
+                if (af.isValidLocally(modPath)) {
+                    //Verify pass
+                    String condition = af.getCondition();
+                    String modfile = af.getModFile();
+                    String task = af.getConditionalDLC();
+
+                    if (!condition.equals(AlternateFile.CONDITION_MANUAL)) {
+                        ArrayList<String> headerAlternates = autoOriginalFiles.get(task);
+                        if (headerAlternates != null) {
+                            if (headerAlternates.contains(modfile.toLowerCase())) {
+                                //auto alts cannot apply to the same thing
+                                ModManager.debugLogger.writeError("Automatic alternate files contains duplicate for same file: " + modfile);
+                                setFailedReason("This mod specifies automatic conditional changes for the following file in more than 1 instance: " + modfile
+                                        + "\n\nEach file in Mod Manager mods can only have 1 automatically applied conditional operation attached to it.");
+                                return;
+                            } else {
+                                headerAlternates.add(modfile.toLowerCase());
+                            }
+                        } else {
+                            ArrayList<String> alts = new ArrayList<>();
+                            alts.add(modfile.toLowerCase());
+                            autoOriginalFiles.put(task, alts);
+                        }
+                    }
+                    ModManager.debugLogger.writeMessageConditionally("Offical Task Alternate file specified: " + af.toString(), ModManager.LOG_MOD_INIT);
+                } else {
+                    ModManager.debugLogger.writeError("Invalid alternate file specified: " + af + ". Some pieces of required information may be missing.");
+                    setFailedReason("This mod contains an invalid alternate file specification:\n" + af);
+                    return;
+                }
+            }
+        }
+
+        //Resolve Official Alternates
+        if (modCMMVer >= 4.5 && !ignoreLoadErrors) { //modpath will be null if we are inspecting a compressed mod. So just ignore this step.
+            for (ModJob job : jobs) {
+                if (job.getJobType() == ModJob.CUSTOMDLC) {
+                    continue;
+                }
+                for (AlternateFile af : job.getAlternateFiles()) {
+                    String replacementFilePath = getModTaskPath(af.getModFile(), job.getJobName());
+                    String relativePath = ResourceUtils.getRelativePath(replacementFilePath, modPath, File.separator);
+                    relativePath = ResourceUtils.normalizeFilePath(relativePath, false);
+                    //af.setAltFile(relativePath);
+                }
+            }
+        }
+
+        generateModDisplayDescription();
+        ModManager.debugLogger.writeMessage("Finished loading moddesc.ini for " + getModName());
+        ModManager.debugLogger.writeMessageConditionally("-------MOD----------------END OF " + modName + "--------------------------", ModManager.LOG_MOD_INIT);
+    }
+
+    public ArrayList<ModDelta> getModDeltas() {
+        return modDeltas;
+    }
+
+    /**
+     * Gets the filepath's internal filename
+     *
+     * @param sfarFilePath path in sfar (or unpacked DLC)
+     * @return filename of passed in string
+     */
+    private String getSfarFilename(String sfarFilePath) {
+        StringTokenizer strok = new StringTokenizer(sfarFilePath, "/|\\");
+        String str = null;
+        while (strok.hasMoreTokens()) {
+            str = strok.nextToken();
+        }
+        // ModManager.debugLogger.writeMessage("SFAR Shortened filename: "+str);
+        return str;
+    }
+
+    /**
+     * Adds a task to this mod for when the mod is deployed.
+     *
+     * @param name
+     * @param newJob
+     */
+    public void addTask(String name, ModJob newJob) {
+        /*
+         * if (name.equals(ModType.COAL)) { modCoal = true;
+         * updateModifyString(ModType.COAL); return; }
+         */
+        if (!name.equals(ModTypeConstants.CUSTOMDLC)) {
+            updateModifyString(name);
+        }
+        jobs.add(newJob);
+
+    }
+
+    /**
+     * Updates the string showing what this mod edits in terms of files
+     *
+     * @param taskName name of task to modify (EARTH, Coalesced, etc)
+     */
+    private void updateModifyString(String taskName) {
+        if (modifyString.equals("")) {
+            modifyString = "\nModifies: " + taskName;
+        } else {
+            modifyString += ", " + taskName;
+        }
+    }
+
+    /**
+     * Returns mod's folder, with a / on the end
+     *
+     * @return
+     */
+    public String getModPath() {
+        return ModManager.appendSlash(modPath);
+    }
+
+    public String getModName() {
+        return modName;
+    }
+
+    /**
+     * Sets this mod description. It should be run through breakfixer() first.
+     *
+     * @param desc
+     */
+    public void setModDescription(String desc) {
+        this.modDescription = desc;
+    }
+
+    public void generateModDisplayDescription() {
+        modDisplayDescription = "This mod has no description in it's moddesc.ini file or there was an error reading the description of this mod.";
+        if (modDescFile == null) {
+            ModManager.debugLogger.writeMessage("Mod Desc file is null, unable to read description");
+            return;
+        }
+        modDisplayDescription = ResourceUtils.convertBrToNewline(modDescription);
+
+        modDisplayDescription += "\n=============================\n";
+
+        //Available deltas
+        if (modDeltas.size() > 0) {
+            modDisplayDescription += "Included Variants:\n";
+            for (ModDelta delta : modDeltas) {
+                modDisplayDescription += " - " + delta.getDeltaName();
+                modDisplayDescription += "\n";
+            }
+        }
+
+        if (hasAutomaticConfiguration()) {
+            modDisplayDescription += "This mod has been automatically configured for your game's current configuration.\n";
+        }
+
+        if (hasOptionalManualCustomDLC()) {
+            modDisplayDescription += "This mod contains alternate installation options. Access them through the mod utils menu.\n";
+        }
+
+        // Add modversion
+        if (modVersion != null) {
+            modDisplayDescription += "\nMod Version: " + modVersion;
+        }
+
+        // Add developer
+        if (modAuthor != null) {
+            modDisplayDescription += "\nMod Developer: " + modAuthor;
+        }
+
+        // Add developer
+        if (modIsUnofficial) {
+            modDisplayDescription += "\nThis mod was imported by Mod Manager using the ME3Tweaks Third Party Mod Identification Service.";
+        }
+
+        // Add mod manager build version
+        modDisplayDescription += "\nTargets Mod Manager " + modCMMVer;
+        if (modCMMVer > ModManager.MODDESC_VERSION_SUPPORT) {
+            modDisplayDescription += ", which is not fully supported by this version of Mod Manager. Update Mod Manager for full support.";
+        }
+        if (classicCode > 0) {
+            modDisplayDescription += "\nUpdate code: " + classicCode;
+        }
+
+        if (getSideloadOnlyTargets().size() > 0) {
+            modDisplayDescription += "\nFuture updates may require sideloading an update package";
+        }
+
+        // Add MP Changer
+        if (modmp != null) {
+            modDisplayDescription += "\nModifies Multiplayer: " + modmp;
+        }
+
+        // Add Modmaker
+        if (modmakerCode > 0) {
+            modDisplayDescription += "\nModMaker code: " + modmakerCode;
+        }
+
+        // Add modifier
+        modDisplayDescription += getModifyString();
+
+        //add required
+        if (requiredDLC.size() > 0) {
+            modDisplayDescription += "\nRequires DLC/Mods: ";
+
+            for (String str : requiredDLC) {
+                String dlcName = ME3TweaksUtils.getThirdPartyModName(str, true);
+                if (!dlcName.equals(str)) {
+                    dlcName += " (" + str + ")";
+                }
+                modDisplayDescription += "\n - " + dlcName;
+            }
+        }
+    }
+
+    private boolean hasAutomaticConfiguration() {
+        if (alternateCustomDLC.size() > 0) {
+            for (AlternateCustomDLC dlc : alternateCustomDLC) {
+                if (!dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL)) {
+                    return true;
+                }
+            }
+        }
+
+        if (alternateFiles.size() > 0) {
+            for (AlternateFile altfile : alternateFiles) {
+                if (!altfile.getCondition().equals(AlternateFile.CONDITION_MANUAL)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean hasOptionalManualCustomDLC() {
+        if (alternateCustomDLC.size() > 0) {
+            for (AlternateCustomDLC dlc : alternateCustomDLC) {
+                if (dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public String getModDisplayDescription() {
+        return modDisplayDescription;
+    }
+
+    public String getModDescription() {
+        return modDescription;
+    }
+
+    @Override
+    public String toString() {
+        return getModName();
+    }
+
+    public ModJob[] getJobs() {
+        return jobs.toArray(new ModJob[jobs.size()]);
+    }
+
+    public String getModifyString() {
+        for (ModJob job : jobs) {
+            if (job.getJobName().equals(ModTypeConstants.CUSTOMDLC)) {
+                String appendStr = " CUSTOMDLC (";
+                if (modifyString.equals("")) {
+                    appendStr = "\nModifies:" + appendStr;
+                } else {
+                    appendStr = "," + appendStr;
+                }
+                boolean first = true;
+                TreeSet<String> ss = new TreeSet<String>(job.getDestFolders());
+                for (String destFolder : ss) {
+                    if (destFolder.endsWith("CookedPCConsole")) {
+                        continue; //do not show this
+                    }
+                    if (first) {
+                        first = false;
+                    } else {
+                        appendStr += ", ";
+                    }
+                    appendStr += destFolder;
+                }
+                appendStr += ")";
+                modifyString += appendStr;
+                break;
+            }
+        }
+        return modifyString;
+    }
+
+    public boolean canMergeWith(Mod other) {
+        ModManager.debugLogger.writeMessage("Checking if mods can cleanly merge. Will report only first failure.");
+        for (ModJob job : jobs) {
+            ModJob otherCorrespondingJob = null;
+            for (ModJob otherjob : other.jobs) {
+                if (otherjob.equals(job)) {
+                    otherCorrespondingJob = otherjob;
+                    break;
+                }
+            }
+            if (otherCorrespondingJob == null) {
+                continue;
+            }
+            // scanned for matching job. Found it. Iterate over files...
+
+            //Compare my replace files to others replace/remove
+            for (String file : job.getFilesToReplaceTargets()) {
+                if (FilenameUtils.getName(file).equalsIgnoreCase("PCConsoleTOC.bin")) {
+                    continue;
+                }
+                ModManager.debugLogger.writeMessage("==Checking file for conflicts " + file + "==");
+
+                for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
+                    ModManager.debugLogger.writeMessage("Comparing replace files: " + file + " vs " + otherfile);
+                    if (file.equalsIgnoreCase(otherfile)) {
+                        ModManager.debugLogger.writeMessage("Merge conflicts with file to update " + file);
+                        return false;
+                    }
+                }
+                for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
+                    if (file.equalsIgnoreCase(otherfile)) {
+                        ModManager.debugLogger.writeMessage("Merge conflicts with file to update " + file);
+                        return false;
+                    }
+                }
+            }
+
+            //Compare my replace files to others replace/remove
+            for (String file : job.getFilesToRemoveTargets()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
+                    if (file.equalsIgnoreCase(otherfile)) {
+                        ModManager.debugLogger.writeMessage("Merge would add a task to remove a file requiring replace: " + file);
+                        return false;
+                    }
+                }
+            }
+
+            //compare files to add
+            for (String file : job.getFilesToAdd()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToAdd()) {
+                    if (file.equalsIgnoreCase(otherfile)) {
+                        ModManager.debugLogger.writeMessage("Merge conflicts with file to add " + file);
+                        return false;
+                    }
+                }
+            }
+
+            //Compare my add files to others remove
+            for (String file : job.getFilesToAddTargets()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
+                    if (file.equalsIgnoreCase(otherfile)) {
+                        ModManager.debugLogger.writeMessage("Merge conflicts with file to add/remove " + file);
+                        return false;
+                    }
+                }
+            }
+            for (String file : job.getFilesToRemoveTargets()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToAddTargets()) {
+                    if (file.equalsIgnoreCase(otherfile)) {
+                        ModManager.debugLogger.writeMessage("Merge conflicts with file to add/remove " + file);
+                        return false;
+                    }
+                }
+            }
+
+            //don't care about files to remove. I think...
+
+        }
+        ModManager.debugLogger.writeMessage("No conflicted detected.");
+        return true;
+    }
+
+    /**
+     * Gets the list of files that conflict with the specified mod, in terms of
+     * files to replace.
+     *
+     * @param other Other mod to compare against
+     * @return hashmap of job names mapped to a list of strings of conflicting
+     * file names
+     */
+    public HashMap<String, ArrayList<String>> getReplaceConflictsWithMod(Mod other) {
+        HashMap<String, ArrayList<String>> conflicts = new HashMap<String, ArrayList<String>>();
+        for (ModJob job : jobs) {
+            ModJob otherCorrespondingJob = null;
+            for (ModJob otherjob : other.jobs) {
+                if (otherjob.equals(job)) {
+                    otherCorrespondingJob = otherjob;
+                    break;
+                }
+            }
+            if (otherCorrespondingJob == null) {
+                continue;
+            }
+            // scanned for matching job. Found it. Iterate over files...
+            for (String file : job.getFilesToReplaceTargets()) {
+                if (FilenameUtils.getName(file).equalsIgnoreCase("PCConsoleTOC.bin")) {
+                    continue;
+                }
+                for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
+                    if (file.equals(otherfile)) {
+                        if (conflicts.containsKey(job.getJobName())) {
+                            conflicts.get(job.getJobName()).add(file);
+                            ModManager.debugLogger.writeMessage("ADDING TO CONFLICT LIST: " + file);
+                        } else {
+                            ArrayList<String> conflictFiles = new ArrayList<String>();
+                            conflictFiles.add(file);
+                            conflicts.put(job.getJobName(), conflictFiles);
+                        }
+                    }
+                }
+            }
+        }
+        if (conflicts.size() <= 0) {
+            return null;
+        }
+        return conflicts;
+    }
+
+    /**
+     * Creates a moddesc.ini string that should be written to a file that
+     * describes this mod object.
+     *
+     * @param keepUpdaterCode Keeps the classic update code
+     * @param cmmVersion      Version of moddesc to write to file
+     * @return moddesc.ini file as a string
+     */
+    public String createModDescIni(boolean keepUpdaterCode, double cmmVersion) {
+        // Write mod descriptor file
+        try {
+            Wini ini = new Wini();
+
+            // put modmanager, modinfo
+            ini.put("ModManager", "cmmver", cmmVersion);
+            ini.put("ModInfo", "modname", modName);
+            ini.put("ModInfo", "moddev", modAuthor);
+            if (modDescription != null) {
+                ini.put("ModInfo", "moddesc", ResourceUtils.convertNewlineToBr(modDescription));
+            }
+            if (modVersion != null) {
+                ini.put("ModInfo", "modver", modVersion);
+            }
+            if (modmp != null) {
+                ini.put("ModInfo", "modmp", modmp);
+            }
+            if (modSite != null) {
+                ini.put("ModInfo", "modsite", modSite);
+            }
+            if (modmakerCode > 0) {
+                ini.put("ModInfo", "modid", Integer.toString(modmakerCode));
+            }
+            if (compiledAgainstModmakerVersion > 0) {
+                ini.put("ModInfo", "compiledagainst", Double.toString(compiledAgainstModmakerVersion));
+            }
+            if (keepUpdaterCode && isME3TweaksUpdatable()) {
+                if (getClassicUpdateCode() > 0) {
+                    ini.put("ModInfo", "updatecode", getClassicUpdateCode());
+                } else {
+                    ini.put("ModInfo", "me3tweaksid", getModMakerCode());
+                }
+            }
+
+            for (ModJob job : jobs) {
+                boolean isFirst = true;
+                if (job.getRequirementText() != null && !job.getRequirementText().equals("")) {
+                    ini.put(job.getJobName(), "jobdescription", job.getRequirementText());
+                }
+
+                if (job.getJobType() == ModJob.CUSTOMDLC) {
+                    StringBuilder sfsb = new StringBuilder();
+                    StringBuilder dfsb = new StringBuilder();
+
+                    //source dirs
+                    for (String file : job.getSourceFolders()) {
+                        if (isFirst) {
+                            isFirst = false;
+                        } else {
+                            sfsb.append(";");
+                        }
+                        sfsb.append(FilenameUtils.getName(file));
+                    }
+                    isFirst = true;
+                    //dest dirs
+                    for (String file : job.getDestFolders()) {
+                        if (isFirst) {
+                            isFirst = false;
+                        } else {
+                            dfsb.append(";");
+                        }
+                        dfsb.append(FilenameUtils.getName(file));
+                    }
+
+                    ini.put(job.getJobName(), "sourcedirs", sfsb.toString());
+                    ini.put(job.getJobName(), "destdirs", dfsb.toString());
+                    continue; //skip dlc,basegame on this pass
+                }
+
+                ini.put(job.getJobName(), "moddir", getStandardFolderName(job.getJobName()));
+                StringBuilder nfsb = new StringBuilder();
+                //new files list
+                isFirst = true;
+                for (String file : job.getFilesToReplace()) {
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        nfsb.append(";");
+                    }
+                    nfsb.append(FilenameUtils.getName(file));
+                }
+
+                //replace files list
+                isFirst = true;
+                StringBuilder rfsb = new StringBuilder();
+                for (String file : job.getFilesToReplaceTargets()) {
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        rfsb.append(";");
+                    }
+                    rfsb.append(file);
+                }
+
+                //add files list
+                isFirst = true;
+                StringBuilder afsb = new StringBuilder();
+                for (String file : job.getFilesToAdd()) {
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        afsb.append(";");
+                    }
+                    afsb.append(FilenameUtils.getName(file));
+                }
+
+                //addfilestargets files list
+                isFirst = true;
+                StringBuilder aftsb = new StringBuilder();
+                for (String file : job.getFilesToAddTargets()) {
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        aftsb.append(";");
+                    }
+                    aftsb.append(file);
+                }
+
+                //removefiles list
+                isFirst = true;
+                StringBuilder rftsb = new StringBuilder();
+                for (String file : job.getFilesToRemoveTargets()) {
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        rftsb.append(";");
+                    }
+                    rftsb.append(file);
+                }
+
+                //DLC, basegame
+                ini.put(job.getJobName(), "newfiles", nfsb.toString());
+                ini.put(job.getJobName(), "replacefiles", rfsb.toString());
+
+                if (job.getFilesToAdd().size() > 0) {
+                    ini.put(job.getJobName(), "addfiles", afsb.toString());
+                }
+
+                if (job.getFilesToAddTargets().size() > 0) {
+                    ini.put(job.getJobName(), "addfilestargets", aftsb.toString());
+                }
+
+                if (job.getFilesToRemoveTargets().size() > 0) {
+                    ini.put(job.getJobName(), "removefilestargets", rftsb.toString());
+                }
+            }
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            ini.store(os);
+            return new String(os.toByteArray(), "ASCII");
+        } catch (Exception e) {
+            ModManager.debugLogger.writeError("Error saving message!");
+            ModManager.debugLogger.writeException(e);
+        }
+        return "Failed to write new moddesc.ini file";
+    }
+
+    /**
+     * Gets the standard folder name a mod uses for a module. Essentially is a
+     * Header => Internal converter
+     *
+     * @param header
+     * @return
+     */
+    public static String getStandardFolderName(String header) {
+        switch (header) {
+            case "BASEGAME":
+                return "BASEGAME";
+            case "RESURGENCE":
+                return "MP1";
+            case "REBELLION":
+                return "MP2";
+            case "EARTH":
+                return "MP3";
+            case "RETALIATION":
+                return "MP4";
+            case "RECKONING":
+                return "MP5";
+            case "PATCH1":
+                return "PATCH1";
+            case "PATCH2":
+                return "PATCH2";
+            case "TESTPATCH":
+                return "TESTPATCH";
+            case "FROM_ASHES":
+                return "FROM_ASHES";
+            case "EXTENDED_CUT":
+                return "EXTENDED_CUT";
+            case "LEVIATHAN":
+                return "LEVIATHAN";
+            case "OMEGA":
+                return "OMEGA";
+            case "CITADEL":
+                return "CITADEL";
+            case "CITADEL_BASE":
+                return "CITADEL_BASE";
+            case "APPEARANCE":
+                return "APPEARANCE";
+            case "FIREFIGHT":
+                return "FIREFIGHT";
+            case "GROUNDSIDE":
+                return "GROUNDSIDE";
+            case "GENESIS2":
+                return "GENESIS2";
+            case "CUSTOMDLC":
+                return "CUSTOMDLC";
+            case "BALANCE_CHANGES":
+                return "BALANCE_CHANGES";
+            default:
+                return "UNKNOWN_DEFAULT_FOLDER";
+        }
+    }
+
+    /**
+     * Creates a new mod package in a folder with the same name as this mod.
+     * Copies files to the new directory based on the name of this mod. Creates
+     * a moddesc.ini file based on jobs in this mod.
+     *
+     * @param otherMergingMod Other mod this one is merging with. This can be null. This is
+     *                        used to find the Custom DLC directory to copy to the new mod
+     *                        if one isn't present for this mod.
+     */
+    public Mod createNewMod(Mod otherMergingMod) {
+        printModContents();
+        File modFolder = new File(ModManager.getModsDir() + modName);
+        modFolder.mkdirs();
+        for (ModJob job : jobs) {
+            if (job.getJobType() == ModJob.CUSTOMDLC) {
+                for (String sourceFolder : job.getSourceFolders()) {
+                    try {
+                        File srcFolder = new File(ModManager.appendSlash(modDescFile.getParentFile().getAbsolutePath()) + sourceFolder);
+                        if (!srcFolder.exists() && otherMergingMod != null) {
+                            //may be in other mod as we haven't copied it yet and we don't use file pointers here (folder names)
+                            srcFolder = new File(ModManager.appendSlash(otherMergingMod.modDescFile.getParentFile().getAbsolutePath()) + sourceFolder);
+                        }
+                        File destFolder = new File(modFolder + File.separator + sourceFolder); //source folder is a string
+                        ModManager.debugLogger.writeMessage("Copying custom DLC folder: " + srcFolder.getAbsolutePath() + " to " + destFolder.getAbsolutePath());
+                        FileUtils.copyDirectory(srcFolder, destFolder);
+                    } catch (IOException e) {
+                        ModManager.debugLogger.writeMessage("IOException while merging mods (custom DLC).");
+                        ModManager.debugLogger.writeException(e);
+                    }
+                }
+                continue;
+            }
+
+            File moduleDir = new File(modFolder + File.separator + getStandardFolderName(job.getJobName()));
+            moduleDir.mkdirs();
+            // scanned for matching job. Found it. Iterate over files...
+            //Copy files to replace
+            for (String mergefile : job.getFilesToReplace()) {
+                File file = new File(mergefile);
+                String baseName = FilenameUtils.getName(mergefile);
+                try {
+                    File destinationFile = new File(moduleDir + File.separator + baseName);
+                    ModManager.debugLogger.writeMessage("Copying to new mod folder: " + file.getAbsolutePath() + " to " + destinationFile.getAbsolutePath());
+                    FileUtils.copyFile(file, destinationFile);
+                } catch (IOException e) {
+                    ModManager.debugLogger.writeMessage("IOException while merging mods.");
+                    ModManager.debugLogger.writeException(e);
+                }
+                ModManager.debugLogger.writeMessage(job.getJobName() + ": " + file);
+            }
+            //copy files to add
+            for (String mergefile : job.getFilesToAdd()) {
+                File file = new File(mergefile);
+                String baseName = FilenameUtils.getName(mergefile);
+                try {
+                    File destinationFile = new File(moduleDir + File.separator + baseName);
+                    ModManager.debugLogger.writeMessage("Copying to new mod folder: " + file.getAbsolutePath() + " to " + destinationFile.getAbsolutePath());
+                    FileUtils.copyFile(file, destinationFile);
+                } catch (IOException e) {
+                    ModManager.debugLogger.writeMessage("IOException while merging mods.");
+                    ModManager.debugLogger.writeException(e);
+                }
+                ModManager.debugLogger.writeMessage(job.getJobName() + ": " + file);
+            }
+        }
+
+        //COPY DELTAS
+        if (modDeltas.size() > 0) {
+            File dir = new File(modFolder + File.separator + DELTAS_FOLDER);
+            dir.mkdirs();
+            for (ModDelta delta : modDeltas) {
+                try {
+                    FileUtils.copyFile(new File(delta.getDeltaFilepath()), new File(dir + File.separator + FilenameUtils.getName(delta.getDeltaFilepath())));
+                } catch (IOException e) {
+                    ModManager.debugLogger.writeErrorWithException("Unable to copy delta:", e);
+                }
+            }
+        }
+
+        try {
+            ModManager.debugLogger.writeMessage("Creating moddesc.ini...");
+            FileUtils.writeStringToFile(new File(modFolder + File.separator + "moddesc.ini"), createModDescIni(false, modCMMVer));
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            ModManager.debugLogger.writeMessage("IOException while merging mods.");
+            ModManager.debugLogger.writeException(e);
+            e.printStackTrace();
+        }
+        Mod newMod = new Mod(modFolder + File.separator + "moddesc.ini");
+        for (ModDelta delta : newMod.getModDeltas()) {
+            new DeltaWindow(newMod, delta, true, true);
+        }
+        if (newMod.isValidMod()) {
+            new AutoTocWindow(newMod, AutoTocWindow.LOCALMOD_MODE, ModManagerWindow.GetBioGameDir());
+        } else {
+            return null;
+        }
+        return newMod;
+    }
+
+    private void printModContents() {
+        ModManager.debugLogger.writeMessage("========" + modName + "========");
+        for (ModJob job : jobs) {
+            if (job.getJobType() == ModJob.CUSTOMDLC) {
+                for (String sourceFolder : job.getSourceFolders()) {
+                    ModManager.debugLogger.writeMessage(job.getJobName() + ": " + sourceFolder);
+                }
+                continue;
+            }
+            for (String sourceFile : job.getFilesToAdd()) {
+                ModManager.debugLogger.writeMessage(job.getJobName() + ": " + sourceFile);
+            }
+        }
+    }
+
+    public void setModName(String modName) {
+        this.modName = modName;
+    }
+
+    @Override
+    public int compareTo(Mod other) {
+        if (!validMod) {
+            return -1;
+        }
+        return getModName().toLowerCase().compareTo(other.getModName().toLowerCase());
+    }
+
+    /**
+     * Checks if this mod has a job for custom DLC
+     *
+     * @return true if contains custom DLC job, false otherwise
+     */
+    public boolean containsCustomDLCJob() {
+        if (modCMMVer < 3.1) {
+            return false;
+        }
+        for (ModJob job : jobs) {
+            if (job.getJobType() == ModJob.CUSTOMDLC) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to parse the mod version from the CMM string If it fails it
+     * returns a 0
+     *
+     * @return
+     */
+    public double getVersion() {
+        if (modVersion == null) {
+            return 0;
+        }
+        try {
+            return Double.parseDouble(modVersion);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    public int getClassicUpdateCode() {
+        if (classicCode <= 0) {
+            return 0;
+        }
+
+        return classicCode;
+    }
+
+    public int getModMakerCode() {
+        return modmakerCode;
+    }
+
+    public String getDescFile() {
+        return getModPath() + "moddesc.ini";
+    }
+
+    public double getCMMVer() {
+        return modCMMVer;
+    }
+
+    /**
+     * Returns if this mod is able to check for updates on ME3Tweaks
+     *
+     * @return true if classic and has update code, or has modmaker code and
+     * version > 0
+     */
+    public boolean isME3TweaksUpdatable() {
+        if ((getClassicUpdateCode() > 0 || getModMakerCode() > 0) && getVersion() > 0) {
+            return true;
+        }
+        return false;
+    }
+
+    public String getAuthor() {
+        return modAuthor;
+    }
+
+    public void setModUpdateCode(int i) {
+        classicCode = i;
+    }
+
+    public void setVersion(double i) {
+        modVersion = Double.toString(i);
+    }
+
+    /**
+     * Returns true if this mod has a job that modifies the basegame coalesced
+     *
+     * @return true if basegame coal is swapped, false otherwise
+     */
+    public boolean modifiesBasegameCoalesced() {
+        for (ModJob job : jobs) {
+            if (job.getJobName() == ModTypeConstants.COAL) {
+                return true;
+            }
+            for (String file : job.filesToReplaceTargets) {
+                file = file.replaceAll("\\\\", "/"); //make sure all are the same (since the yall work)
+                if (file.toLowerCase().equals("/BIOGame/CookedPCConsole/Coalesced.bin".toLowerCase())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets this mods basegame coalesced file it will install.
+     *
+     * @return new basegame coalesced file, or null if this mod does not specify
+     * one
+     */
+    public String getBasegameCoalesced() {
+        return getModTaskPath("\\BIOGame\\CookedPCConsole\\Coalesced.bin", ModTypeConstants.BASEGAME);
+    }
+
+    /**
+     * Searches through all jobs for the specified path. Uses a module ID
+     * (header) to find a job.
+     *
+     * @return path to new file if found, null if it does't exist.
+     */
+    public String getModTaskPath(String modulePath, String header) {
+        if (header.equals(ModTypeConstants.COAL)) {
+            header = ModTypeConstants.BASEGAME;
+            modulePath = "\\BIOGame\\CookedPCConsole\\Coalesced.bin";
+        }
+        modulePath = modulePath.replaceAll("\\\\", "/");
+        if (!modulePath.startsWith("/")) {
+            modulePath = "/" + modulePath;
+        }
+        for (ModJob job : jobs) {
+            if (!job.getJobName().equals(header)) {
+                continue;
+            }
+            for (int i = 0; i < job.filesToReplaceTargets.size(); i++) {
+                String file = job.filesToReplaceTargets.get(i);
+                file = file.replaceAll("\\\\", "/"); //make sure all are the same (since the yall work)
+                if (!file.startsWith("/")) {
+                    file = "/" + file;
+                }
+                if (file.toLowerCase().equals(modulePath.toLowerCase())) {
+                    return job.filesToReplace.get(i);
+                }
+            }
+        }
+        return null;
+    }
+
+    public ArrayList<Patch> getRequiredPatches() {
+        return requiredPatches;
+    }
+
+    public void setRequiredPatches(ArrayList<Patch> requiredPatches) {
+        this.requiredPatches = requiredPatches;
+    }
+
+    public boolean isValidMod() {
+        return validMod;
+    }
+
+    private void setValidMod(boolean validMod) {
+        this.validMod = validMod;
+    }
+
+    /**
+     * Checks for conflicts with the other mod pertaining to add/replace.
+     *
+     * @param other
+     * @return Hashmap of job names mapping to a list of targets that conflict
+     */
+    public HashMap<String, ArrayList<String>> getAddRemoveConflictsWithMod(Mod other) {
+        HashMap<String, ArrayList<String>> conflicts = new HashMap<String, ArrayList<String>>();
+        for (ModJob job : jobs) {
+            ModJob otherCorrespondingJob = null;
+            for (ModJob otherjob : other.jobs) {
+                if (otherjob.equals(job)) {
+                    otherCorrespondingJob = otherjob;
+                    break;
+                }
+            }
+            if (otherCorrespondingJob == null) {
+                continue;
+            }
+
+            // scanned for matching job. Found it. Iterate over files...
+            for (String file : job.getFilesToAddTargets()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
+                    if (file.equals(otherfile)) {
+                        if (conflicts.containsKey(job.getJobName())) {
+                            conflicts.get(job.getJobName()).add(file);
+                            ModManager.debugLogger.writeMessage("ADDING TO ADDREMOVE CONFLICT LIST: " + file);
+                        } else {
+                            ArrayList<String> conflictFiles = new ArrayList<String>();
+                            conflictFiles.add(file);
+                            conflicts.put(job.getJobName(), conflictFiles);
+                            ModManager.debugLogger.writeMessage("ADDING TO ADDREMOVE CONFLICT LIST: " + file);
+                        }
+                    }
+                }
+            }
+
+            //versa
+            for (String file : job.getFilesToRemoveTargets()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToAddTargets()) {
+                    if (file.equals(otherfile)) {
+                        if (conflicts.containsKey(job.getJobName())) {
+                            conflicts.get(job.getJobName()).add(file);
+                            ModManager.debugLogger.writeMessage("ADDING TO ADDREMOVE CONFLICT LIST: " + file);
+                        } else {
+                            ArrayList<String> conflictFiles = new ArrayList<String>();
+                            conflictFiles.add(file);
+                            conflicts.put(job.getJobName(), conflictFiles);
+                        }
+                    }
+                }
+            }
+        }
+        if (conflicts.size() <= 0) {
+            return null;
+        }
+        return conflicts;
+    }
+
+    /**
+     * Checks for conflicts with the other mod pertaining to remove/replace.
+     *
+     * @param other
+     * @return Hashmap of job names mapping to a list of targets that conflict
+     */
+    public HashMap<String, ArrayList<String>> getReplaceRemoveConflictsWithMod(Mod other) {
+        HashMap<String, ArrayList<String>> conflicts = new HashMap<String, ArrayList<String>>();
+        for (ModJob job : jobs) {
+            ModJob otherCorrespondingJob = null;
+            for (ModJob otherjob : other.jobs) {
+                if (otherjob.equals(job)) {
+                    otherCorrespondingJob = otherjob;
+                    break;
+                }
+            }
+            if (otherCorrespondingJob == null) {
+                continue;
+            }
+            // scanned for matching job. Found it. Iterate over files...
+            for (String file : job.getFilesToReplaceTargets()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToRemoveTargets()) {
+                    if (file.equals(otherfile)) {
+                        if (conflicts.containsKey(job.getJobName())) {
+                            conflicts.get(job.getJobName()).add(file);
+                            ModManager.debugLogger.writeMessage("ADDING TO REPLACEREMOVE CONFLICT LIST: " + file);
+                        } else {
+                            ArrayList<String> conflictFiles = new ArrayList<String>();
+                            conflictFiles.add(file);
+                            conflicts.put(job.getJobName(), conflictFiles);
+                        }
+                    }
+                }
+            }
+
+            //versa
+            for (String file : job.getFilesToRemoveTargets()) {
+                for (String otherfile : otherCorrespondingJob.getFilesToReplaceTargets()) {
+                    if (file.equals(otherfile)) {
+                        if (conflicts.containsKey(job.getJobName())) {
+                            conflicts.get(job.getJobName()).add(file);
+                            ModManager.debugLogger.writeMessage("ADDING TO REPLACEREMOVE CONFLICT LIST: " + file);
+                        } else {
+                            ArrayList<String> conflictFiles = new ArrayList<String>();
+                            conflictFiles.add(file);
+                            conflicts.put(job.getJobName(), conflictFiles);
+                        }
+                    }
+                }
+            }
+        }
+        if (conflicts.size() <= 0) {
+            return null;
+        }
+        return conflicts;
+    }
+
+    /**
+     * Finds a source file using the specified target file
+     *
+     * @param targetFile target to find match
+     * @param useReplace search replacements. Otherwise search adds
+     * @return null if not found (should not occur!) or the string source path
+     */
+    public String findTargetSourceFileFromJob(boolean useReplace, ModJob job, String targetFile) {
+        ArrayList<String> sourceList = useReplace ? job.getFilesToReplace() : job.getFilesToAdd();
+        ArrayList<String> targetList = useReplace ? job.getFilesToReplaceTargets() : job.getFilesToAddTargets();
+
+        for (int i = 0; i < sourceList.size(); i++) {
+            if (targetList.get(i).equals(targetFile)) {
+                return sourceList.get(i);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets a modjob from this mod by the name (ModType)
+     *
+     * @param moduleName module job to return
+     * @return null if not found, job otherwise
+     */
+    public ModJob getJobByModuleName(String moduleName) {
+        for (ModJob job : jobs) {
+            if (job.getJobName().equals(moduleName)) {
+                return job;
+            }
+        }
+        return null;
+    }
+
+    public void setAuthor(String modAuthor) {
+        this.modAuthor = modAuthor;
+    }
+
+    public void setSite(String modSite) {
+        this.modSite = modSite;
+    }
+
+    public String getModSite() {
+        return modSite;
+    }
+
+    public String getFailedReason() {
+        return failedReason;
+    }
+
+    public void setFailedReason(String failedReason) {
+        setValidMod(false);
+        this.failedReason = failedReason;
+    }
+
+    public void setModPath(String modPath) {
+        this.modPath = modPath;
+    }
+
+    public ArrayList<String> getSideloadOnlyTargets() {
+        return sideloadOnlyTargets;
+    }
+
+    public void setSideloadOnlyTargets(ArrayList<String> sideloadOnlyTargets) {
+        this.sideloadOnlyTargets = sideloadOnlyTargets;
+    }
+
+    public String getSideloadURL() {
+        return sideloadURL;
+    }
+
+    public void setSideloadURL(String sideloadURL) {
+        this.sideloadURL = sideloadURL;
+    }
+
+    /**
+     * Processes alternate DLC specifications and will add them into this mod as
+     * necessary
+     *
+     * @return true if all were added OK. False if any failed.
+     */
+    public boolean addCustomDLCAlternates(String biogamedir) {
+        if (alternateFiles.size() > 0 && ModManagerWindow.validateBIOGameDir()) {
+            boolean altApplied = false;
+            ModManager.debugLogger.writeMessageConditionally(
+                    getModName() + ": Checking automatic alternate custom dlc list to see if applicable and will apply if conditions are right", ModManager.LOG_MOD_INIT);
+            //get list of installed DLC
+            ArrayList<String> installedDLC = ModManager.getInstalledDLC(biogamedir);
+            HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
+            ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
+
+            for (AlternateCustomDLC altdlc : alternateCustomDLC) {
+                ModManager.debugLogger.writeMessageConditionally("Checking if Alternate DLC applies: " + altdlc, ModManager.LOG_MOD_INIT);
+                String condition = altdlc.getCondition();
+                String conditionaldlc = altdlc.getConditionalDLC();
+                ArrayList<String> conditionaldlcs = altdlc.getConditionalDLCList();
+                if (conditionaldlcs != null && conditionaldlcs.size() > 0) {
+                    //MULTI DLC
+                    ArrayList<String> remappedHeaders = new ArrayList<String>();
+                    for (String dlcpart : conditionaldlcs) { //for all dlc in the list
+                        if (!installedDLC.contains(dlcpart)) { //if installed dlc does not contain this (e.g. CITADEL vs DLC_EXP_Pack003)
+                            //check if its an official dlc header...
+                            if (officialDLCHeaders.contains(dlcpart)) {
+                                //convert to dlc folder name
+                                String fname = headerFolderMap.get(dlcpart);
+                                if (fname != null) {
+                                    remappedHeaders.add(fname.toUpperCase()); //Remap CITADEL To DLC_EXP_Pack003, etc.
+                                } else {
+                                    //remappedHeaders.add(dlcpart);
+                                    ModManager.debugLogger
+                                            .writeError("[alt dlc application] Alt dlc specifies non-existent Custom DLC/Mod Manager Header, this shouldn't really be possible. "
+                                                    + conditionaldlc);
+                                }
+                            }
+                        } else {
+                            remappedHeaders.add(dlcpart.toUpperCase());
+                        }
+                    }
+
+                    switch (condition) {
+                        case AlternateCustomDLC.CONDITION_ALL_DLC_PRESENT:
+                            if (installedDLC.containsAll(remappedHeaders)) {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as all DLC in condition is present: " + altdlc,
+                                        ModManager.LOG_MOD_INIT);
+                                ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
+                                applyAlternateDLCOperation(job, altdlc);
+                                altApplied = true;
+
+                            } else {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable at least one DLC in condition is not present: " + altdlc,
+                                        ModManager.LOG_MOD_INIT);
+                            }
+                            break;
+                        case AlternateCustomDLC.CONDITION_ANY_DLC_NOT_PRESENT:
+                            if (!installedDLC.containsAll(remappedHeaders)) {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as at least one DLC in condition are not present: " + altdlc,
+                                        ModManager.LOG_MOD_INIT);
+                                ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
+                                applyAlternateDLCOperation(job, altdlc);
+                                altApplied = true;
+                            } else {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable as all DLC in condition are present: " + altdlc,
+                                        ModManager.LOG_MOD_INIT);
+                            }
+                            break;
+                        default:
+                            ModManager.debugLogger.writeError("Unknown CustomDLC condition: " + condition);
+                            break;
+                    }
+                } else {
+                    //SINGLE DLC
+                    if (!installedDLC.contains(conditionaldlc)) {
+                        //check if its an official dlc header...
+                        if (officialDLCHeaders.contains(conditionaldlc)) {
+                            //convert to dlc folder name
+                            String fname = headerFolderMap.get(conditionaldlc);
+                            if (fname != null) {
+                                conditionaldlc = fname;
+                            } else {
+                                ModManager.debugLogger.writeError("[alt dlc application] Alt dlc specifies non-existent Custom DLC/Mod Manager Header: " + conditionaldlc);
+                                continue;
+                            }
+                        }
+                    }
+                    switch (condition) {
+                        case AlternateCustomDLC.CONDITION_DLC_NOT_PRESENT:
+                            if (!installedDLC.contains(conditionaldlc.toUpperCase())) {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as " + conditionaldlc + " is not present",
+                                        ModManager.LOG_MOD_INIT);
+                                ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
+                                applyAlternateDLCOperation(job, altdlc);
+                                altApplied = true;
+                            } else {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable as " + conditionaldlc + " is present",
+                                        ModManager.LOG_MOD_INIT);
+                            }
+                            break;
+                        case AlternateCustomDLC.CONDITION_DLC_PRESENT:
+                            if (installedDLC.contains(conditionaldlc.toUpperCase())) {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is applicable as " + conditionaldlc + " is present", ModManager.LOG_MOD_INIT);
+                                ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
+                                applyAlternateDLCOperation(job, altdlc);
+                                altApplied = true;
+                            } else {
+                                ModManager.debugLogger.writeMessageConditionally(" > Custom DLC Alternate is not applicable as " + conditionaldlc + " is not present",
+                                        ModManager.LOG_MOD_INIT);
+                            }
+                            break;
+                    }
+                }
+            }
+            return altApplied;
+        } else {
+            return false; //no operations performed
+        }
+    }
+
+    private void applyAlternateDLCOperation(ModJob job, AlternateCustomDLC altdlc) {
+        File sf = new File(getModPath() + altdlc.getAltDLC());
+        String destdlc = altdlc.getDestDLC();
+        switch (altdlc.getOperation()) {
+            case AlternateCustomDLC.OPERATION_ADD_FILES_TO_CUSTOMDLC_FOLDER:
+                ModManager.debugLogger.writeMessageConditionally("Condition match, adding additional layer for DLC folder: " + altdlc.getDestDLC(), ModManager.LOG_MOD_INIT);
+                job.getSourceFolders().add(altdlc.getAltDLC());
+                job.getDestFolders().add(altdlc.getDestDLC());
+                List<File> sourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+                for (File file : sourceFiles) {
+                    String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
+                    String destFilePath = ModManager.appendSlash(destdlc) + relativePath;
+                    if (!(job.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath(), false), ResourceUtils.normalizeFilePath(destFilePath, false), ignoreLoadErrors, true)
+                            && !ignoreLoadErrors)) {
+                        setFailedReason("Mod specifies a CUSTOMDLC header, but an Alternate DLC operation failed to apply: " + altdlc
+                                + ". The issue occurred when attempting to add the file " + file + " to the mod.");
+                        ModManager.debugLogger.writeError("Failed to add file to replace with ALTERNATE CUSTOM DLC (File likely does not exist), marking as invalid.");
+                        return;
+                    } else {
+                        appliedAutomaticAlternateCustomDLC.add(altdlc);
+                    }
+                }
+                break;
+            case AlternateCustomDLC.OPERATION_ADD_CUSTOMDLC_JOB:
+                ModManager.debugLogger.writeMessageConditionally("Condition match, adding custom DLC folder: " + altdlc.getDestDLC(), ModManager.LOG_MOD_INIT);
+                job.getSourceFolders().add(altdlc.getAltDLC());
+                job.getDestFolders().add(altdlc.getDestDLC());
+                List<File> addsourceFiles = (List<File>) FileUtils.listFiles(sf, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+                for (File file : addsourceFiles) {
+                    String relativePath = ResourceUtils.getRelativePath(file.getAbsolutePath(), sf.getAbsolutePath(), File.separator);
+                    String destFilePath = ModManager.appendSlash(destdlc) + relativePath;
+                    if (!(job.addFileReplace(ResourceUtils.normalizeFilePath(file.getAbsolutePath(), false), ResourceUtils.normalizeFilePath(destFilePath, false), ignoreLoadErrors, false)
+                            && !ignoreLoadErrors)) {
+                        setFailedReason("Mod specifies a CUSTOMDLC header, but an Alternate DLC operation failed to apply: " + altdlc
+                                + ". The issue occured when attempting to add the file in an additional DLC to the mod: " + file + ".");
+                        ModManager.debugLogger.writeError("Failed to add file to replace with ADD ALTERNATE CUSTOM DLC (File likely does not exist), marking as invalid.");
+                        return;
+                    } else {
+                        appliedAutomaticAlternateCustomDLC.add(altdlc);
+                    }
+                }
+                break;
+        }
+    }
+
+    /**
+     * Applies automatic alternate files to this mod
+     *
+     * @param biogamedir biogame directory
+     */
+    public boolean applyAutomaticAlternates(String biogamedir) {
+        if (alternateFiles.size() > 0) {
+            boolean altApplied = false;
+            ModManager.debugLogger.writeMessageConditionally(getModName() + ": Checking automatic alternate files list to see if applicable and will apply if conditions are right",
+                    ModManager.LOG_MOD_INIT);
+            //get list of installed DLC
+            ArrayList<String> installedDLC = ModManager.getInstalledDLC(biogamedir);
+            ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
+
+            for (AlternateFile af : alternateFiles) {
+                ModManager.debugLogger.writeMessageConditionally("Checking if Alt file applies: " + af, ModManager.LOG_MOD_INIT);
+                String condition = af.getCondition();
+                String conditionaldlc = af.getConditionalDLC();
+                if (!installedDLC.contains(conditionaldlc)) {
+                    //check if its a header...
+                    if (officialDLCHeaders.contains(conditionaldlc)) {
+                        //convert to dlc name
+                        HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
+                        String fname = headerFolderMap.get(conditionaldlc);
+                        if (fname != null) {
+                            conditionaldlc = fname;
+                        } else {
+                            ModManager.debugLogger.writeError("[alt file application] Alt file specifies non-existent Custom DLC/Mod Manager Header: " + conditionaldlc);
+                            continue;
+                        }
+                    }
+                }
+
+                switch (condition) {
+                    case AlternateFile.CONDITION_DLC_NOT_PRESENT:
+                        if (!installedDLC.contains(conditionaldlc.toUpperCase())) {
+                            ModJob job = null;
+                            if (officialDLCHeaders.contains(conditionaldlc)) {
+                                //official DLC task
+                                job = getJobByModuleName(conditionaldlc);
+                            } else {
+                                //custom dlc task
+                                job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
+                            }
+                            applyAlternateFileOperation(job, af);
+                            altApplied = true;
+                        }
+                        break;
+                    case AlternateFile.CONDITION_DLC_PRESENT:
+                        if (installedDLC.contains(conditionaldlc.toUpperCase())) {
+                            ModJob job = null;
+                            if (officialDLCHeaders.contains(conditionaldlc)) {
+                                //official DLC task
+                                job = getJobByModuleName(conditionaldlc);
+                            } else {
+                                //custom dlc task
+                                job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
+                            }
+                            applyAlternateFileOperation(job, af);
+                            altApplied = true;
+                        }
+                        break;
+                }
+            }
+            return altApplied;
+        } else {
+            return false; //no operations performed
+        }
+    }
+
+    private void applyAlternateFileOperation(ModJob job, AlternateFile af) {
+        switch (af.getOperation()) {
+            case AlternateFile.OPERATION_INSTALL:
+                //add file to task
+                if (job.getFilesToReplace().contains(getModPath() + af.getAltFile())) {
+                    return; //file to replace already exists, user may have already applied mod in session.
+                }
+                ModManager.debugLogger.writeMessage("Condition match, " + af.getModFile() + " will now install new file " + af.getAltFile());
+                job.getFilesToReplace().add(getModPath() + af.getAltFile());
+                job.getFilesToReplaceTargets().add(af.getModFile());
+                break;
+            case AlternateFile.OPERATION_NOINSTALL:
+                ModManager.debugLogger.writeMessage("Condition match, will no longer modify " + af.getModFile());
+                String fileToRemovePath = af.getModFile();
+                if (fileToRemovePath.charAt(0) == '/' || fileToRemovePath.charAt(0) == '\\') {
+                    fileToRemovePath = fileToRemovePath.substring(1);
+                }
+
+                String fileToRemoveTarget = ResourceUtils.normalizeFilePath(af.getModFile(), false);
+                int indexToRemove = job.getFilesToReplaceTargets().indexOf(fileToRemoveTarget);
+
+                job.getFilesToReplaceTargets().remove(indexToRemove);
+                job.getFilesToReplace().remove(indexToRemove);
 
 /*			String fileToRemove = ResourceUtils.normalizeFilePath(getModPath() + af.get fileToRemovePath, false);
 			/*
@@ -2445,158 +2428,226 @@ public class Mod implements Comparable<Mod> {
 				ModManager.debugLogger.writeError(
 						"Application of NO_INSTALL has caused mod to become invalid as one of the replace files lists didn't contain the correct values to remove, but the other one did.");
 			}*/
-			break;
-		case AlternateFile.OPERATION_SUBSTITUTE:
-			int index = job.getFilesToReplaceTargets().indexOf(af.getModFile());
-			if (modCMMVer <= 4.5) {
-				if (af.getSubstituteFile() != null) { //Substitute on OFFICIAL HEADERS - moddesc 4.5 only.
-					ModManager.debugLogger.writeMessage("Condition match, (ModDesc 4.5 backcompat) repointing " + af.getModFile() + " to use " + af.getSubstituteFile());
-					job.getFilesToReplace().set(index, getModPath() + af.getSubstituteFile());
-				} else {
-					ModManager.debugLogger.writeError("Applying substitute file failed: af.getSubstituteFile() returned null in Mod:applyAlternateFileOperation()");
-				}
-			} else {
-				ModManager.debugLogger.writeMessage("Condition match, repointing " + af.getModFile() + " to use " + af.getAltFile());
-				String repointedSource = getModPath() + af.getAltFile();
-				job.getFilesToReplace().set(index, repointedSource);
-			}
-			break;
-		}
-	}
+                break;
+            case AlternateFile.OPERATION_SUBSTITUTE:
+                int index = job.getFilesToReplaceTargets().indexOf(af.getModFile());
+                if (modCMMVer <= 4.5) {
+                    if (af.getSubstituteFile() != null) { //Substitute on OFFICIAL HEADERS - moddesc 4.5 only.
+                        ModManager.debugLogger.writeMessage("Condition match, (ModDesc 4.5 backcompat) repointing " + af.getModFile() + " to use " + af.getSubstituteFile());
+                        job.getFilesToReplace().set(index, getModPath() + af.getSubstituteFile());
+                    } else {
+                        ModManager.debugLogger.writeError("Applying substitute file failed: af.getSubstituteFile() returned null in Mod:applyAlternateFileOperation()");
+                    }
+                } else {
+                    ModManager.debugLogger.writeMessage("Condition match, repointing " + af.getModFile() + " to use " + af.getAltFile());
+                    String repointedSource = getModPath() + af.getAltFile();
+                    job.getFilesToReplace().set(index, repointedSource);
+                }
+                break;
+        }
+    }
 
-	public ArrayList<String> getBlacklistedFiles() {
-		return blacklistedFiles;
-	}
+    public ArrayList<String> getBlacklistedFiles() {
+        return blacklistedFiles;
+    }
 
-	public void setBlacklistedFiles(ArrayList<String> blacklistedFiles) {
-		this.blacklistedFiles = blacklistedFiles;
-	}
+    public void setBlacklistedFiles(ArrayList<String> blacklistedFiles) {
+        this.blacklistedFiles = blacklistedFiles;
+    }
 
-	public boolean isEmptyModIsOK() {
-		return emptyModIsOK;
-	}
+    public boolean isEmptyModIsOK() {
+        return emptyModIsOK;
+    }
 
-	public void setEmptyModIsOK(boolean emptyModIsOK) {
-		this.emptyModIsOK = emptyModIsOK;
-	}
+    public void setEmptyModIsOK(boolean emptyModIsOK) {
+        this.emptyModIsOK = emptyModIsOK;
+    }
 
-	public ArrayList<String> getOutdatedDLCModules() {
-		return outdatedDLCModules;
-	}
+    public ArrayList<String> getOutdatedDLCModules() {
+        return outdatedDLCModules;
+    }
 
-	public void setOutdatedDLCModules(ArrayList<String> outdatedDLCModules) {
-		this.outdatedDLCModules = outdatedDLCModules;
-	}
+    public void setOutdatedDLCModules(ArrayList<String> outdatedDLCModules) {
+        this.outdatedDLCModules = outdatedDLCModules;
+    }
 
-	/**
-	 * Gets applicable automatic alternate files to this mod
-	 * 
-	 * @param biogamedir
-	 *            biogame directory
-	 */
-	public ArrayList<AlternateFile> getApplicableAutomaticAlternates(String biogamedir) {
-		ArrayList<AlternateFile> applicableAutomaticAlternates = new ArrayList<AlternateFile>();
-		if (alternateFiles.size() > 0) {
-			ModManager.debugLogger.writeMessage(getModName() + ": Checking automatic alternate files for modutils list.");
-			//get list of installed DLC
-			ArrayList<String> installedDLC = ModManager.getInstalledDLC(biogamedir);
-			ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
+    /**
+     * Gets applicable automatic alternate files to this mod
+     *
+     * @param biogamedir biogame directory
+     */
+    public ArrayList<AlternateFile> getApplicableAutomaticAlternates(String biogamedir) {
+        ArrayList<AlternateFile> applicableAutomaticAlternates = new ArrayList<AlternateFile>();
+        if (alternateFiles.size() > 0) {
+            ModManager.debugLogger.writeMessage(getModName() + ": Checking automatic alternate files for modutils list.");
+            //get list of installed DLC
+            ArrayList<String> installedDLC = ModManager.getInstalledDLC(biogamedir);
+            ArrayList<String> officialDLCHeaders = new ArrayList<String>(Arrays.asList(ModTypeConstants.getDLCHeaderNameArray()));
 
-			for (AlternateFile af : alternateFiles) {
-				String condition = af.getCondition();
-				String conditionaldlc = af.getConditionalDLC();
-				if (!installedDLC.contains(conditionaldlc)) {
-					//check if its a header...
-					if (officialDLCHeaders.contains(conditionaldlc)) {
-						//convert to dlc name
-						HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
-						String fname = headerFolderMap.get(conditionaldlc);
-						if (fname != null) {
-							conditionaldlc = fname;
-						} else {
-							//ModManager.debugLogger.writeError("[alt file application] Alt file specifies non-existent Custom DLC/Mod Manager Header: " + conditionaldlc);
-							continue;
-						}
-					}
-				}
+            for (AlternateFile af : alternateFiles) {
+                String condition = af.getCondition();
+                String conditionaldlc = af.getConditionalDLC();
+                if (!installedDLC.contains(conditionaldlc)) {
+                    //check if its a header...
+                    if (officialDLCHeaders.contains(conditionaldlc)) {
+                        //convert to dlc name
+                        HashMap<String, String> headerFolderMap = ModTypeConstants.getHeaderFolderMap();
+                        String fname = headerFolderMap.get(conditionaldlc);
+                        if (fname != null) {
+                            conditionaldlc = fname;
+                        } else {
+                            //ModManager.debugLogger.writeError("[alt file application] Alt file specifies non-existent Custom DLC/Mod Manager Header: " + conditionaldlc);
+                            continue;
+                        }
+                    }
+                }
 
-				switch (condition) {
-				case AlternateFile.CONDITION_DLC_NOT_PRESENT:
-					if (!installedDLC.contains(conditionaldlc.toUpperCase())) {
-						applicableAutomaticAlternates.add(af);
-					}
-					break;
-				case AlternateFile.CONDITION_DLC_PRESENT:
-					if (installedDLC.contains(conditionaldlc.toUpperCase())) {
-						applicableAutomaticAlternates.add(af);
-					}
-					break;
-				}
-			}
-		}
-		return applicableAutomaticAlternates;
-	}
+                switch (condition) {
+                    case AlternateFile.CONDITION_DLC_NOT_PRESENT:
+                        if (!installedDLC.contains(conditionaldlc.toUpperCase())) {
+                            applicableAutomaticAlternates.add(af);
+                        }
+                        break;
+                    case AlternateFile.CONDITION_DLC_PRESENT:
+                        if (installedDLC.contains(conditionaldlc.toUpperCase())) {
+                            applicableAutomaticAlternates.add(af);
+                        }
+                        break;
+                }
+            }
+        }
+        return applicableAutomaticAlternates;
+    }
 
-	/**
-	 * Applies Manually chosen Custom DLC configurations to this mod
-	 */
-	public void applyManualCustomDLCs() {
-		for (AlternateCustomDLC dlc : alternateCustomDLC) {
-			if (dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL) && dlc.hasBeenChoosen()) {
-				ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
-				applyAlternateDLCOperation(job, dlc);
-			}
-		}
-	}
+    /**
+     * Applies Manually chosen Custom DLC configurations to this mod
+     */
+    public void applyManualCustomDLCs() {
+        for (AlternateCustomDLC dlc : alternateCustomDLC) {
+            if (dlc.getCondition().equals(AlternateCustomDLC.CONDITION_MANUAL) && dlc.hasBeenChoosen()) {
+                ModJob job = getJobByModuleName(ModTypeConstants.CUSTOMDLC);
+                applyAlternateDLCOperation(job, dlc);
+            }
+        }
+    }
 
-	/**
-	 * Applies Manual Alternate files to this mod
-	 * 
-	 * @param bioGameDir
-	 * @return
-	 */
-	public boolean applyManualAlternates(String bioGameDir) {
-		boolean altApplied = false;
-		ModJob customDLCJob = null;
-		for (ModJob job : jobs) {
-			if (job.getJobType() == ModJob.CUSTOMDLC) {
-				customDLCJob = job;
-				continue; //This is for official only
-			}
-			if (job.getAlternateFiles().size() > 0) {
-				System.out.println();
-			}
-			for (AlternateFile af : job.getAlternateFiles()) {
-				if (af.isEnabled()) {
-					applyAlternateFileOperation(job, af);
-					altApplied = true;
-				}
-			}
-		}
-		if (customDLCJob != null) {
-			for (AlternateFile af : alternateFiles) {
-				if (af.isEnabled()) {
-					applyAlternateFileOperation(customDLCJob, af);
-					altApplied = true;
-				}
-			}
-		}
-		return altApplied;
-	}
+    /**
+     * Applies Manual Alternate files to this mod
+     *
+     * @param bioGameDir
+     * @return
+     */
+    public boolean applyManualAlternates(String bioGameDir) {
+        boolean altApplied = false;
+        ModJob customDLCJob = null;
+        for (ModJob job : jobs) {
+            if (job.getJobType() == ModJob.CUSTOMDLC) {
+                customDLCJob = job;
+                continue; //This is for official only
+            }
+            if (job.getAlternateFiles().size() > 0) {
+                System.out.println();
+            }
+            for (AlternateFile af : job.getAlternateFiles()) {
+                if (af.isEnabled()) {
+                    applyAlternateFileOperation(job, af);
+                    altApplied = true;
+                }
+            }
+        }
+        if (customDLCJob != null) {
+            for (AlternateFile af : alternateFiles) {
+                if (af.isEnabled()) {
+                    applyAlternateFileOperation(customDLCJob, af);
+                    altApplied = true;
+                }
+            }
+        }
+        return altApplied;
+    }
 
-	public boolean shouldApplyAutos() {
-		return shouldApplyAutos;
-	}
+    public boolean shouldApplyAutos() {
+        return shouldApplyAutos;
+    }
 
-	public void setShouldApplyAutos(boolean shouldApplyAutos) {
-		this.shouldApplyAutos = shouldApplyAutos;
-	}
+    public void setShouldApplyAutos(boolean shouldApplyAutos) {
+        this.shouldApplyAutos = shouldApplyAutos;
+    }
 
-	public ArrayList<String> getRequiredDLCHeaders() {
-		return requiredDLC;
-	}
+    public ArrayList<String> getRequiredDLCHeaders() {
+        return requiredDLC;
+    }
 
-	public void setRequiredDLCHeaders(ArrayList<String> requiredDLCHeaders) {
-		this.requiredDLC = requiredDLCHeaders;
-	}
+    public void setRequiredDLCHeaders(ArrayList<String> requiredDLCHeaders) {
+        this.requiredDLC = requiredDLCHeaders;
+    }
+
+    /**
+     * Compacts all job installation targets list to only
+     * contain the latest item if the list contains duplicates.
+     * This is useful for preventing extra disk I/O,
+     */
+    public void compactInstallationTargets() {
+        for (ModJob job : jobs) {
+            if (job.getJobType() == ModJob.BALANCE_CHANGES) {
+                continue;
+            }
+            ArrayList<String> replaceTargets = job.getFilesToReplaceTargets();
+            ArrayList<String> addTargets = job.getFilesToAddTargets();
+            ArrayList<String> addFiles = job.getFilesToAdd();
+            ArrayList<String> replaceFiles = job.getFilesToReplace();
+
+            Collections.reverse(replaceTargets);
+            Collections.reverse(addTargets);
+            Collections.reverse(addFiles);
+            Collections.reverse(replaceFiles);
+
+            ArrayList<String> newReplaceTargetsList = new ArrayList<>();
+            ArrayList<String> newAddTargetsList = new ArrayList<>();
+            ArrayList<String> newAddFilesList = new ArrayList<>();
+            ArrayList<String> newReplaceFilesList = new ArrayList<>();
+
+            for (int i = 0; i < replaceTargets.size(); i++) {
+                String target = replaceTargets.get(i);
+                if (!newReplaceTargetsList.contains(target)) {
+                    newReplaceTargetsList.add(0, target);
+                    newReplaceFilesList.add(0, replaceFiles.get(i));
+                }
+            }
+            for (int i = 0; i < addTargets.size(); i++) {
+                String target = addTargets.get(i);
+                if (!newAddTargetsList.contains(target)) {
+                    newAddTargetsList.add(0, target);
+                    newAddFilesList.add(0, addFiles.get(i));
+                }
+            }
+            job.addFiles = newAddFilesList;
+            job.addFilesTargets = newAddTargetsList;
+            job.filesToReplace = newReplaceFilesList;
+            job.filesToReplaceTargets = newReplaceTargetsList;
+        }
+    }
+
+    /**
+     * Checks that the replace and add lists are the same length
+     *
+     * @return False if add or replace lists are of different lengths, true otherwise
+     */
+    public boolean validateTargetListSizes() {
+        for (ModJob job : jobs) {
+            if (job.getJobType() == ModJob.BALANCE_CHANGES) {
+                continue;
+            }
+
+            if (job.getFilesToReplaceTargets().size() != job.getFilesToReplace().size()) {
+                ModManager.debugLogger.writeError("Size of replacefiles and replacefiletargets is not the same for " + job.getJobName() + "! This is a bug.");
+                return false;
+            }
+            if (job.getFilesToAddTargets().size() != job.getFilesToAdd().size()) {
+                ModManager.debugLogger.writeError("Size of addfiles and addfiletargets is not the same for " + job.getJobName() + "! This is a bug.");
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
This update cleans up a few behaviors in Mod Manager.

## Changed features
 - Alternate DLC and Alternate Files will no longer attempt to write the same target to disk multiple times if a duplicate is added (thus overriding the original). The list has all duplicates removed from latest addition to first added, thus keeping the result the same.
 - Required Missing DLC now throws a dialog instead of locking out the apply button.
 - Required Missing DLC now only lists DLC you don't actually have installed rather than all of the required one.
 - If the list of source files and targets is not the same size, Mod Manager will abort installation, as a bug has been encountered. This is a sanity check.
 - Changing the biogame target will check LOD settings and offer to update them as appropriate to the detection of ALOT (upgrade if going to alot, downgrade if going away). This is part of #68, another update will add this to restores. 

## Bug fixes
 - Restoring SFAR's no longer marks 2 completed items, now only marked 1 completed. This should fix up some progress bars when restoring.
 - No separator will be shown between alternate DLC and alternate files in the alternate installation options menu if no alternate files are present but DLC is (there would be nothing to separate)