### PR TITLE
Mass Effect 3 Mod Manager 5.1.3 MR4 Build 91

### DIFF
--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -39,7 +39,7 @@ public class ModManager {
     public static boolean IS_DEBUG = false;
     public static final String VERSION = "5.1.3";
     public static long BUILD_NUMBER = 91L;
-    public static final String BUILD_DATE = "01/01/2019";
+    public static final String BUILD_DATE = "01/12/2019";
     public static final String SETTINGS_FILENAME = "me3cmm.ini";
     public static DebugLogger debugLogger;
     public static boolean logging = false;
@@ -159,7 +159,7 @@ public class ModManager {
             ToolTipManager.sharedInstance().setDismissDelay(15000);
 
             System.setProperty("derby.system.home", new File(ModManager.getDatabaseDir()).getAbsolutePath()); //move derby.log
-
+            System.setProperty("https.protocols", "TLSv1.2");
             File settings = new File(ModManager.SETTINGS_FILENAME);
             if (!settings.exists()) {
                 settings.createNewFile();

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -722,6 +722,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
             // Check for update
             try {
                 String update_check_link = "https://me3tweaks.com/modmanager/updatecheck?currentversion=" + ModManager.BUILD_NUMBER;
+                //System.out.println(update_check_link);
                 String serverJSON = null;
                 try {
                     serverJSON = IOUtils.toString(new URL(update_check_link), StandardCharsets.UTF_8);


### PR DESCRIPTION
 - Fix "handshake_failure" error by forcing TLS 1.2 as only supported TLS protocol. Will enable TLS1.3 in future java versions