### PR TITLE
Mass Effect 3 Mod Manager 5.1.5 Build 93

### DIFF
--- a/src/com/me3tweaks/modmanager/ASIModWindow.java
+++ b/src/com/me3tweaks/modmanager/ASIModWindow.java
@@ -185,7 +185,7 @@ public class ASIModWindow extends JDialog {
 				//String filepath = ModManager.appendSlash(asiDir.getAbsolutePath()) + asifile;
 				Object[] row = new Object[3];
 				row[COL_ASIFILENAME] = mod;
-				row[COL_DESCRIPTION] = "Manually installed ASI. This ASI has not been verified by ME3Tweaks. If you wish to have it verified, please visit the forums.";
+				row[COL_DESCRIPTION] = "Manually installed ASI. This ASI has not been verified by ME3Tweaks. If you wish to have it verified, please come to the ME3Tweaks Discord server.";
 				row[COL_ACTION] = "<html><center>Manually Installed</center></html>";
 				model.addRow(row);
 			}

--- a/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
+++ b/src/com/me3tweaks/modmanager/CustomDLCConflictWindow.java
@@ -267,7 +267,7 @@ public class CustomDLCConflictWindow extends JDialog {
 		guiPatchPanel.add(guiPatchButton, BorderLayout.NORTH);
 
 		progressPanel = new JPanel(new BorderLayout());
-		statusText = new JLabel("Preparing to create compatibilty mod", SwingConstants.CENTER);
+		statusText = new JLabel("Preparing to create compatibility mod", SwingConstants.CENTER);
 		guiProgressBar = new JProgressBar();
 		guiProgressBar.setVisible(true);
 		guiProgressBar.setIndeterminate(true);
@@ -375,6 +375,7 @@ public class CustomDLCConflictWindow extends JDialog {
 			HashMap<String, ArrayList<CustomDLC>> nonguimodfiles = new HashMap<>();
 			// filter out files where the gui mod is superceding, we don't care.
 			for (Map.Entry<String, ArrayList<CustomDLC>> entry : dlcfilemap.entrySet()) {
+				//If highest priority DLC item is a GUI mod, or the file is a blacklisted file, do not scan it
 				if (entry.getValue().get(entry.getValue().size() - 1).isGUIMod()
 						|| blacklistedGUIconflictfiles.contains(entry.getKey())) {
 					// ignores heavy MP4/MP5 files that dont have any actual GUIs.
@@ -386,6 +387,7 @@ public class CustomDLCConflictWindow extends JDialog {
 			numFilesToScan = nonguimodfiles.size();
 			int cores = Runtime.getRuntime().availableProcessors();
 			cores = Math.max(1, cores - 1);
+			//cores = 1; //Debugging
 			ModManager.debugLogger.writeMessage("GUI Conflict scanner will use " + cores + " threads.");
 			ExecutorService guiscanExecutor = Executors.newFixedThreadPool(cores);
 			ArrayList<Future<GUIScanResult>> futures = new ArrayList<Future<GUIScanResult>>();
@@ -423,6 +425,11 @@ public class CustomDLCConflictWindow extends JDialog {
 			private String filepath;
 			private ArrayList<CustomDLC> dlcs;
 
+			/**
+			 * Task to scan a DLC for a GUI export with GUI transplanter scanner.
+			 * @param filepath basic filename of the file
+			 * @param dlcs list of custom DLCs that contain this file, in order of lowest to highest priority. The highest priority one will be scanned
+			 */
 			public GUIScanTask(String filepath, ArrayList<CustomDLC> dlcs) {
 				this.filepath = filepath;
 				this.dlcs = dlcs;
@@ -431,7 +438,7 @@ public class CustomDLCConflictWindow extends JDialog {
 			@Override
 			public GUIScanResult call() throws Exception {
 				// scan file
-				String scanFile = biogameDirectory + "DLC/" + dlcs.get(0).getDlcName() + "/CookedPCConsole/" + filepath;
+				String scanFile = biogameDirectory + "DLC/" + dlcs.get(dlcs.size()-1).getDlcName() + "/CookedPCConsole/" + filepath;
 				ArrayList<String> commandBuilder = new ArrayList<String>();
 				commandBuilder.add(transplanterpath);
 				commandBuilder.add("--guiscan");
@@ -843,8 +850,7 @@ public class CustomDLCConflictWindow extends JDialog {
 	 * Detects if the conflicts are caused by one of the following mods: -
 	 * DLC_CON_XBX (SP Controller Support) - DLC_CON_UIScaling (Interface Scaling
 	 * Mod) - DLC_CON_UIScaling_Shared (Interface Scaling Add-On).
-	 * 
-	 * 
+	 *
 	 * @param conflicts
 	 *            hashmap of conflict files and the list of dlc they appear in
 	 * @return null if no UI mod conflicts, otherwise a map of the next superceeding

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -37,9 +37,9 @@ import java.util.prefs.Preferences;
 
 public class ModManager {
     public static boolean IS_DEBUG = false;
-    public static final String VERSION = "5.1.5 DEV BUILD";
+    public static final String VERSION = "5.1.5";
     public static long BUILD_NUMBER = 93L;
-    public static final String BUILD_DATE = "04/07/2019";
+    public static final String BUILD_DATE = "04/23/2019";
     public static final String SETTINGS_FILENAME = "me3cmm.ini";
     public static DebugLogger debugLogger;
     public static boolean logging = false;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -37,9 +37,9 @@ import java.util.prefs.Preferences;
 
 public class ModManager {
     public static boolean IS_DEBUG = false;
-    public static final String VERSION = "5.1.4";
-    public static long BUILD_NUMBER = 92L;
-    public static final String BUILD_DATE = "04/06/2019";
+    public static final String VERSION = "5.1.5 DEV BUILD";
+    public static long BUILD_NUMBER = 93L;
+    public static final String BUILD_DATE = "04/07/2019";
     public static final String SETTINGS_FILENAME = "me3cmm.ini";
     public static DebugLogger debugLogger;
     public static boolean logging = false;

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -885,7 +885,7 @@ public class ModManager {
             ModManager.ExportResource("/zlib1.dll", zlib.toString());
             File me3logger_truncating = new File(gamedir.toString() + "\\Binaries\\Win32\\asi\\me3logger_truncating.asi");
             me3logger_truncating.getParentFile().mkdirs();
-            ModManager.ExportResource("/me3logger_truncating.asi", me3logger_truncating.toString());
+            ModManager.ExportResource("/ME3Logger_truncating.asi", me3logger_truncating.toString());
 
         } catch (Exception e1) {
             ModManager.debugLogger.writeMessage(ExceptionUtils.getStackTrace(e1));

--- a/src/com/me3tweaks/modmanager/ModManager.java
+++ b/src/com/me3tweaks/modmanager/ModManager.java
@@ -868,7 +868,7 @@ public class ModManager {
             return false;
         } else if (exebuild != 5) {
             JOptionPane.showMessageDialog(ModManagerWindow.ACTIVE_WINDOW, "Binkw32 bypass does not support any version of Mass Effect 3 except 1.05.\n" + (exebuild == 6
-                    ? "Downgrade to Mass Effect 3 1.05 to use it, or continue using LauncherWV through Mod Manager.\nThe ME3Tweaks forums has instructions on how to do this."
+                    ? "Downgrade to Mass Effect 3 1.05 to use it."
                     : "Upgrade your game to use 1.05. Pirated editions of the game are not supported."), "Unsupported ME3 version", JOptionPane.ERROR_MESSAGE);
             return false;
         }

--- a/src/com/me3tweaks/modmanager/ModManagerWindow.java
+++ b/src/com/me3tweaks/modmanager/ModManagerWindow.java
@@ -598,7 +598,7 @@ public class ModManagerWindow extends JFrame implements ActionListener, ListSele
          */
         private void checkForALOTInstallerUpdates() {
             try {
-                String alotInstallerReleaseAPIEndpoint = "https://api.github.com/repos/Mgamerz/ALOTAddonGUI/releases/latest";
+                String alotInstallerReleaseAPIEndpoint = "https://api.github.com/repos/ME3Tweaks/ALOTInstaller/releases/latest";
                 String response = IOUtils.toString(new URL(alotInstallerReleaseAPIEndpoint), StandardCharsets.UTF_8);
                 JSONParser parser = new JSONParser();
                 JSONObject latestRelease = (JSONObject) parser.parse(response);

--- a/src/com/me3tweaks/modmanager/StarterKitWindow.java
+++ b/src/com/me3tweaks/modmanager/StarterKitWindow.java
@@ -124,7 +124,7 @@ public class StarterKitWindow extends JDialog {
 
         modName.setUI(new HintTextFieldUI("A Most Excellent Mod", true));
         modDeveloper.setUI(new HintTextFieldUI("GatorZ", true));
-        modSite.setUI(new HintTextFieldUI("https://me3tweaks.com/forums/...", true));
+        modSite.setUI(new HintTextFieldUI("https://nexusmods.com/massefect3/...", true));
         internalDLCName.setUI(new HintTextFieldUI("ExcellentMod", true));
         internalDisplayName.setUI(new HintTextFieldUI("Excellent DLC Module", true));
         internalTLKId.setUI(new HintTextFieldUI("13370000", true));

--- a/src/com/me3tweaks/modmanager/help/HelpMenu.java
+++ b/src/com/me3tweaks/modmanager/help/HelpMenu.java
@@ -109,7 +109,7 @@ public class HelpMenu {
 	 */
 	public static JMenu constructHelpMenu() {
 		JMenu helpMenu = new JMenu("Help");
-		JMenuItem helpModDescDocumentation, helpForums, helpAbout, helpLogViewer, helpGetLog, helpContactMgamerz;
+		JMenuItem helpModDescDocumentation, helpAbout, helpLogViewer, helpGetLog, helpContactMgamerz;
 
 		helpModDescDocumentation = new JMenuItem("ModDesc File Documentation");
 		helpModDescDocumentation.setToolTipText("Opens the documentation for Mod Manager's moddesc.ini format");

--- a/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
+++ b/src/com/me3tweaks/modmanager/modmaker/ModMakerCompilerWindow.java
@@ -661,10 +661,10 @@ public class ModMakerCompilerWindow extends JDialog {
 			try {
 				get(); // this line can throw InterruptedException or ExecutionException
 			} catch (ExecutionException e) {
-				ModManager.debugLogger.writeMessage("Error occured in DecompilerWorker():");
+				ModManager.debugLogger.writeMessage("Error occurred in DecompilerWorker():");
 				ModManager.debugLogger.writeException(e);
 				JOptionPane.showMessageDialog(ModMakerCompilerWindow.this,
-						"An error occured while decompiling coalesced files:\n" + e.getMessage() + "\n\nYou should report this to Mgamerz via the Forums link in the help menu.",
+						"An error occurred while decompiling coalesced files:\n" + e.getMessage() + "\n\nYou should report this to Mgamerz via the ME3Tweaks Discord link in the help menu.",
 						"Compiling Error", JOptionPane.ERROR_MESSAGE);
 				error = true;
 			} catch (InterruptedException e) {

--- a/src/com/me3tweaks/modmanager/ui/AboutWindow2Controller.java
+++ b/src/com/me3tweaks/modmanager/ui/AboutWindow2Controller.java
@@ -53,7 +53,7 @@ public class AboutWindow2Controller {
 
 	@FXML
 	private void openME3ExplorerPage() {
-		ResourceUtils.openWebpage("https://github.com/Mgamerz/ME3Explorer");
+		ResourceUtils.openWebpage("https://github.com/ME3Tweaks/ME3Explorer");
 	}
 
 	@FXML


### PR DESCRIPTION
# Mass Effect 3 Mod Manager 5.1.5 Build 93
This is a bugfix build.

# Changed features
 - References to the forums for help have been changed to Discord references instead. I will be soon making the forums read only as they don't provide much value except to spammers

# Bugfixes
 - Fix GUI compatibility generator to use the correct tier file when multiple mods are stacked that modify the same file, but the UI mod is not part of the stack
 - Failed to extract binkw32 asi should be fixed as a required asset was not included in the executable